### PR TITLE
Refactor CMakeLists to support Yocto build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - echo '#!/bin/sh' > cov.sh
   - echo 'git config --global user.email "cmake@cmake.org"' >> cov.sh
   - echo 'git config --global user.name "CMake"' >> cov.sh
-  - echo "mkdir build-coverage; cd build-coverage; cmake -DBUILD_WITH_DBUS_GATEWAY=ON -DBUILD_WITH_CODE_COVERAGE=ON ..; env CTEST_OUTPUT_ON_FAILURE=1 make coverage" >> cov.sh
+  - echo "mkdir build-coverage; cd build-coverage; cmake -DBUILD_GENIVI=ON -DBUILD_WITH_CODE_COVERAGE=ON ..; env CTEST_OUTPUT_ON_FAILURE=1 make coverage" >> cov.sh
   - chmod 755 cov.sh
 script: docker run --rm -it -v $PWD/build-coverage:/source/build-coverage -v $PWD:/source/script advancedtelematic/aktualizr /source/script/cov.sh
 after_success:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,37 +4,41 @@ project(aktualizr)
 
 option(WARNING_AS_ERROR "Treat warnings as errors" ON)
 option(BUILD_WITH_CODE_COVERAGE "Enable gcov code coverage" OFF)
+option(BUILD_GENIVI "Set to ON to compile with SWM and RVI gateway support" OFF)
+option(BUILD_TESTS "Build tests (requires gtest/gmock)" ON)
 
-IF( NOT CMAKE_BUILD_TYPE )
+# clang-check and clang-format
+# The .clang-format file requires clang-format-3.8
+find_program(CLANG_FORMAT NAMES clang-format clang-format-3.8)
+find_program(CLANG_CHECK NAMES clang-check clang-check-3.8 clang-check-3.7 clang-check-3.6 clang-check-3.5 clang-check-3.4)
+
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake-modules)
+
+if(NOT CMAKE_BUILD_TYPE)
+    message(STATUS "No CMAKE_BUILD_TYPE specified, defaulting to Debug")
     set(CMAKE_BUILD_TYPE Debug)
-ENDIF()
+endif(NOT CMAKE_BUILD_TYPE)
+
+if(BUILD_GENIVI)
+    add_subdirectory("third_party/rvi_lib")
+endif(BUILD_GENIVI)
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-OPTION(BUILD_WITH_DBUS_GATEWAY "Set to ON to compile with dbus gateway support" OFF)
-message(STATUS "BUILD_WITH_DBUS_GATEWAY is set to value: ${BUILD_WITH_DBUS_GATEWAY}")
-
-include(ExternalProject)
-
-if(BUILD_WITH_DBUS_GATEWAY)
-    add_definitions(-DWITH_DBUS)
-endif(BUILD_WITH_DBUS_GATEWAY)
-
-ExternalProject_Add(rvi_lib
-    DOWNLOAD_COMMAND ""
-    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/rvi_lib
-    CONFIGURE_COMMAND  autoreconf -i  COMMAND ./configure 
-    INSTALL_COMMAND ""
-	BUILD_COMMAND ${MAKE}
-    BUILD_IN_SOURCE 1)
-
-
+add_custom_target(qa)
 #add_subdirectory("src")
 # FIXME temporary use include because of bugs with coverage
 include("src/CMakeLists.txt")
-include("tests/CMakeLists.txt")
+
+if(BUILD_TESTS)
+    include("tests/CMakeLists.txt")
+endif(BUILD_TESTS)
+
 
 # Generate ctags
 set_source_files_properties(tags PROPERTIES GENERATED true)
 add_custom_target(tags
     COMMAND ctags -R --c++-kinds=+p --fields=+iaS --extra=+q src
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+# vim: set tabstop=4 shiftwidth=4 expandtab:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,24 +1,11 @@
 # set symbols used when compiling
-add_definitions(-DBOOST_LOG_DYN_LINK=1)
+add_definitions(-DBOOST_LOG_DYN_LINK)
 
 # find all required libraries
 find_package(Boost COMPONENTS system thread program_options log log_setup regex REQUIRED)
-find_package(PkgConfig REQUIRED)
+find_package(CURL REQUIRED)
+find_package(OpenSSL REQUIRED)
 find_package(Threads REQUIRED)
-pkg_search_module(LIBCURL REQUIRED libcurl)
-pkg_search_module(LIBDBUS REQUIRED dbus-1)
-pkg_search_module(LIBOPENSSL REQUIRED libssl)
-
-# configure libraries
-set(LINK_LIBS ${CMAKE_THREAD_LIBS_INIT}
-              ${Boost_SYSTEM_LIBRARY}
-              ${Boost_THREAD_LIBRARY}
-              ${Boost_LOG_LIBRARIES}
-              ${Boost_LOG_SETUP_LIBRARIES}
-              ${Boost_PROGRAM_OPTIONS_LIBRARY}
-              ${Boost_REGEX_LIBRARY}
-              ${LIBCURL_LIBRARIES})
-
 
 # set source files excluded main for using the list for the test target
 set(SOURCES third_party/jsoncpp/jsoncpp.cpp
@@ -31,53 +18,61 @@ set(SOURCES third_party/jsoncpp/jsoncpp.cpp
             src/commands.cc
             src/types.cc
             src/main.cc
-            src/sotarviclient.cc
             src/eventsinterpreter.cc
             src/gatewaymanager.cc
             src/socketgateway.cc)
 
             
-if(BUILD_WITH_DBUS_GATEWAY)
-    set(DBUS_SOURCES    src/dbusgateway/dbusgateway.cc
-                        src/dbusgateway/swlm.cc)
-endif(BUILD_WITH_DBUS_GATEWAY)
+if(BUILD_GENIVI)
+    find_package(PkgConfig REQUIRED)
+    pkg_search_module(LIBDBUS REQUIRED dbus-1)
+    list(APPEND SOURCES src/dbusgateway/dbusgateway.cc
+                        src/dbusgateway/swlm.cc
+                        src/sotarviclient.cc)
+endif(BUILD_GENIVI)
 
-
+include_directories(src)
 include_directories(third_party/jsoncpp)
 include_directories(third_party/picojson)
 set_property(SOURCE third_party/jsoncpp/jsoncpp.cpp APPEND_STRING PROPERTY COMPILE_FLAGS " -w")
 
-
-ExternalProject_Get_Property(rvi_lib source_dir)
-set(RVI_INCLUDE_DIR ${source_dir}/include)
-include_directories(${RVI_INCLUDE_DIR})
-set(RVI_LINK_DIR ${source_dir}/src/.libs)
-link_directories(${RVI_LINK_DIR})
-
-# set output folder
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY target/)
-
 # set the name of the executable
-add_executable(aktualizr ${SOURCES} ${DBUS_SOURCES})
+add_executable(aktualizr ${SOURCES})
+set_property(TARGET aktualizr PROPERTY CXX_STANDARD 11)
+target_link_libraries(aktualizr ${Boost_LIBRARIES} ${CURL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
-if(BUILD_WITH_DBUS_GATEWAY)
+if(BUILD_GENIVI)
+    add_definitions(-DWITH_GENIVI)
+    target_compile_options(aktualizr PUBLIC ${LIBDBUS_CFLAGS})
+    target_link_libraries(aktualizr ${LIBDBUS_LIBRARIES} rvi)
+endif(BUILD_GENIVI)
 
-    if(STAGING_DIR_TARGET)
-        set(DBUS_INCLUDE_DIRS ${STAGING_DIR_TARGET}/usr/include/dbus-1.0/ ${STAGING_DIR_TARGET}/usr/lib/dbus-1.0/include)
-        include_directories(${DBUS_INCLUDE_DIRS})
-    else()
-        target_compile_options(aktualizr PUBLIC ${LIBDBUS_CFLAGS})
-    endif()
-    
-    set(DBUS_LIBS ${LIBDBUS_LIBRARIES})
-endif(BUILD_WITH_DBUS_GATEWAY)
 
-target_link_libraries(aktualizr ${LINK_LIBS} ${DBUS_LIBS} rvi)
-add_dependencies(aktualizr rvi_lib)
+if(CLANG_FORMAT)
+    add_custom_target(format-src
+        COMMAND ${CLANG_FORMAT} -i -style=file ${SOURCES}
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        COMMENT "Running clang-format on src"
+        VERBATIM)
+    add_dependencies(qa format-src)
+else()
+    message(WARNING "clang-format not found, skipping")
+endif()
+
+if(CLANG_CHECK)
+    add_custom_target(check-src
+        COMMAND ${CLANG_CHECK} -analyze -p ${CMAKE_BINARY_DIR} ${SOURCES}
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        COMMENT "Running clang-check"
+        VERBATIM)
+    add_dependencies(qa check-src aktualizr)
+else()
+    message(WARNING "clang-check not found, skipping")
+endif(CLANG_CHECK)
 
 
 ################## INSTALL RULES
-configure_file(distribution/sota.service.cmake distribution/sota.service)
-install(FILES distribution/sota.service DESTINATION /etc/systemd/system  COMPONENT init)
+#configure_file(distribution/sota.service.cmake distribution/sota.service)
+#install(FILES distribution/sota.service DESTINATION /etc/systemd/system  COMPONENT init)
 install(TARGETS aktualizr RUNTIME  DESTINATION bin)
-install(FILES  config/config.toml.example DESTINATION /etc/  RENAME sota.conf  COMPONENT configuration)
+# vim: set tabstop=4 shiftwidth=4 expandtab:

--- a/src/dbusgateway/dbusgateway.cc
+++ b/src/dbusgateway/dbusgateway.cc
@@ -5,7 +5,7 @@
 #include "types.h"
 
 DbusGateway::DbusGateway(const Config& config_in, command::Channel* command_channel_in) : config(config_in), command_channel(command_channel_in), swlm(config) {
-  int ret;
+  dbus_threads_init_default();
   dbus_error_init(&err);
   conn = dbus_bus_get(DBUS_BUS_SESSION, &err);
   if (dbus_error_is_set(&err)) {
@@ -14,7 +14,7 @@ DbusGateway::DbusGateway(const Config& config_in, command::Channel* command_chan
     return;
   }
 
-  ret = dbus_bus_request_name(conn, config_in.dbus.interface.c_str(), DBUS_NAME_FLAG_REPLACE_EXISTING, &err);
+  int ret = dbus_bus_request_name(conn, config_in.dbus.interface.c_str(), DBUS_NAME_FLAG_REPLACE_EXISTING, &err);
   if (DBUS_REQUEST_NAME_REPLY_PRIMARY_OWNER != ret) {
     LOGGER_LOG(LVL_error, "Cannot request Dbus name '" << config_in.dbus.interface << "' as primary owner");
     return;

--- a/src/dbusgateway/dbusgateway.h
+++ b/src/dbusgateway/dbusgateway.h
@@ -1,6 +1,7 @@
 #ifndef DBUSGATEWAY_H_
 #define DBUSGATEWAY_H_
 
+#include <boost/atomic.hpp>
 #include <dbus/dbus.h>
 
 #include "commands.h"
@@ -20,6 +21,8 @@ class DbusGateway : public Gateway {
   void run();
 
  private:
+  boost::thread thread;
+  boost::atomic<bool> stop;
   data::OperationResult getOperationResult(DBusMessageIter *);
   Config config;
   command::Channel *command_channel;

--- a/src/gatewaymanager.cc
+++ b/src/gatewaymanager.cc
@@ -2,7 +2,7 @@
 #include <boost/make_shared.hpp>
 #include "gatewaymanager.h"
 #include "socketgateway.h"
-#ifdef WITH_DBUS
+#ifdef WITH_GENIVI
 #include "dbusgateway/dbusgateway.h"
 #endif
 
@@ -12,7 +12,7 @@ GatewayManager::GatewayManager(const Config &config,
     gateways.push_back(boost::shared_ptr<Gateway>(
         new SocketGateway(config, commands_channel_in)));
   }
-#ifdef WITH_DBUS
+#ifdef WITH_GENIVI
   if (config.gateway.dbus) {
     gateways.push_back(boost::shared_ptr<Gateway>(
         new DbusGateway(config, commands_channel_in)));

--- a/src/main.cc
+++ b/src/main.cc
@@ -34,7 +34,9 @@
 #include "eventsinterpreter.h"
 #include "logger.h"
 #include "sotahttpclient.h"
+#ifdef WITH_GENIVI
 #include "sotarviclient.h"
+#endif
 
 /*****************************************************************************/
 
@@ -142,7 +144,12 @@ int main(int argc, char *argv[]) {
 
   SotaClient *client;
   if (config.gateway.rvi) {
+#ifdef WITH_GENIVI
     client = new SotaRVIClient(config, events_channel);
+#else
+    LOGGER_LOG(LVL_error, "RVI support is not enabled");
+    return EXIT_FAILURE;
+#endif
   } else {
     client = new SotaHttpClient(config, events_channel, commands_channel);
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,50 +1,31 @@
 
 
-IF( NOT GTEST_ROOT )
+if(NOT GTEST_ROOT )
     set(GTEST_ROOT /usr/src/gtest)
-ENDIF()
-
-IF( NOT GMOCK_ROOT )
-    set(GMOCK_ROOT /usr/src/gmock)
-ENDIF()
-
-# build google test as static library
-set(BUILD_SHARED_LIBS OFF)
-set(BUILD_SHARED_LIBS_AUTOMATIC_OFF 1)
-
-add_subdirectory(${GMOCK_ROOT} ${CMAKE_CURRENT_BINARY_DIR}/gmock EXCLUDE_FROM_ALL)
-#add_subdirectory(${GTEST_ROOT} ${CMAKE_CURRENT_BINARY_DIR}/gtest EXCLUDE_FROM_ALL)
-
-set(BUILD_SHARED_LIBS ON)
-set(BUILD_SHARED_LIBS_AUTOMATIC_OFF 0)
-
-set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake-modules)
-
-# Setup warnings
-
-if (CMAKE_COMPILER_IS_GNUCXX)
-        add_definitions(-fstack-protector-all)
-        # Enable maximum of Warnings :
-        add_definitions(-Wall -Wextra -Wswitch-default -Wswitch -Winit-self -Wformat-security -Wfloat-equal -Wcast-qual -Wconversion -Wlogical-op)
-        if (CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL "4.9" OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "4.9")
-            add_definitions (-Wfloat-conversion)
-            add_definitions (-Wshadow)
-        endif ()
-
-  if(WARNING_AS_ERROR)
-            add_definitions (-Werror)
-  endif()
 endif()
 
+if(NOT GMOCK_ROOT )
+    set(GMOCK_ROOT /usr/src/gmock)
+endif()
 
-# Setup linting
+add_subdirectory(${GMOCK_ROOT} ${CMAKE_CURRENT_BINARY_DIR}/gmock EXCLUDE_FROM_ALL)
 
-# clang-check and clang-format
-find_program(CLANG_FORMAT NAMES clang-format clang-format-3.8 clang-format-3.7 clang-format-3.6 clang-format-3.5)
-find_program(CLANG_CHECK NAMES clang-check clang-check-3.8 clang-check-3.7 clang-check-3.6 clang-check-3.5 clang-check-3.4)
+# Setup warnings
+if (CMAKE_COMPILER_IS_GNUCXX)
+    add_definitions(-fstack-protector-all)
+    # Enable maximum of Warnings :
+    add_definitions(-Wall -Wextra -Wswitch-default -Wswitch -Winit-self -Wformat-security -Wfloat-equal -Wcast-qual -Wconversion -Wlogical-op)
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL "4.9" OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "4.9")
+        add_definitions (-Wfloat-conversion)
+        add_definitions (-Wshadow)
+    endif ()
+
+    if(WARNING_AS_ERROR)
+        add_definitions (-Werror)
+    endif()
+endif()
 
 # Setup coverage
-
 if(BUILD_WITH_CODE_COVERAGE)
     include(CodeCoverage)
     setup_target_for_coverage(coverage ctest coverage)
@@ -53,35 +34,32 @@ if(BUILD_WITH_CODE_COVERAGE)
     add_dependencies(coverage aktualizr)
 endif()
 
-add_custom_target(qa)
 
 # Export compile_commands.json for clang-check
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 
-set(ALL_TEST_SRCS   tests/config_test.cc
-                    tests/events_test.cc
-                    tests/commands_test.cc
-                    test/httpsotaclient_test.cc
-                    test/httpclient_test.cc)
+
+set(ALL_TEST_SRCS tests/commands_test.cc
+                  tests/config_test.cc
+                  tests/dbusgateway_test.cc
+                  tests/events_test.cc
+                  tests/httpclient_test.cc
+                  tests/httpsotaclient_test.cc
+                  tests/rvisotaclient_test.cc
+                  tests/socketgateway_test.cc
+                  tests/swm_test.cc)
 
 if(CLANG_FORMAT)
-add_custom_target(format-tools
-    COMMAND ${CLANG_FORMAT} -i -style file ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc ${CMAKE_CURRENT_SOURCE_DIR}/src/*.h ${CMAKE_CURRENT_SOURCE_DIR}/tests/*.cc
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    COMMENT "Running clang-format"
-    VERBATIM)
-add_dependencies(qa format-tools)
+    add_custom_target(format-tests
+        COMMAND ${CLANG_FORMAT} -i -style=file ${ALL_TEST_SRCS}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMENT "Running clang-format on tests"
+        VERBATIM)
+    add_dependencies(qa format-tests)
 else()
     message(WARNING "clang-format not found, skipping")
 endif()
-
-add_custom_target(check-tools
-    COMMAND ${CLANG_CHECK} -analyze -p ${CMAKE_BINARY_DIR} ${SOURCES}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    COMMENT "Running clang-check"
-    VERBATIM)
-add_dependencies(qa check-tools aktualizr)
 
 ###############################################################################
 
@@ -95,22 +73,17 @@ add_dependencies(qa check)
 ###############################################################################
 
 #Setup CMake to run tests
-
-# using boost test requires using static linking of libraries
-set(Boost_USE_STATIC_LIBS ON)
 # let cmake find the boost test library
-find_package(Boost COMPONENTS unit_test_framework REQUIRED)
+find_package(Boost COMPONENTS system thread program_options log log_setup regex unit_test_framework REQUIRED)
 
 #enable test features of cmake
 enable_testing()
 
-INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/src)
-
+include_directories(${PROJECT_SOURCE_DIR}/src)
 
 # use the same libiraries as the normal target but add boost test
-set (TEST_LIBS ${LINK_LIBS}
+set (TEST_LIBS ${Boost_LIBRARIES} ${CURL_LIBRARIES}
                ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} gtest gmock)
-
 
 # Config Test
 set(TEST_CONFIG_SRC src/logger.cc
@@ -126,8 +99,6 @@ set(TEST_SRCS   third_party/jsoncpp/jsoncpp.cpp
                 src/events.cc
                 tests/events_test.cc)
 add_executable(aktualizr_test_events ${TEST_SRCS})
-
-# set the libraries for the current target
 target_link_libraries(aktualizr_test_events ${TEST_LIBS})
 
 
@@ -137,24 +108,7 @@ set(TEST_SRCS   third_party/jsoncpp/jsoncpp.cpp
                 src/commands.cc
                 tests/commands_test.cc)
 add_executable(aktualizr_test_commands ${TEST_SRCS})
-
-# set the libraries for the current target
 target_link_libraries(aktualizr_test_commands ${TEST_LIBS})
-
-if(BUILD_WITH_DBUS_GATEWAY)
-    unset(TEST_SRCS)
-    set(TEST_SRCS   third_party/jsoncpp/jsoncpp.cpp
-                    src/types.cc
-                    src/commands.cc
-                    src/events.cc
-                    src/logger.cc
-                    tests/dbusgateway_test.cc)
-    add_executable(aktualizr_test_dbusgateway ${TEST_SRCS} ${DBUS_SOURCES})
-    target_compile_options(aktualizr_test_dbusgateway PUBLIC ${LIBDBUS_CFLAGS})
-
-    # set the libraries for the current target
-    target_link_libraries(aktualizr_test_dbusgateway ${TEST_LIBS} ${DBUS_LIBS})
-endif(BUILD_WITH_DBUS_GATEWAY)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -std=c++0x")
 
@@ -195,45 +149,55 @@ set(TEST_SOCKET_SRC src/logger.cc
               src/socketgateway.cc
               tests/socketgateway_test.cc)
 add_executable(aktualizr_test_socket_gateway ${TEST_SOCKET_SRC})
-target_link_libraries(aktualizr_test_socket_gateway ${LINK_LIBS} gtest)
+target_link_libraries(aktualizr_test_socket_gateway ${TEST_LIBS} gtest)
 
 add_test(NAME test_socket_gateway COMMAND aktualizr_test_socket_gateway ${PROJECT_SOURCE_DIR}/tests/fake_unix_socket/ WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
+if(BUILD_GENIVI)
+    unset(TEST_SRCS)
+    set(TEST_SRCS third_party/jsoncpp/jsoncpp.cpp
+                  src/types.cc
+                  src/commands.cc
+                  src/events.cc
+                  src/logger.cc
+                  src/dbusgateway/dbusgateway.cc
+                  src/dbusgateway/swlm.cc
+                  tests/dbusgateway_test.cc)
+    add_executable(aktualizr_test_dbusgateway ${TEST_SRCS})
+    target_compile_options(aktualizr_test_dbusgateway PUBLIC ${LIBDBUS_CFLAGS})
+    target_link_libraries(aktualizr_test_dbusgateway ${TEST_LIBS} ${LIBDBUS_LIBRARIES})
 
+    set(TEST_RVI_SRC src/logger.cc
+                     src/logger.cc
+                     third_party/jsoncpp/jsoncpp.cpp
+                     src/config.cc
+                     src/commands.cc
+                     src/events.cc
+                     src/types.cc
+                     src/sotarviclient.cc
+                     src/logger.cc
+                     tests/rvisotaclient_test.cc)
+    add_executable(aktualizr_test_rvi_client ${TEST_RVI_SRC})
+    target_link_libraries(aktualizr_test_rvi_client rvi ${TEST_LIBS} gtest)
+    add_test(NAME test_rvi_client COMMAND aktualizr_test_rvi_client WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
-set(TEST_RVI_SRC src/logger.cc
-              src/logger.cc
-              third_party/jsoncpp/jsoncpp.cpp
-              src/config.cc
-              src/commands.cc
-              src/events.cc
-              src/types.cc
-              src/sotarviclient.cc
-              src/logger.cc
-              tests/rvisotaclient_test.cc)
-add_executable(aktualizr_test_rvi_client ${TEST_RVI_SRC})
-link_directories(${RVI_LINK_DIR})
-target_link_libraries(aktualizr_test_rvi_client ${LINK_LIBS} gtest)
-add_dependencies(aktualizr_test_rvi_client rvi_lib)
-add_test(NAME test_rvi_client COMMAND aktualizr_test_rvi_client WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
-
-
-set(TEST_SWM_SRC third_party/jsoncpp/jsoncpp.cpp
-                    src/types.cc
-                    src/commands.cc
-                    src/events.cc
-                    src/logger.cc
-                    tests/swm_test.cc)
-add_executable(aktualizr_test_swm ${TEST_SWM_SRC} ${DBUS_SOURCES})
-target_compile_options(aktualizr_test_swm PUBLIC ${LIBDBUS_CFLAGS})
-target_link_libraries(aktualizr_test_swm ${LINK_LIBS} ${DBUS_LIBS} gtest)
-add_test(NAME test_swm COMMAND dbus-run-session bash -c "${CMAKE_BINARY_DIR}/target/aktualizr_test_swm ${PROJECT_SOURCE_DIR}/tests/fake_dbus_tools/" WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
-
+    set(TEST_SWM_SRC third_party/jsoncpp/jsoncpp.cpp
+                     src/types.cc
+                     src/commands.cc
+                     src/events.cc
+                     src/logger.cc
+                     src/dbusgateway/dbusgateway.cc
+                     src/dbusgateway/swlm.cc
+                     tests/swm_test.cc)
+    add_executable(aktualizr_test_swm ${TEST_SWM_SRC} ${DBUS_SOURCES})
+    target_compile_options(aktualizr_test_swm PUBLIC ${LIBDBUS_CFLAGS})
+    target_link_libraries(aktualizr_test_swm ${TEST_LIBS} ${LIBDBUS_LIBRARIES} gtest)
+    add_test(NAME test_swm COMMAND dbus-run-session --config-file ${PROJECT_SOURCE_DIR}/tests/session.conf bash -c "${CMAKE_BINARY_DIR}/aktualizr_test_swm ${PROJECT_SOURCE_DIR}/tests/fake_dbus_tools/" WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+endif(BUILD_GENIVI)
 
 
 
 ###############################################################################
-
 # add the test target to coverage analysis
 if(BUILD_WITH_CODE_COVERAGE)
     target_link_libraries(aktualizr_test_config gcov)
@@ -242,10 +206,10 @@ if(BUILD_WITH_CODE_COVERAGE)
     add_dependencies(coverage aktualizr_test_events)
     target_link_libraries(aktualizr_test_commands gcov)
     add_dependencies(coverage aktualizr_test_commands)
-    if(BUILD_WITH_DBUS_GATEWAY)
+    if(BUILD_GENIVI)
         target_link_libraries(aktualizr_test_dbusgateway gcov)
         add_dependencies(coverage aktualizr_test_dbusgateway)
-    endif(BUILD_WITH_DBUS_GATEWAY)
+    endif(BUILD_GENIVI)
     target_link_libraries(aktualizr_test_http_aktualizr gcov)
     add_dependencies(coverage aktualizr_test_http_aktualizr)
     target_link_libraries(aktualizr_test_http_client gcov)
@@ -259,15 +223,15 @@ if(BUILD_WITH_CODE_COVERAGE)
 endif(BUILD_WITH_CODE_COVERAGE)
 
 
-    # declares a test using the test target
-    add_test(NAME test_config COMMAND aktualizr_test_config WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
-    file(WRITE Testing/config.toml "")
-    add_test(NAME test_events COMMAND aktualizr_test_events WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
-    add_test(NAME test_commands COMMAND aktualizr_test_commands WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+# declares a test using the test target
+add_test(NAME test_config COMMAND aktualizr_test_config WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+file(WRITE Testing/config.toml "")
+add_test(NAME test_events COMMAND aktualizr_test_events WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+add_test(NAME test_commands COMMAND aktualizr_test_commands WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
-    if(BUILD_WITH_DBUS_GATEWAY)
-        add_test(NAME test_dbusgateway COMMAND dbus-run-session bash -c "${CMAKE_BINARY_DIR}/target/aktualizr_test_dbusgateway ${PROJECT_SOURCE_DIR}/tests/fake_dbus_tools/" WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
-    endif(BUILD_WITH_DBUS_GATEWAY)
+if(BUILD_GENIVI)
+    add_test(NAME test_dbusgateway COMMAND dbus-run-session --config-file ${PROJECT_SOURCE_DIR}/tests/session.conf bash -c "${CMAKE_BINARY_DIR}/aktualizr_test_dbusgateway ${PROJECT_SOURCE_DIR}/tests/fake_dbus_tools/" WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+endif(BUILD_GENIVI)
 
 ###############################################################################
 # The test feature of cmake checks the return value when the program
@@ -304,3 +268,4 @@ set_tests_properties(feat1_test--something
                      test_plain
                      test_log_invalid
                      PROPERTIES WILL_FAIL TRUE)
+# vim: set tabstop=4 shiftwidth=4 expandtab:

--- a/tests/fake_dbus_tools/swm.py
+++ b/tests/fake_dbus_tools/swm.py
@@ -1,8 +1,8 @@
 
-import gtk
 import dbus.service
 import sys
 from dbus.mainloop.glib import DBusGMainLoop
+import gobject
 
 
 class SLMService(dbus.service.Object):
@@ -28,6 +28,7 @@ class SLMService(dbus.service.Object):
 
 if __name__ == "__main__":
     DBusGMainLoop(set_as_default=True)
+    mainloop = gobject.MainLoop()
     swlm_service = SLMService()
     while True:
-        gtk.main_iteration()
+        mainloop.run()

--- a/tests/session.conf
+++ b/tests/session.conf
@@ -1,0 +1,65 @@
+<!-- This configuration file controls the per-user-login-session message bus.
+     Add a session-local.conf and edit that rather than changing this 
+     file directly. -->
+
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <!-- Our well-known bus type, don't change this -->
+  <type>session</type>
+
+  <!-- If we fork, keep the user's original umask to avoid affecting
+       the behavior of child processes. -->
+  <keep_umask/>
+
+  <listen>unix:tmpdir=/tmp</listen>
+
+  <!-- On Unix systems, the most secure authentication mechanism is
+  EXTERNAL, which uses credential-passing over Unix sockets.
+
+  This authentication mechanism is not available on Windows,
+  is not suitable for use with the tcp: or nonce-tcp: transports,
+  and will not work on obscure flavours of Unix that do not have
+  a supported credentials-passing mechanism. On those platforms/transports,
+  comment out the <auth> element to allow fallback to DBUS_COOKIE_SHA1. -->
+  <auth>EXTERNAL</auth>
+
+  <standard_session_servicedirs />
+
+  <policy context="default">
+    <!-- Allow everything to be sent -->
+    <allow send_destination="*" eavesdrop="true"/>
+    <!-- Allow everything to be received -->
+    <allow eavesdrop="true"/>
+    <!-- Allow anyone to own anything -->
+    <allow own="*"/>
+  </policy>
+
+  <!-- For the session bus, override the default relatively-low limits 
+       with essentially infinite limits, since the bus is just running 
+       as the user anyway, using up bus resources is not something we need 
+       to worry about. In some cases, we do set the limits lower than 
+       "all available memory" if exceeding the limit is almost certainly a bug, 
+       having the bus enforce a limit is nicer than a huge memory leak. But the 
+       intent is that these limits should never be hit. -->
+
+  <!-- the memory limits are 1G instead of say 4G because they can't exceed 32-bit signed int max -->
+  <limit name="max_incoming_bytes">1000000000</limit>
+  <limit name="max_incoming_unix_fds">250000000</limit>
+  <limit name="max_outgoing_bytes">1000000000</limit>
+  <limit name="max_outgoing_unix_fds">250000000</limit>
+  <limit name="max_message_size">1000000000</limit>
+  <!-- We do not override max_message_unix_fds here since the in-kernel
+       limit is also relatively low -->
+  <limit name="service_start_timeout">120000</limit>  
+  <limit name="auth_timeout">240000</limit>
+  <limit name="pending_fd_timeout">150000</limit>
+  <limit name="max_completed_connections">100000</limit>  
+  <limit name="max_incomplete_connections">10000</limit>
+  <limit name="max_connections_per_user">100000</limit>
+  <limit name="max_pending_service_starts">10000</limit>
+  <limit name="max_names_per_connection">50000</limit>
+  <limit name="max_match_rules_per_connection">50000</limit>
+  <limit name="max_replies_per_connection">50000</limit>
+
+</busconfig>

--- a/third_party/rvi_lib/CMakeLists.txt
+++ b/third_party/rvi_lib/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_subdirectory(libjwt)
+add_library(rvi STATIC
+	src/btree.c src/rvi.c src/rvi_list.c
+)
+target_include_directories(rvi PUBLIC include)
+target_include_directories(rvi PRIVATE libjwt/include)
+target_link_libraries(rvi jwt)

--- a/third_party/rvi_lib/libjwt/CMakeLists.txt
+++ b/third_party/rvi_lib/libjwt/CMakeLists.txt
@@ -60,7 +60,7 @@ install(TARGETS ${LIBRARY_NAME} ${LIBRARY_NAME}_static
 
 install(FILES include/jwt.h DESTINATION "${CMAKE_INSTALL_PREFIX}/include/jwt")
 
-if (CHECK_FOUND)
+if (FALSE AND CHECK_FOUND)
   include_directories(${CHECK_INCLUDE_DIRS})
   link_directories(${CHECK_LIBRARY_DIRS})
   add_definitions(${CHECK_CFLAGS_OTHER} -DKEYDIR="${PROJECT_SOURCE_DIR}/tests/keys")
@@ -82,4 +82,4 @@ if (CHECK_FOUND)
   InitialiseTest(jwt_new tests/jwt_new.c)
   InitialiseTest(jwt_rsa tests/jwt_rsa.c)
   InitialiseTest(jwt_ec tests/jwt_ec.c)
-endif (CHECK_FOUND)
+endif (FALSE AND CHECK_FOUND)


### PR DESCRIPTION
This includes several changes to support building in Yocto
 - Both RVI and SWM support are now behind a single BUILD_GENIVI flag
 - All third_party dependencies are build with cmake
 - A new flag disables building tests, to avoid a dependency on gtest/gmock