### PR TITLE
Explicitly check the results of system() calls

### DIFF
--- a/tests/httpclient_test.cc
+++ b/tests/httpclient_test.cc
@@ -65,12 +65,12 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   if (argc >= 2){
     std::string command =  std::string(argv[1]) + "/fake_http_server.py &";
-    system(command.c_str());
+    EXPECT_EQ(system(command.c_str()), 0);
     sleep(1);
   }
   int ret = RUN_ALL_TESTS();
   if (argc >= 2){
-    system("killall fake_http_server.py");
+    EXPECT_EQ(system("killall fake_http_server.py"), 0);
   }
   return ret;
 }

--- a/tests/socketgateway_test.cc
+++ b/tests/socketgateway_test.cc
@@ -26,7 +26,7 @@ TEST(EventsTest, broadcasted) {
   
   SocketGateway gateway(conf, chan);
   std::string cmd = "python "+fake_path + "events.py &";
-  system(cmd.c_str());
+  EXPECT_EQ(system(cmd.c_str()), 0);
   sleep(1);
   gateway.processEvent(boost::make_shared<event::NoUpdateRequests>(event::NoUpdateRequests()));
   sleep(1);
@@ -48,7 +48,7 @@ TEST(EventsTest, not_broadcasted) {
   
   SocketGateway gateway(conf, chan);
   std::string cmd = "python "+fake_path + "events.py &";
-  system(cmd.c_str());
+  EXPECT_EQ(system(cmd.c_str()), 0);
   sleep(1);
   gateway.processEvent(boost::make_shared<event::NoUpdateRequests>(event::NoUpdateRequests()));
   sleep(1);
@@ -70,7 +70,7 @@ TEST(CommandsTest, recieved) {
   
   SocketGateway gateway(conf, chan);
   std::string cmd = "python "+fake_path + "commands.py &";
-  system(cmd.c_str());
+  EXPECT_EQ(system(cmd.c_str()), 0);
   sleep(1);
   boost::shared_ptr<command::BaseCommand> command;
   *chan >> command;


### PR DESCRIPTION
Without this, a release build fails with warnings like:
error: ignoring return value of ‘int system(const char*)’