### PR TITLE
Workaround for bug with big chunks

### DIFF
--- a/third_party/rvi_lib/src/rvi.c
+++ b/third_party/rvi_lib/src/rvi.c
@@ -1514,7 +1514,7 @@ int rviProcessInput(TRviHandle handle, int *fdArr, int fdLen)
     json_t          *root   = NULL;
     json_error_t    jserr   = {0};
 
-    int             len     = 1024 * 8;
+    int             len     = 1024 * 64 + 2000;
     int             read    = 0;
     char            *buf    = {0};
     long            mode    = 0;


### PR DESCRIPTION
This PR, setups maximum buffer size for default configuration of rvi_sota_server https://github.com/GENIVI/rvi_sota_server/blob/master/core/src/main/resources/application.conf 
64K for chunk and 2000 bytes for rest of message.