### PR TITLE
Removed new line at the and of generated string.

### DIFF
--- a/third_party/jsoncpp/jsoncpp.cpp
+++ b/third_party/jsoncpp/jsoncpp.cpp
@@ -2679,7 +2679,6 @@ void FastWriter::enableYAMLCompatibility() { yamlCompatiblityEnabled_ = true; }
 std::string FastWriter::write(const Value &root) {
   document_ = "";
   writeValue(root);
-  document_ += "\n";
   return document_;
 }
 


### PR DESCRIPTION
This pull request removes single new line from generated string with FastWriter writer of JsonCpp parser.
By default, FastWriter writes json without any whitespaces(except end of the string), keys are sorted,  list items preserved with original order. 

Also I have tried Ukrainian symbols, and it sorts regarding to the Ukrainian alphabet.
And I have not  tested Double values. Do we will use them?

