### PR TITLE
Fix SSL linking issue when BUILD_GENIVI disabled

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,13 +45,13 @@ add_library(aktualizr_static_lib STATIC ${SOURCES})
 # set the name of the executable
 add_executable(aktualizr ${MAIN})
 
-target_link_libraries(aktualizr aktualizr_static_lib ${Boost_LIBRARIES} ${CURL_LIBRARIES} ${OpenSSL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} )
+target_link_libraries(aktualizr aktualizr_static_lib
+   ${Boost_LIBRARIES} ${CURL_LIBRARIES} ${OPENSSL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} )
 
 if(BUILD_GENIVI)
     set_property(TARGET aktualizr PROPERTY CXX_STANDARD 11)
     add_definitions(-DWITH_GENIVI)
     target_compile_options(aktualizr_static_lib PUBLIC ${LIBDBUS_CFLAGS})
-    #target_compile_options(aktualizr_static_lib PUBLIC ${LIBDBUS_CFLAGS})
     target_include_directories(aktualizr_static_lib PUBLIC third_party/rvi_lib/include)
     target_link_libraries(aktualizr ${LIBDBUS_LIBRARIES} rvi)
 endif(BUILD_GENIVI)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,7 +74,7 @@ include_directories(${PROJECT_SOURCE_DIR}/src)
 include_directories(${PROJECT_SOURCE_DIR}/third_party/rvi_lib/include)
 
 # use the same libiraries as the normal target but add gtest
-set (TEST_LIBS ${Boost_LIBRARIES} ${CURL_LIBRARIES} ${OpenSSL_LIBRARIES} gtest gmock gcov)
+set (TEST_LIBS ${Boost_LIBRARIES} ${CURL_LIBRARIES} ${OPENSSL_LIBRARIES} gtest gmock gcov)
                
 
 # Setup coverage
@@ -198,4 +198,19 @@ set_tests_properties(feat1_test--something
                      test_plain
                      test_log_invalid
                      PROPERTIES WILL_FAIL TRUE)
+
+# Try building with various cmake options
+add_test(NAME test_build_all_off
+        COMMAND ${PROJECT_SOURCE_DIR}/tests/build_with_options ${PROJECT_SOURCE_DIR} test_build_all_off "-DBUILD_GENIVI=OFF -DBUILD_TESTS=OFF")
+
+add_test(NAME test_build_all_on
+        COMMAND ${PROJECT_SOURCE_DIR}/tests/build_with_options ${PROJECT_SOURCE_DIR} test_build_all_on "-DBUILD_WITH_CODE_COVERAGE=ON -DBUILD_GENIVI=ON")
+
+add_test(NAME test_build_debug
+        COMMAND ${PROJECT_SOURCE_DIR}/tests/build_with_options ${PROJECT_SOURCE_DIR} test_build_debug "-DCMAKE_BUILD_TYPE=Debug")
+
+add_test(NAME test_build_release
+        COMMAND ${PROJECT_SOURCE_DIR}/tests/build_with_options ${PROJECT_SOURCE_DIR} test_build_release "-DCMAKE_BUILD_TYPE=Release")
+
+
 # vim: set tabstop=4 shiftwidth=4 expandtab:

--- a/tests/build_with_options
+++ b/tests/build_with_options
@@ -1,0 +1,5 @@
+echo $PWD
+mkdir "$2"
+cd "$2"
+cmake $3 $1
+make -j8 aktualizr

--- a/third_party/rvi_lib/libjwt/CMakeLists.txt
+++ b/third_party/rvi_lib/libjwt/CMakeLists.txt
@@ -27,20 +27,25 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)# executables
 # Detect required packages
 INCLUDE( FindPkgConfig )
 
-PKG_SEARCH_MODULE (OPENSSL REQUIRED openssl)
+find_package(OpenSSL REQUIRED)
 PKG_SEARCH_MODULE (JANSSON REQUIRED jansson)
 PKG_SEARCH_MODULE (CHECK check)
 
 add_definitions(-DUSE_CMAKE)
 
-include_directories(include ${OPENSSL_INCLUDE_DIRS} ${JANSSON_INCLUDE_DIRS})
-link_directories(${OPENSSL_LIBRARY_DIRS} ${JANSSON_LIBRARY_DIRS})
-
 add_library(${LIBRARY_NAME} SHARED libjwt/jwt.c)
 add_library(${LIBRARY_NAME}_static STATIC libjwt/jwt.c)
 set_target_properties(${LIBRARY_NAME}_static PROPERTIES OUTPUT_NAME ${LIBRARY_NAME})
 set_target_properties(${LIBRARY_NAME} PROPERTIES VERSION ${LIBJWT_VERSION_STRING}
-                      SOVERSION ${LIBJWT_VERSION_MAJOR})
+        SOVERSION ${LIBJWT_VERSION_MAJOR})
+
+target_include_directories(${LIBRARY_NAME}
+        PUBLIC include
+        PRIVATE ${OPENSSL_INCLUDE_DIR} ${JANSSON_INCLUDE_DIRS})
+target_include_directories(${LIBRARY_NAME}_static
+        PUBLIC include
+        PRIVATE ${OPENSSL_INCLUDE_DIR} ${JANSSON_INCLUDE_DIRS})
+
 
 # Check if _GNU_SOURCE is available.
 CHECK_SYMBOL_EXISTS(__GNU_LIBRARY__ "features.h" _GNU_SOURCE)


### PR DESCRIPTION
Change libjwt to use the modern method to find OpenSSL, and fix a build issue with -DBUILD_GENIVI=OFF.

This also adds a set of tests to build aktualizr with various configuration options.