### PR TITLE
Tidy up CI docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+build*
+cmake-build-debug
+.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,7 @@ sudo: false
 language: cpp
 services:
   - docker
-before_install:
+script:
   - docker build -t advancedtelematic/aktualizr .
-  - mkdir build-coverage
-  - echo '#!/bin/sh' > cov.sh
-  - echo 'git config --global user.email "cmake@cmake.org"' >> cov.sh
-  - echo 'git config --global user.name "CMake"' >> cov.sh
-  - echo "mkdir build-coverage; cd build-coverage; cmake -DBUILD_GENIVI=ON -DBUILD_WITH_CODE_COVERAGE=ON ..; env CTEST_OUTPUT_ON_FAILURE=1 make -j8 coverage" >> cov.sh
-  - chmod 755 cov.sh
-script: docker run --rm -it -v $PWD/build-coverage:/source/build-coverage -v $PWD:/source/script advancedtelematic/aktualizr /source/script/cov.sh
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - ci_env=`bash <(curl -s https://codecov.io/env)`
+  - docker run $ci_env --rm -it advancedtelematic/aktualizr src/coverage.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,11 @@
 FROM ubuntu:xenial
+LABEL Description="Aktualizr testing dockerfile"
 
-ENV HOME /source
 ENV DEBIAN_FRONTEND noninteractive
-RUN mkdir $HOME
 RUN apt-get update
 RUN apt-get -y install gcc g++ make cmake git psmisc dbus python-dbus python-gtk2 libdbus-1-dev
 RUN apt-get -y install libjansson-dev libgtest-dev google-mock libssl-dev autoconf automake pkg-config libtool libexpat1-dev libboost-program-options-dev libboost-test-dev libboost-regex-dev libboost-dev libboost-system-dev libboost-thread-dev libboost-log-dev libjsoncpp-dev curl libcurl4-openssl-dev
 RUN apt-get -y install lcov clang clang-format-3.8 
 
-WORKDIR $HOME
-COPY src/ $HOME/src/
-COPY distribution $HOME/distribution/
-COPY tests/ $HOME/tests/
-COPY third_party/ $HOME/third_party/
-COPY config/ $HOME/config/
-COPY cmake-modules/ $HOME/cmake-modules/
-COPY CMakeLists.txt $HOME/
-RUN mkdir $HOME/build
+WORKDIR aktualizr
+ADD . src

--- a/README.md
+++ b/README.md
@@ -110,29 +110,15 @@ A Dockerfile is provided to support building / testing the application without d
 docker build -t advancedtelematic/aktualizr .
 ~~~
 
-and run
+Once this docker image is built, Aktualizr can be built and tested with:
 
 ~~~
-docker run --rm -it advancedtelematic/aktualizr make
+docker run --rm -it advancedtelematic/aktualizr src/coverage.sh
 ~~~
 
-to build the software,
+The following command will get a shell to perform an interactive build, but note that your local working copy will not be synchronised with the Docker container. The recommended development workflow is perform local cmake builds, but passing `-v $(pwd):/aktualizr-local` to `docker run` is an alternative.
 
 ~~~
-docker run --rm -it advancedtelematic/aktualizr make test
+docker run --rm -it advancedtelematic/aktualizr
 ~~~
 
-to run the tests, and
-
-~~~
-docker run --rm -it advancedtelematic/aktualizr build/target/aktualizr
-~~~
-
-to run the client. If you want the build artifacts to appear on your host machine (outside of the docker container), you can try
-
-~~~
-mkdir build
-docker run --rm -it --read-only -u $UID -v $PWD/build:/source/build advancedtelematic/aktualizr make
-~~~
-
-though be aware that the output binary (`build/target/aktualizr`) may have dynamic linking requirements that are not met by your host environment. Also note that running the linting rule (`make qa`) may attempt to modify the source files in the Docker container. If the linting rule is run with `-u $UID` or `--read-only`, the execution will fail with an `llvm` segfault when the linter outputs the source files.

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,5 @@ ignore:
   - "third_party"
   - "tests"
   - "src/dbusgateway/src-gen"
+fixes:
+  - "src/::"

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+set -e
+mkdir -p build-coverage
+cd build-coverage
+cmake -DBUILD_GENIVI=ON -DBUILD_WITH_CODE_COVERAGE=ON ../src
+make -j8
+CTEST_OUTPUT_ON_FAILURE=1 make -j1 coverage
+cd ..
+if [ -n "$CODECOV_TOKEN" ]; then
+  bash <(curl -s https://codecov.io/bash)
+else
+  echo "No CODECOV_TOKEN, not uploading to codecov.io"
+fi


### PR DESCRIPTION
This moves most of the logic for the code coverage build into coverage.sh, and
fixes up the Docker instructions in the README to work.