### PR TITLE
src/CMakeLists.txt: Add Boost filesystem

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,7 @@
 add_definitions(-DBOOST_LOG_DYN_LINK)
 
 # find all required libraries
-find_package(Boost COMPONENTS system thread program_options log log_setup regex chrono REQUIRED)
+find_package(Boost COMPONENTS system filesystem thread program_options log log_setup regex chrono REQUIRED)
 find_package(CURL REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(Threads REQUIRED)


### PR DESCRIPTION
Explicitly add the Boost filesystem component as
a required package in the CMake file and fix the
issue with "adding symbols: DSO missing from
command line" when building from Yocto/OE recipe.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>