### PR TITLE
main.cc: Handle missing RVI configurations

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -150,7 +150,12 @@ int main(int argc, char *argv[]) {
 
   if (config.gateway.rvi) {
 #ifdef WITH_GENIVI
-    SotaRVIClient(config, events_channel).runForever(commands_channel);
+    try {
+      SotaRVIClient(config, events_channel).runForever(commands_channel);
+    } catch(std::runtime_error e) {
+      LOGGER_LOG(LVL_error, "Missing RVI configurations: " << e.what());
+      exit(EXIT_FAILURE);
+    }
 #else
     LOGGER_LOG(LVL_error, "RVI support is not enabled");
     return EXIT_FAILURE;


### PR DESCRIPTION
Gracefully terminate the applicaiton if RVI
support is enabled but RVI configurations are
missing.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>