### PR TITLE
Reformat using clang-format

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -139,7 +139,6 @@ void Config::updateFromToml(const std::string& filename) {
   CopyFromConfig(tls.client_certificate, "tls.client_certificate", LVL_warning, pt);
   CopyFromConfig(tls.pkey_file, "tls.pkey_file", LVL_warning, pt);
 
-
   CopyFromConfig(provision.p12_path, "provision.p12_path", LVL_warning, pt);
   CopyFromConfig(provision.p12_password, "provision.p12_password", LVL_warning, pt);
 
@@ -150,7 +149,7 @@ void Config::updateFromToml(const std::string& filename) {
   CopyFromConfig(uptane.metadata_path, "uptane.metadata_path", LVL_warning, pt);
   CopyFromConfig(uptane.private_key_path, "uptane.private_key_path", LVL_warning, pt);
   CopyFromConfig(uptane.public_key_path, "uptane.public_key_path", LVL_warning, pt);
-  
+
   CopyFromConfig(ostree.os, "ostree.os", LVL_warning, pt);
   CopyFromConfig(ostree.sysroot, "ostree.sysroot", LVL_warning, pt);
 

--- a/src/config.h
+++ b/src/config.h
@@ -141,7 +141,7 @@ struct UptaneConfig {
 };
 
 struct OstreeConfig {
-  OstreeConfig(): os(""), sysroot("") {}
+  OstreeConfig() : os(""), sysroot("") {}
   std::string os;
   std::string sysroot;
 };

--- a/src/httpclient.h
+++ b/src/httpclient.h
@@ -25,7 +25,6 @@ class HttpClient {
   unsigned int http_code;
   std::string token; /**< the OAuth2 token stored as string */
 
-
  private:
   CURL *curl;
   curl_slist *headers;

--- a/src/ostree.cc
+++ b/src/ostree.cc
@@ -1,19 +1,19 @@
 #include "ostree.h"
 #include <stdio.h>
-#include <boost/filesystem.hpp>
-#include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/filesystem.hpp>
 #include <fstream>
 #include "logger.h"
 
 #include <gio/gio.h>
 
-OstreeSysroot * Ostree::LoadSysroot(const std::string &path) {
+OstreeSysroot *Ostree::LoadSysroot(const std::string &path) {
   OstreeSysroot *sysroot = NULL;
 
-  if(path.size()){
+  if (path.size()) {
     sysroot = ostree_sysroot_new(g_file_new_for_path(path.c_str()));
-  }else{
+  } else {
     sysroot = ostree_sysroot_new_default();
   }
   GCancellable *cancellable = NULL;
@@ -22,51 +22,48 @@ OstreeSysroot * Ostree::LoadSysroot(const std::string &path) {
   return sysroot;
 }
 
-OstreeDeployment* Ostree::getBootedDeployment() {
-  
+OstreeDeployment *Ostree::getBootedDeployment() {
   OstreeSysroot *sysroot = Ostree::LoadSysroot("");
   OstreeRepo *repo = NULL;
   OstreeDeployment *booted_deployment = NULL;
 
   GCancellable *cancellable = NULL;
   GError **error = NULL;
-  
+
   if (!ostree_sysroot_get_repo(sysroot, &repo, cancellable, error)) throw std::runtime_error("could not get repo");
 
-  booted_deployment = ostree_sysroot_get_booted_deployment (sysroot);
-  //booted_deployment = (OstreeDeployment *)ostree_sysroot_get_deployments(sysroot)->pdata[0];
+  booted_deployment = ostree_sysroot_get_booted_deployment(sysroot);
+  // booted_deployment = (OstreeDeployment *)ostree_sysroot_get_deployments(sysroot)->pdata[0];
   return booted_deployment;
 }
 
-bool Ostree::addRemote(OstreeRepo *repo, const std::string &remote, const std::string &url, const data::PackageManagerCredentials &cred) {
+bool Ostree::addRemote(OstreeRepo *repo, const std::string &remote, const std::string &url,
+                       const data::PackageManagerCredentials &cred) {
   GCancellable *cancellable = NULL;
   GError *error = NULL;
   GVariantBuilder b;
   GVariant *options;
-  
-  g_variant_builder_init (&b, G_VARIANT_TYPE ("a{sv}"));
-  g_variant_builder_add (&b, "{s@v}", "gpg-verify", g_variant_new_variant(g_variant_new_boolean (FALSE)));
-  
-  if(cred.cert_file.size() && cred.pkey_file.size() && cred.ca_file.size()){
-     g_variant_builder_add (&b, "{s@v}", "tls-client-cert-path", g_variant_new_variant (g_variant_new_string (cred.cert_file.c_str())));
-     g_variant_builder_add (&b, "{s@v}", "tls-client-key-path", g_variant_new_variant (g_variant_new_string (cred.pkey_file.c_str())));
-     g_variant_builder_add (&b, "{s@v}", "tls-ca-path", g_variant_new_variant (g_variant_new_string (cred.ca_file.c_str())));
+
+  g_variant_builder_init(&b, G_VARIANT_TYPE("a{sv}"));
+  g_variant_builder_add(&b, "{s@v}", "gpg-verify", g_variant_new_variant(g_variant_new_boolean(FALSE)));
+
+  if (cred.cert_file.size() && cred.pkey_file.size() && cred.ca_file.size()) {
+    g_variant_builder_add(&b, "{s@v}", "tls-client-cert-path",
+                          g_variant_new_variant(g_variant_new_string(cred.cert_file.c_str())));
+    g_variant_builder_add(&b, "{s@v}", "tls-client-key-path",
+                          g_variant_new_variant(g_variant_new_string(cred.pkey_file.c_str())));
+    g_variant_builder_add(&b, "{s@v}", "tls-ca-path",
+                          g_variant_new_variant(g_variant_new_string(cred.ca_file.c_str())));
   }
-  options = g_variant_builder_end (&b);
-  
-  if (!ostree_repo_remote_change (repo, NULL,
-                                  OSTREE_REPO_REMOTE_CHANGE_DELETE_IF_EXISTS,
-                                  remote.c_str(), url.c_str(),
-                                  options,
-                                  cancellable, &error)){
+  options = g_variant_builder_end(&b);
+
+  if (!ostree_repo_remote_change(repo, NULL, OSTREE_REPO_REMOTE_CHANGE_DELETE_IF_EXISTS, remote.c_str(), url.c_str(),
+                                 options, cancellable, &error)) {
     LOGGER_LOG(LVL_error, "Error of adding remote: " << error->message);
     return false;
   }
-  if (!ostree_repo_remote_change (repo, NULL,
-                                  OSTREE_REPO_REMOTE_CHANGE_ADD_IF_NOT_EXISTS,
-                                  remote.c_str(), url.c_str(),
-                                  options,
-                                  cancellable, &error)){
+  if (!ostree_repo_remote_change(repo, NULL, OSTREE_REPO_REMOTE_CHANGE_ADD_IF_NOT_EXISTS, remote.c_str(), url.c_str(),
+                                 options, cancellable, &error)) {
     LOGGER_LOG(LVL_error, "Error of adding remote: " << error->message);
     return false;
   }
@@ -81,8 +78,8 @@ OstreePackage::OstreePackage(const std::string &ecu_serial_in, const std::string
 
 data::InstallOutcome OstreePackage::install(const data::PackageManagerCredentials &cred, OstreeConfig config) {
   const char remote[] = "aktualizr-remote";
-  const char* const refs[] = {commit.c_str()};
-  const char* opt_osname = NULL;
+  const char *const refs[] = {commit.c_str()};
+  const char *opt_osname = NULL;
   OstreeRepo *repo = NULL;
   GCancellable *cancellable = NULL;
   GError *error = NULL;
@@ -90,58 +87,55 @@ data::InstallOutcome OstreePackage::install(const data::PackageManagerCredential
   GVariantBuilder builder;
   GVariant *options;
 
-  if(config.os.size()){
+  if (config.os.size()) {
     opt_osname = config.os.c_str();
   }
   OstreeSysroot *sysroot = Ostree::LoadSysroot(config.sysroot);
-  if (!ostree_sysroot_get_repo (sysroot, &repo, cancellable, &error)){
+  if (!ostree_sysroot_get_repo(sysroot, &repo, cancellable, &error)) {
     LOGGER_LOG(LVL_error, "could not get repo");
     return data::InstallOutcome(data::INSTALL_FAILED, "could not get repo");
   }
 
-  if (!Ostree::addRemote(repo, remote, pull_uri, cred)){
-     return data::InstallOutcome(data::INSTALL_FAILED, "Error of adding remote");
+  if (!Ostree::addRemote(repo, remote, pull_uri, cred)) {
+    return data::InstallOutcome(data::INSTALL_FAILED, "Error of adding remote");
   }
 
+  g_variant_builder_init(&builder, G_VARIANT_TYPE("a{sv}"));
+  g_variant_builder_add(&builder, "{s@v}", "flags", g_variant_new_variant(g_variant_new_int32(0)));
 
-  g_variant_builder_init (&builder, G_VARIANT_TYPE ("a{sv}"));
-  g_variant_builder_add (&builder, "{s@v}", "flags",
-                           g_variant_new_variant (g_variant_new_int32 (0)));
-  
-  g_variant_builder_add (&builder, "{s@v}", "refs",
-                             g_variant_new_variant (g_variant_new_strv (refs, 1)));
-                             
+  g_variant_builder_add(&builder, "{s@v}", "refs", g_variant_new_variant(g_variant_new_strv(refs, 1)));
+
   if (cred.access_token.size()) {
     GVariantBuilder hdr_builder;
     std::string av("Bearer ");
     av += cred.access_token;
-    g_variant_builder_init (&hdr_builder, G_VARIANT_TYPE ("a(ss)"));
-    g_variant_builder_add (&hdr_builder, "(ss)", "Authorization", av.c_str());
-    g_variant_builder_add (&builder, "{s@v}", "http-headers",
-                               g_variant_new_variant (g_variant_builder_end (&hdr_builder)));
+    g_variant_builder_init(&hdr_builder, G_VARIANT_TYPE("a(ss)"));
+    g_variant_builder_add(&hdr_builder, "(ss)", "Authorization", av.c_str());
+    g_variant_builder_add(&builder, "{s@v}", "http-headers",
+                          g_variant_new_variant(g_variant_builder_end(&hdr_builder)));
   }
-  options = g_variant_ref_sink (g_variant_builder_end (&builder));
+  options = g_variant_ref_sink(g_variant_builder_end(&builder));
 
-  if(!ostree_repo_pull_with_options (repo, remote, options, NULL, cancellable, &error)){
+  if (!ostree_repo_pull_with_options(repo, remote, options, NULL, cancellable, &error)) {
     LOGGER_LOG(LVL_error, "Error of pulling image: " << error->message);
     return data::InstallOutcome(data::INSTALL_FAILED, error->message);
   }
 
-  OstreeDeployment* booted_deployment =  Ostree::getBootedDeployment();
-  if(booted_deployment == NULL && !config.os.size() && !config.sysroot.size()){
+  OstreeDeployment *booted_deployment = Ostree::getBootedDeployment();
+  if (booted_deployment == NULL && !config.os.size() && !config.sysroot.size()) {
     LOGGER_LOG(LVL_error, "No booted deplyment");
     return data::InstallOutcome(data::INSTALL_FAILED, "No booted deplyment");
   }
-  
-  GKeyFile *origin = ostree_sysroot_origin_new_from_refspec (sysroot, commit.c_str());
-  if (!ostree_repo_resolve_rev (repo, commit.c_str(), FALSE, &revision, &error)){
+
+  GKeyFile *origin = ostree_sysroot_origin_new_from_refspec(sysroot, commit.c_str());
+  if (!ostree_repo_resolve_rev(repo, commit.c_str(), FALSE, &revision, &error)) {
     LOGGER_LOG(LVL_error, error->message);
     return data::InstallOutcome(data::INSTALL_FAILED, error->message);
   }
-  
-  OstreeDeployment* merge_deployment = ostree_sysroot_get_merge_deployment (sysroot, opt_osname);
-  
-  if (!ostree_sysroot_prepare_cleanup (sysroot, cancellable, &error)){
+
+  OstreeDeployment *merge_deployment = ostree_sysroot_get_merge_deployment(sysroot, opt_osname);
+
+  if (!ostree_sysroot_prepare_cleanup(sysroot, cancellable, &error)) {
     LOGGER_LOG(LVL_error, error->message);
     return data::InstallOutcome(data::INSTALL_FAILED, error->message);
   }
@@ -152,38 +146,32 @@ data::InstallOutcome OstreePackage::install(const data::PackageManagerCredential
   boost::split(args_vector, args_content, boost::is_any_of(" "));
 
   std::vector<const char *> kargs_strv_vector;
-  kargs_strv_vector.reserve(args_vector.size()+1);
+  kargs_strv_vector.reserve(args_vector.size() + 1);
 
-  for (std::vector<std::string>::iterator it = args_vector.begin(); it != args_vector.end(); ++it){
+  for (std::vector<std::string>::iterator it = args_vector.begin(); it != args_vector.end(); ++it) {
     kargs_strv_vector.push_back((*it).c_str());
   }
   kargs_strv_vector[args_vector.size()] = 0;
-  GStrv kargs_strv = const_cast<char**>(&kargs_strv_vector[0]);
+  GStrv kargs_strv = const_cast<char **>(&kargs_strv_vector[0]);
 
   OstreeDeployment *new_deployment = NULL;
-  if (!ostree_sysroot_deploy_tree (sysroot,
-                                     opt_osname, revision, origin,
-                                     merge_deployment, kargs_strv,
-                                     &new_deployment,
-                                     cancellable, &error)){
+  if (!ostree_sysroot_deploy_tree(sysroot, opt_osname, revision, origin, merge_deployment, kargs_strv, &new_deployment,
+                                  cancellable, &error)) {
     LOGGER_LOG(LVL_error, "ostree_sysroot_deploy_tree: " << error->message);
     return data::InstallOutcome(data::INSTALL_FAILED, error->message);
   }
 
-  if (!ostree_sysroot_simple_write_deployment (sysroot, "",
-                                               new_deployment, merge_deployment,
-                                              OSTREE_SYSROOT_SIMPLE_WRITE_DEPLOYMENT_FLAGS_RETAIN,
-                                               cancellable, &error)){
+  if (!ostree_sysroot_simple_write_deployment(sysroot, "", new_deployment, merge_deployment,
+                                              OSTREE_SYSROOT_SIMPLE_WRITE_DEPLOYMENT_FLAGS_RETAIN, cancellable,
+                                              &error)) {
     LOGGER_LOG(LVL_error, "ostree_sysroot_simple_write_deployment:" << error->message);
     return data::InstallOutcome(data::INSTALL_FAILED, error->message);
- }
+  }
   return data::InstallOutcome(data::OK, "Installation succesfull");
 }
 
-
 OstreeBranch OstreeBranch::getCurrent(const std::string &ecu_serial, const std::string &branch) {
-  
-  OstreeDeployment * booted_deployment = Ostree::getBootedDeployment();
+  OstreeDeployment *booted_deployment = Ostree::getBootedDeployment();
   GKeyFile *origin = ostree_deployment_get_origin(booted_deployment);
   const char *ref = ostree_deployment_get_csum(booted_deployment);
   char *origin_refspec = g_key_file_get_string(origin, "origin", "refspec", NULL);

--- a/src/ostree.h
+++ b/src/ostree.h
@@ -1,20 +1,20 @@
 #ifndef OSTREE_H_
 #define OSTREE_H_
 
-#include <string>
-#include <ostree-1/ostree.h>
 #include <glib/gi18n.h>
-#include "types.h"
+#include <ostree-1/ostree.h>
+#include <string>
 #include "config.h"
+#include "types.h"
 
 static const std::string NEW_PACKAGE = "/tmp/sota-package";
 static const std::string BOOT_BRANCH = "/boot/sota/branchname";
 
-struct Ostree{
- static OstreeDeployment* getBootedDeployment();
- static OstreeSysroot * LoadSysroot(const std::string &path);
- static bool addRemote(OstreeRepo *repo, const std::string &remote, const std::string &url, const data::PackageManagerCredentials &cred);
-
+struct Ostree {
+  static OstreeDeployment *getBootedDeployment();
+  static OstreeSysroot *LoadSysroot(const std::string &path);
+  static bool addRemote(OstreeRepo *repo, const std::string &remote, const std::string &url,
+                        const data::PackageManagerCredentials &cred);
 };
 
 class OstreePackage {
@@ -32,7 +32,6 @@ class OstreePackage {
   static OstreePackage getEcu(const std::string &);
   static OstreePackage fromJson(const Json::Value &json);
 };
-
 
 struct OstreeBranch {
   OstreeBranch(bool current_in, const std::string &os_name_in, const OstreePackage &package_in)

--- a/src/sotauptaneclient.cc
+++ b/src/sotauptaneclient.cc
@@ -236,9 +236,10 @@ bool SotaUptaneClient::ecuRegister() {
   std::string pub_key_str((std::istreambuf_iterator<char>(ks)), std::istreambuf_iterator<char>());
   ks.close();
   pub_key_str = boost::replace_all_copy(pub_key_str, "\n", "\\n");
-  
+
   std::string data = "{\"primary_ecu_serial\":\"" + config.uptane.primary_ecu_serial +
-                     "\", \"ecus\":[{\"hardware_identifier\":\"" + config.device.uuid +"\",\"ecu_serial\":\"" + config.uptane.primary_ecu_serial +
+                     "\", \"ecus\":[{\"hardware_identifier\":\"" + config.device.uuid + "\",\"ecu_serial\":\"" +
+                     config.uptane.primary_ecu_serial +
                      "\", \"clientKey\": {\"keytype\": \"RSA\", \"keyval\": {\"public\": \"" + pub_key_str + "\"}}}]}";
 
   std::string result = http->post(config.tls.server + "/director/ecus", data);

--- a/src/types.cc
+++ b/src/types.cc
@@ -117,7 +117,7 @@ Json::Value OperationResult::toJson() {
   return json;
 }
 
-UpdateReport OperationResult::toReport(){
+UpdateReport OperationResult::toReport() {
   UpdateReport report;
   report.update_id = id;
   report.operation_results.push_back(*this);

--- a/src/types.h
+++ b/src/types.h
@@ -97,7 +97,7 @@ struct OperationResult {
   std::string result_text;
   Json::Value toJson();
   UpdateReport toReport();
-  bool isSuccess(){ return result_code == OK || result_code == ALREADY_PROCESSED;};
+  bool isSuccess() { return result_code == OK || result_code == ALREADY_PROCESSED; };
   static OperationResult fromJson(const std::string& json_str);
   static OperationResult fromOutcome(const std::string& id, const InstallOutcome& outcome);
 };


### PR DESCRIPTION
The 'make qa' command was used to reformat, using clang-format-3.8