### PR TITLE
Stop .gitignore skipping cmake-modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # build folder
 build/
 /build-*
-/cmake-*
+/cmake-build-debug
 
 # clion
 /.idea


### PR DESCRIPTION
The Clion IDE uses cmake-build-debug as the default build directory. Replace a
wildcard match (which caught the real directory cmake-modules) with a specific
path in .gitignore.