### PR TITLE
Let OSTree sysroot be changed in config

### DIFF
--- a/src/ostree.cc
+++ b/src/ostree.cc
@@ -22,8 +22,8 @@ OstreeSysroot *Ostree::LoadSysroot(const std::string &path) {
   return sysroot;
 }
 
-OstreeDeployment *Ostree::getBootedDeployment() {
-  OstreeSysroot *sysroot = Ostree::LoadSysroot("");
+OstreeDeployment *Ostree::getBootedDeployment(const std::string& path) {
+  OstreeSysroot *sysroot = Ostree::LoadSysroot(path);
   OstreeRepo *repo = NULL;
   OstreeDeployment *booted_deployment = NULL;
 
@@ -121,7 +121,7 @@ data::InstallOutcome OstreePackage::install(const data::PackageManagerCredential
     return data::InstallOutcome(data::INSTALL_FAILED, error->message);
   }
 
-  OstreeDeployment *booted_deployment = Ostree::getBootedDeployment();
+  OstreeDeployment *booted_deployment = Ostree::getBootedDeployment(config.sysroot);
   if (booted_deployment == NULL && !config.os.size() && !config.sysroot.size()) {
     LOGGER_LOG(LVL_error, "No booted deplyment");
     return data::InstallOutcome(data::INSTALL_FAILED, "No booted deplyment");
@@ -170,8 +170,12 @@ data::InstallOutcome OstreePackage::install(const data::PackageManagerCredential
   return data::InstallOutcome(data::OK, "Installation succesfull");
 }
 
-OstreeBranch OstreeBranch::getCurrent(const std::string &ecu_serial, const std::string &branch) {
-  OstreeDeployment *booted_deployment = Ostree::getBootedDeployment();
+OstreeBranch OstreeBranch::getCurrent(const std::string &ecu_serial, const std::string &branch, const std::string &ostree_sysroot, const std::string &ostree_os) {
+  OstreeDeployment *booted_deployment = Ostree::getBootedDeployment(ostree_sysroot);
+
+  if (!booted_deployment)
+    booted_deployment = ostree_sysroot_get_merge_deployment(Ostree::LoadSysroot(ostree_sysroot), ostree_os.c_str());
+
   GKeyFile *origin = ostree_deployment_get_origin(booted_deployment);
   const char *ref = ostree_deployment_get_csum(booted_deployment);
   char *origin_refspec = g_key_file_get_string(origin, "origin", "refspec", NULL);
@@ -203,7 +207,7 @@ Json::Value OstreePackage::toEcuVersion(const Json::Value &custom) {
   return value;
 }
 
-OstreePackage OstreePackage::getEcu(const std::string &ecu_serial) {
+OstreePackage OstreePackage::getEcu(const std::string &ecu_serial, const std::string &ostree_sysroot, const std::string &ostree_os) {
   if (boost::filesystem::exists(NEW_PACKAGE)) {
     std::ifstream path_stream(NEW_PACKAGE.c_str());
     std::string json_content((std::istreambuf_iterator<char>(path_stream)), std::istreambuf_iterator<char>());
@@ -213,7 +217,7 @@ OstreePackage OstreePackage::getEcu(const std::string &ecu_serial) {
       std::ifstream boot_branch_stream(BOOT_BRANCH.c_str());
       std::string branch_name((std::istreambuf_iterator<char>(boot_branch_stream)), std::istreambuf_iterator<char>());
       branch_name.erase(std::remove(branch_name.begin(), branch_name.end(), '\n'), branch_name.end());
-      return OstreeBranch::getCurrent(ecu_serial, branch_name).package;
+      return OstreeBranch::getCurrent(ecu_serial, branch_name, ostree_sysroot, ostree_os).package;
     }
   }
   throw std::runtime_error("unknown current branch");

--- a/src/ostree.cc
+++ b/src/ostree.cc
@@ -22,7 +22,7 @@ OstreeSysroot *Ostree::LoadSysroot(const std::string &path) {
   return sysroot;
 }
 
-OstreeDeployment *Ostree::getBootedDeployment(const std::string& path) {
+OstreeDeployment *Ostree::getBootedDeployment(const std::string &path) {
   OstreeSysroot *sysroot = Ostree::LoadSysroot(path);
   OstreeRepo *repo = NULL;
   OstreeDeployment *booted_deployment = NULL;
@@ -170,7 +170,8 @@ data::InstallOutcome OstreePackage::install(const data::PackageManagerCredential
   return data::InstallOutcome(data::OK, "Installation succesfull");
 }
 
-OstreeBranch OstreeBranch::getCurrent(const std::string &ecu_serial, const std::string &branch, const std::string &ostree_sysroot, const std::string &ostree_os) {
+OstreeBranch OstreeBranch::getCurrent(const std::string &ecu_serial, const std::string &branch,
+                                      const std::string &ostree_sysroot, const std::string &ostree_os) {
   OstreeDeployment *booted_deployment = Ostree::getBootedDeployment(ostree_sysroot);
 
   if (!booted_deployment)
@@ -207,7 +208,8 @@ Json::Value OstreePackage::toEcuVersion(const Json::Value &custom) {
   return value;
 }
 
-OstreePackage OstreePackage::getEcu(const std::string &ecu_serial, const std::string &ostree_sysroot, const std::string &ostree_os) {
+OstreePackage OstreePackage::getEcu(const std::string &ecu_serial, const std::string &ostree_sysroot,
+                                    const std::string &ostree_os) {
   if (boost::filesystem::exists(NEW_PACKAGE)) {
     std::ifstream path_stream(NEW_PACKAGE.c_str());
     std::string json_content((std::istreambuf_iterator<char>(path_stream)), std::istreambuf_iterator<char>());

--- a/src/ostree.h
+++ b/src/ostree.h
@@ -11,7 +11,7 @@ static const std::string NEW_PACKAGE = "/tmp/sota-package";
 static const std::string BOOT_BRANCH = "/usr/share/sota/branchname";
 
 struct Ostree {
-  static OstreeDeployment *getBootedDeployment();
+  static OstreeDeployment *getBootedDeployment(const std::string& path);
   static OstreeSysroot *LoadSysroot(const std::string &path);
   static bool addRemote(OstreeRepo *repo, const std::string &remote, const std::string &url,
                         const data::PackageManagerCredentials &cred);
@@ -29,14 +29,14 @@ class OstreePackage {
   data::InstallOutcome install(const data::PackageManagerCredentials &cred, OstreeConfig config);
 
   Json::Value toEcuVersion(const Json::Value &custom);
-  static OstreePackage getEcu(const std::string &);
+  static OstreePackage getEcu(const std::string &ecu_serial, const std::string &ostree_sysroot, const std::string &ostree_os);
   static OstreePackage fromJson(const Json::Value &json);
 };
 
 struct OstreeBranch {
   OstreeBranch(bool current_in, const std::string &os_name_in, const OstreePackage &package_in)
       : current(current_in), os_name(os_name_in), package(package_in) {}
-  static OstreeBranch getCurrent(const std::string &ecu_serial, const std::string &branch);
+  static OstreeBranch getCurrent(const std::string &ecu_serial, const std::string &branch, const std::string &ostree_sysroot, const std::string &ostree_os);
   bool current;
   std::string os_name;
   OstreePackage package;

--- a/src/ostree.h
+++ b/src/ostree.h
@@ -11,7 +11,7 @@ static const std::string NEW_PACKAGE = "/tmp/sota-package";
 static const std::string BOOT_BRANCH = "/usr/share/sota/branchname";
 
 struct Ostree {
-  static OstreeDeployment *getBootedDeployment(const std::string& path);
+  static OstreeDeployment *getBootedDeployment(const std::string &path);
   static OstreeSysroot *LoadSysroot(const std::string &path);
   static bool addRemote(OstreeRepo *repo, const std::string &remote, const std::string &url,
                         const data::PackageManagerCredentials &cred);
@@ -29,14 +29,16 @@ class OstreePackage {
   data::InstallOutcome install(const data::PackageManagerCredentials &cred, OstreeConfig config);
 
   Json::Value toEcuVersion(const Json::Value &custom);
-  static OstreePackage getEcu(const std::string &ecu_serial, const std::string &ostree_sysroot, const std::string &ostree_os);
+  static OstreePackage getEcu(const std::string &ecu_serial, const std::string &ostree_sysroot,
+                              const std::string &ostree_os);
   static OstreePackage fromJson(const Json::Value &json);
 };
 
 struct OstreeBranch {
   OstreeBranch(bool current_in, const std::string &os_name_in, const OstreePackage &package_in)
       : current(current_in), os_name(os_name_in), package(package_in) {}
-  static OstreeBranch getCurrent(const std::string &ecu_serial, const std::string &branch, const std::string &ostree_sysroot, const std::string &ostree_os);
+  static OstreeBranch getCurrent(const std::string &ecu_serial, const std::string &branch,
+                                 const std::string &ostree_sysroot, const std::string &ostree_os);
   bool current;
   std::string os_name;
   OstreePackage package;

--- a/src/uptane/uptanerepository.cc
+++ b/src/uptane/uptanerepository.cc
@@ -46,7 +46,7 @@ std::string Repository::signManifest(const Json::Value& custom) {
   Json::Value version_manifest;
   version_manifest["primary_ecu_serial"] = config.uptane.primary_ecu_serial;
   version_manifest["ecu_version_manifest"] = Json::Value(Json::arrayValue);
-  Json::Value ecu_version_signed = sign(OstreePackage::getEcu(config.uptane.primary_ecu_serial).toEcuVersion(custom));
+  Json::Value ecu_version_signed = sign(OstreePackage::getEcu(config.uptane.primary_ecu_serial, config.ostree.sysroot, config.ostree.os).toEcuVersion(custom));
   version_manifest["ecu_version_manifest"].append(ecu_version_signed);
   Json::Value tuf_signed = sign(version_manifest);
   return Json::FastWriter().write(tuf_signed);

--- a/src/uptane/uptanerepository.cc
+++ b/src/uptane/uptanerepository.cc
@@ -46,7 +46,9 @@ std::string Repository::signManifest(const Json::Value& custom) {
   Json::Value version_manifest;
   version_manifest["primary_ecu_serial"] = config.uptane.primary_ecu_serial;
   version_manifest["ecu_version_manifest"] = Json::Value(Json::arrayValue);
-  Json::Value ecu_version_signed = sign(OstreePackage::getEcu(config.uptane.primary_ecu_serial, config.ostree.sysroot, config.ostree.os).toEcuVersion(custom));
+  Json::Value ecu_version_signed =
+      sign(OstreePackage::getEcu(config.uptane.primary_ecu_serial, config.ostree.sysroot, config.ostree.os)
+               .toEcuVersion(custom));
   version_manifest["ecu_version_manifest"].append(ecu_version_signed);
   Json::Value tuf_signed = sign(version_manifest);
   return Json::FastWriter().write(tuf_signed);

--- a/tests/uptane_test.cc
+++ b/tests/uptane_test.cc
@@ -52,7 +52,7 @@ Json::Value OstreePackage::toEcuVersion(const Json::Value &custom) {
   return value;
 }
 
-OstreePackage OstreePackage::getEcu(const std::string &ecu_serial) {
+OstreePackage OstreePackage::getEcu(const std::string &ecu_serial, const std::string& ostree_sysroot, const std::string& ostree_os) {
   return OstreePackage(ecu_serial, "frgfdg", "sfsdf", "dsfsdf", "sfsdfs");
 }
 

--- a/tests/uptane_test.cc
+++ b/tests/uptane_test.cc
@@ -53,8 +53,8 @@ Json::Value OstreePackage::toEcuVersion(const Json::Value &custom) {
 }
 
 OstreePackage OstreePackage::getEcu(const std::string &ecu_serial,
-				    const std::string& ostree_sysroot __attribute__((unused)),
-				    const std::string& ostree_os __attribute__((unused))) {
+                                    const std::string &ostree_sysroot __attribute__((unused)),
+                                    const std::string &ostree_os __attribute__((unused))) {
   return OstreePackage(ecu_serial, "frgfdg", "sfsdf", "dsfsdf", "sfsdfs");
 }
 

--- a/tests/uptane_test.cc
+++ b/tests/uptane_test.cc
@@ -52,7 +52,9 @@ Json::Value OstreePackage::toEcuVersion(const Json::Value &custom) {
   return value;
 }
 
-OstreePackage OstreePackage::getEcu(const std::string &ecu_serial, const std::string& ostree_sysroot, const std::string& ostree_os) {
+OstreePackage OstreePackage::getEcu(const std::string &ecu_serial,
+				    const std::string& ostree_sysroot __attribute__((unused)),
+				    const std::string& ostree_os __attribute__((unused))) {
   return OstreePackage(ecu_serial, "frgfdg", "sfsdf", "dsfsdf", "sfsdfs");
 }
 


### PR DESCRIPTION
Normally one will need to set both ostree.sysroot and ostree.os when updating a directory, because in this case there will be no "currently booted" deployment.