### PR TITLE
Remove unnecessary check

### DIFF
--- a/src/uptane/tufrepository.cc
+++ b/src/uptane/tufrepository.cc
@@ -183,15 +183,6 @@ void TufRepository::initRoot(const Json::Value& new_content) {
                                                                << requiredThreshold);
       throw IllegalThreshold(name_, "root.json contains a role that requires too many signatures");
     }
-    for (Json::ValueIterator it_keyid = (*it)["keyids"].begin(); it_keyid != (*it)["keyids"].end(); ++it_keyid) {
-      if (keys_.count((*it_keyid).asString())) {
-        std::string key_can = Json::FastWriter().write(Json::Value(keys_[(*it_keyid).asString()].value));
-        std::string key_id = boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(key_can)));
-        if ((*it_keyid).asString() != key_id) {
-          throw UnmetThreshold(name_, role);
-        }
-      }
-    }
     thresholds_[role] += requiredThreshold;
   }
   verifyRole(content);
@@ -234,3 +225,4 @@ void TufRepository::refresh() {
   }
 }
 };
+


### PR DESCRIPTION
keyid MAY be a hash of the key, it's not a requirement. This check is actually incompatible with how our server generates keyids, i.e. based on binary data, not PEM representation.