### PR TITLE
Overwrite server options and primary_ecu_serial from cmdline

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -28,7 +28,7 @@ struct CoreConfig {
 };
 
 struct AuthConfig {
-  AuthConfig() : server("http://127.0.0.1:9001"), client_id("client-id"), client_secret("client-secret") {}
+  AuthConfig() : server("http://127.0.0.1:9001"), client_id(""), client_secret("") {}
 
   std::string server;
   std::string client_id;
@@ -63,11 +63,7 @@ struct DeviceConfig {
       : uuid("123e4567-e89b-12d3-a456-426655440000"),
         packages_dir("/tmp/"),
         certificates_path("/tmp/aktualizr/"),
-        package_manager(PMOFF) {
-    createCertificatesPath();
-  }
-  void createCertificatesPath();
-
+        package_manager(PMOFF) {}
   std::string uuid;
   boost::filesystem::path packages_dir;
   boost::filesystem::path certificates_path;
@@ -111,7 +107,7 @@ struct RviConfig {
 };
 
 struct TlsConfig {
-  TlsConfig() : server("localhost"), ca_file("ca.pem"), pkey_file("pkey.pem"), client_certificate("client.pem") {}
+  TlsConfig() : server(""), ca_file("ca.pem"), pkey_file("pkey.pem"), client_certificate("client.pem") {}
   std::string server;
   std::string ca_file;
   std::string pkey_file;
@@ -133,6 +129,7 @@ struct ProvisionConfig {
 struct UptaneConfig {
   UptaneConfig()
       : primary_ecu_serial(""),
+        primary_ecu_hardware_id(""),
         ostree_server(""),
         director_server(""),
         repo_server(""),
@@ -141,6 +138,7 @@ struct UptaneConfig {
         public_key_path("ecukey.pub"),
         disable_keyid_validation(false) {}
   std::string primary_ecu_serial;
+  std::string primary_ecu_hardware_id;
   std::string ostree_server;
   std::string director_server;
   std::string repo_server;
@@ -158,9 +156,12 @@ struct OstreeConfig {
 
 class Config {
  public:
-  void updateFromToml(const std::string& filename);
+  Config();
+  Config(const std::string& filename, const boost::program_options::variables_map& cmd);
+  Config(const std::string& filename);
+
   void updateFromTomlString(const std::string& contents);
-  void updateFromCommandLine(const boost::program_options::variables_map& cmd);
+  void postUpdateValues();
 
   // config data structures
   CoreConfig core;
@@ -177,6 +178,8 @@ class Config {
 
  private:
   void updateFromPropertyTree(const boost::property_tree::ptree& pt);
+  void updateFromToml(const std::string& filename);
+  void updateFromCommandLine(const boost::program_options::variables_map& cmd);
 };
 
 #endif  // CONFIG_H_

--- a/src/httpclient.cc
+++ b/src/httpclient.cc
@@ -192,10 +192,10 @@ std::string HttpClient::perform(CURL* curl_handler, int retry_times) {
     std::ostringstream error_message;
     error_message << "curl error: " << curl_easy_strerror(result);
     LOGGER_LOG(LVL_error, error_message.str());
-    if (retry_times){
+    if (retry_times) {
       sleep(1);
       perform(curl_handler, --retry_times);
-    }else{
+    } else {
       throw std::runtime_error(error_message.str());
     }
   }

--- a/src/uptane/tufrepository.cc
+++ b/src/uptane/tufrepository.cc
@@ -15,6 +15,7 @@ namespace Uptane {
 TufRepository::TufRepository(const std::string& name, const std::string& base_url, const Config& config)
     : name_(name), path_(config.uptane.metadata_path / name_), config_(config), base_url_(base_url) {
   boost::filesystem::create_directories(path_);
+  boost::filesystem::create_directories(path_ / "targets");
   http_.authenticate((config_.device.certificates_path / config_.tls.client_certificate).string(),
                      (config_.device.certificates_path / config_.tls.ca_file).string(),
                      (config_.device.certificates_path / config_.tls.pkey_file).string());
@@ -102,7 +103,7 @@ void TufRepository::verifyRole(const Json::Value& tuf_signed) {
 
 void TufRepository::saveRole(const Json::Value& content) {
   std::string role = boost::algorithm::to_lower_copy(content["signed"]["_type"].asString());
-  std::ofstream file((path_ / name_ / (role + ".json")).string().c_str());
+  std::ofstream file((path_ / (role + ".json")).string().c_str());
   file << content;
   file.close();
 }
@@ -116,7 +117,7 @@ void TufRepository::saveTarget(Target target) {
     if (!target.hash_.matchWith(content)) {
       throw TargetHashMismatch(name_, HASH_METADATA_MISMATCH);
     }
-    std::ofstream file((path_ / name_ / "targets" / target.filename_).string().c_str());
+    std::ofstream file((path_ / "targets" / target.filename_).string().c_str());
     file << content;
     file.close();
   }

--- a/src/uptane/uptanerepository.cc
+++ b/src/uptane/uptanerepository.cc
@@ -151,8 +151,8 @@ bool Repository::ecuRegister() {
   pub_key_str = boost::replace_all_copy(pub_key_str, "\n", "\\n");
 
   std::string data = "{\"primary_ecu_serial\":\"" + config.uptane.primary_ecu_serial +
-                     "\", \"ecus\":[{\"hardware_identifier\":\"" + config.device.uuid + "\",\"ecu_serial\":\"" +
-                     config.uptane.primary_ecu_serial +
+                     "\", \"ecus\":[{\"hardware_identifier\":\"" + config.uptane.primary_ecu_hardware_id +
+                     "\",\"ecu_serial\":\"" + config.uptane.primary_ecu_serial +
                      "\", \"clientKey\": {\"keytype\": \"RSA\", \"keyval\": {\"public\": \"" + pub_key_str + "\"}}}]}";
 
   authenticate();

--- a/tests/config_test.cc
+++ b/tests/config_test.cc
@@ -16,8 +16,6 @@ TEST(config, config_initialized_values) {
   EXPECT_EQ(conf.core.polling_sec, 10u);
 
   EXPECT_EQ(conf.auth.server, "http://127.0.0.1:9001");
-  EXPECT_EQ(conf.auth.client_id, "client-id");
-  EXPECT_EQ(conf.auth.client_secret, "client-secret");
 
   EXPECT_EQ(conf.device.uuid, "123e4567-e89b-12d3-a456-426655440000");
   EXPECT_EQ(conf.device.packages_dir, "/tmp/");
@@ -27,8 +25,7 @@ TEST(config, config_initialized_values) {
 }
 
 TEST(config, config_toml_parsing) {
-  Config conf;
-  conf.updateFromToml("tests/config_tests.toml");
+  Config conf("tests/config_tests.toml");
 
   EXPECT_EQ(conf.core.server, "https://example.com/core");
   EXPECT_EQ(conf.core.polling, false);
@@ -85,9 +82,8 @@ TEST(config, config_toml_dbus_invalid) {
 #endif
 
 TEST(config, config_oauth_tls_parsing) {
-  Config conf;
   try {
-    conf.updateFromToml("tests/config_tests_prov_bad.toml");
+    Config conf("tests/config_tests_prov_bad.toml");
   } catch (std::logic_error e) {
     EXPECT_STREQ(e.what(),
                  "It is not possible to set [tls] section with 'auth.client_id' or 'auth.client_secret' properties");
@@ -103,8 +99,6 @@ TEST(config, config_toml_parsing_empty_file) {
   EXPECT_EQ(conf.core.polling_sec, 10u);
 
   EXPECT_EQ(conf.auth.server, "http://127.0.0.1:9001");
-  EXPECT_EQ(conf.auth.client_id, "client-id");
-  EXPECT_EQ(conf.auth.client_secret, "client-secret");
 
   EXPECT_EQ(conf.device.uuid, "123e4567-e89b-12d3-a456-426655440000");
   EXPECT_EQ(conf.device.packages_dir, "/tmp/");
@@ -114,7 +108,6 @@ TEST(config, config_toml_parsing_empty_file) {
 }
 
 TEST(config, config_cmdl_parsing) {
-  Config conf;
   int argc = 7;
   const char *argv[] = {"./aktualizr", "--gateway-http", "off", "--gateway-rvi", "on", "--gateway-socket", "on"};
 
@@ -125,7 +118,7 @@ TEST(config, config_cmdl_parsing) {
 
   bpo::variables_map vm;
   bpo::store(bpo::parse_command_line(argc, argv, description), vm);
-  conf.updateFromCommandLine(vm);
+  Config conf("tests/config_tests.toml", vm);
 
   EXPECT_EQ(conf.gateway.http, false);
   EXPECT_EQ(conf.gateway.rvi, true);

--- a/tests/uptane_test.cc
+++ b/tests/uptane_test.cc
@@ -270,8 +270,7 @@ TEST(uptane, sign) {
 }
 
 TEST(SotaUptaneClientTest, device_registered) {
-  Config conf;
-  conf.updateFromToml("tests/config_tests_prov.toml");
+  Config conf("tests/config_tests_prov.toml");
 
   boost::filesystem::remove(conf.device.certificates_path / conf.tls.client_certificate);
   boost::filesystem::remove(conf.device.certificates_path / conf.tls.ca_file);
@@ -287,8 +286,7 @@ TEST(SotaUptaneClientTest, device_registered) {
 }
 
 TEST(SotaUptaneClientTest, device_registered_fail) {
-  Config conf;
-  conf.updateFromToml("tests/config_tests_prov.toml");
+  Config conf("tests/config_tests_prov.toml");
 
   boost::filesystem::remove(conf.device.certificates_path / conf.tls.client_certificate);
   boost::filesystem::remove(conf.device.certificates_path / conf.tls.ca_file);
@@ -349,8 +347,7 @@ TEST(SotaUptaneClientTest, device_ecu_register) {
 }
 
 TEST(SotaUptaneClientTest, RunForeverNoUpdates) {
-  Config conf;
-  conf.updateFromToml("tests/config_tests_prov.toml");
+  Config conf("tests/config_tests_prov.toml");
   conf.uptane.metadata_path = "tests/test_data";
   conf.uptane.director_server = tls_server + "/director";
   conf.device.certificates_path = "tests/test_data/";
@@ -386,8 +383,7 @@ TEST(SotaUptaneClientTest, RunForeverNoUpdates) {
 }
 
 TEST(SotaUptaneClientTest, RunForeverHasUpdates) {
-  Config conf;
-  conf.updateFromToml("tests/config_tests_prov.toml");
+  Config conf("tests/config_tests_prov.toml");
   conf.uptane.metadata_path = "tests/test_data";
   conf.uptane.director_server = tls_server + "/director";
   conf.device.certificates_path = "tests/test_data/";
@@ -419,8 +415,7 @@ TEST(SotaUptaneClientTest, RunForeverHasUpdates) {
 }
 
 TEST(SotaUptaneClientTest, RunForeverInstall) {
-  Config conf;
-  conf.updateFromToml("tests/config_tests_prov.toml");
+  Config conf("tests/config_tests_prov.toml");
   conf.uptane.primary_ecu_serial = "testecuserial";
   conf.uptane.private_key_path = "private.key";
   conf.uptane.director_server = tls_server + "/director";


### PR DESCRIPTION
Add primary_ecu_hardware_id option instead of device.uuid
Construct default urls if repo,direcor, or ostree urls are empty