### PR TITLE
Push utils.h header into the config.cc

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -5,6 +5,7 @@
 #include <sstream>
 
 #include "logger.h"
+#include "utils.h"
 
 /**
  * \par Description:

--- a/src/config.h
+++ b/src/config.h
@@ -13,7 +13,6 @@
 #ifdef WITH_GENIVI
 #include <dbus/dbus.h>
 #endif
-#include "utils.h"
 
 enum Auth { OAUTH2 = 0, CERTIFICATE };
 


### PR DESCRIPTION
Since config.h is included in lots of places, reducing the number of files it
includes should reduce the number of large rebuilds.