### PR TITLE
Fix ordering of warning and info log levels

### DIFF
--- a/src/logger.h
+++ b/src/logger.h
@@ -42,8 +42,8 @@ typedef enum {
   LVL_trace = 0,
   LVL_minimum = LVL_trace,
   LVL_debug,
-  LVL_warning,
   LVL_info,
+  LVL_warning,
   LVL_error,
   LVL_maximum = LVL_error,
 } LoggerLevels; /**< define own logging levels */


### PR DESCRIPTION
Most people would expect that the 'warning' log level is more serious than the
'info' log level.

Fixes: PRO-3290