### PR TITLE
Add uptane.device_id option

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -119,6 +119,18 @@ void Config::postUpdateValues() {
       Utils::writeFile((device.certificates_directory / ecu_serial_filename).string(), uptane.primary_ecu_serial);
     }
   }
+
+  std::string device_id_filename = "device_id";
+  if (!uptane.device_id.empty()) {
+    Utils::writeFile((device.certificates_directory / device_id_filename).string(), uptane.device_id);
+  } else {
+    if (boost::filesystem::exists(device.certificates_directory / device_id_filename)) {
+      uptane.device_id = Utils::readFile((device.certificates_directory / device_id_filename).string());
+    } else {
+      uptane.device_id = Utils::genPrettyName();
+      Utils::writeFile((device.certificates_directory / device_id_filename).string(), uptane.device_id);
+    }
+  }
 }
 
 void Config::updateFromToml(const std::string& filename) {
@@ -211,6 +223,7 @@ void Config::updateFromPropertyTree(const boost::property_tree::ptree& pt) {
   CopyFromConfig(provision.p12_password, "provision.p12_password", LVL_warning, pt);
 
   CopyFromConfig(uptane.director_server, "uptane.director_server", LVL_warning, pt);
+  CopyFromConfig(uptane.device_id, "uptane.device_id", LVL_warning, pt);
   CopyFromConfig(uptane.primary_ecu_serial, "uptane.primary_ecu_serial", LVL_warning, pt);
   CopyFromConfig(uptane.primary_ecu_hardware_id, "uptane.primary_ecu_hardware_id", LVL_warning, pt);
 

--- a/src/config.h
+++ b/src/config.h
@@ -123,7 +123,8 @@ struct ProvisionConfig {
 
 struct UptaneConfig {
   UptaneConfig()
-      : primary_ecu_serial(""),
+      : device_id(""),
+        primary_ecu_serial(""),
         primary_ecu_hardware_id(""),
         ostree_server(""),
         director_server(""),
@@ -132,6 +133,7 @@ struct UptaneConfig {
         private_key_path("ecukey.pem"),
         public_key_path("ecukey.pub"),
         disable_keyid_validation(false) {}
+  std::string device_id;
   std::string primary_ecu_serial;
   std::string primary_ecu_hardware_id;
   std::string ostree_server;


### PR DESCRIPTION
Using dynamically generated pretty name for registering without storing it anywhere is probably not the right way to do the registration. This PR breaks picking a new name if the old one is busy, but it looks like a lesser evil for now.