### PR TITLE
Use Debian mirrors from Germany

### DIFF
--- a/Dockerfile.deb-stable
+++ b/Dockerfile.deb-stable
@@ -3,12 +3,11 @@ LABEL Description="Aktualizr testing dockerfile"
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update
-RUN apt-get -y install debian-archive-keyring
-RUN echo "deb http://httpredir.debian.org/debian jessie-backports main contrib non-free" > /etc/apt/sources.list.d/jessie-backports.list
 
-RUN apt-get update
-RUN apt-get -y install liblzma-dev bison e2fslibs-dev libgpgme11-dev libglib2.0-dev gcc g++ make cmake git psmisc dbus python-dbus python-gobject-2 libdbus-1-dev libjansson-dev libgtest-dev google-mock libssl-dev autoconf automake pkg-config libtool libexpat1-dev libboost-program-options-dev libboost-test-dev libboost-regex-dev libboost-dev libboost-system-dev libboost-thread-dev libboost-log-dev libjsoncpp-dev curl libcurl4-openssl-dev lcov clang clang-format-3.8
+RUN apt-get update && apt-get -y install debian-archive-keyring
+RUN echo "deb http://ftp.de.debian.org/debian jessie-backports main contrib non-free" > /etc/apt/sources.list.d/jessie-backports.list
+
+RUN apt-get update && apt-get -y install liblzma-dev bison e2fslibs-dev libgpgme11-dev libglib2.0-dev gcc g++ make cmake git psmisc dbus python-dbus python-gobject-2 libdbus-1-dev libjansson-dev libgtest-dev google-mock libssl-dev autoconf automake pkg-config libtool libexpat1-dev libboost-program-options-dev libboost-test-dev libboost-regex-dev libboost-dev libboost-system-dev libboost-thread-dev libboost-log-dev libjsoncpp-dev curl libcurl4-openssl-dev lcov clang clang-format-3.8
 RUN apt-get update && apt-get -y install ostree libostree-dev libsodium-dev python-virtualenv python3-dev
 WORKDIR aktualizr
 ADD . src

--- a/Dockerfile.deb-unstable
+++ b/Dockerfile.deb-unstable
@@ -3,6 +3,8 @@ LABEL Description="Aktualizr testing dockerfile for Debian Unstable"
 
 ENV DEBIAN_FRONTEND noninteractive
 
+RUN echo "deb http://ftp.de.debian.org/debian unstable main" > /etc/apt/sources.list
+
 RUN apt-get update &&  apt-get -y install liblzma-dev bison e2fslibs-dev libgpgme11-dev libglib2.0-dev gcc g++ make cmake git psmisc dbus python-dbus python-gobject-2 libdbus-1-dev libjansson-dev libgtest-dev google-mock libssl-dev autoconf automake pkg-config libtool libexpat1-dev libboost-program-options-dev libboost-test-dev libboost-regex-dev libboost-dev libboost-system-dev libboost-thread-dev libboost-log-dev libjsoncpp-dev curl libcurl4-gnutls-dev lcov clang clang-format-3.8
 RUN apt-get update && apt-get -y install ostree libostree-dev libsodium-dev python-virtualenv python3-dev valgrind
 WORKDIR aktualizr

--- a/src/sotauptaneclient.cc
+++ b/src/sotauptaneclient.cc
@@ -64,7 +64,6 @@ void SotaUptaneClient::reportInstalledPackages() {
                     (config.device.certificates_directory / config.tls.pkey_file).string());
 
   http.put(config.tls.server + "/core/installed", Ostree::getInstalledPackages(config.ostree.packages_file));
-
 }
 
 void SotaUptaneClient::runForever(command::Channel *commands_channel) {


### PR DESCRIPTION
Our CI builds are with Travis, so using an EU mirror should help the build
performance.  At the moment the default Debian mirror is throwing 500 errors
during the CI run.