### PR TITLE
src/main.cc: Improve the seed of srand

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -46,6 +46,7 @@
 #include "utils.h"
 
 #include <sodium.h>
+#include <sys/time.h>
 
 /*****************************************************************************/
 
@@ -118,7 +119,10 @@ bpo::variables_map parse_options(int argc, char *argv[]) {
 
 /*****************************************************************************/
 int main(int argc, char *argv[]) {
-  std::srand(static_cast<unsigned int>(std::time(0)));  // seeds pseudo random generator with cuurent time
+  // seeds pseudo random generator with current time
+  struct timeval current_time;
+  gettimeofday(&current_time , 0);
+  std::srand(static_cast<unsigned int>(current_time.tv_sec * 1000000 + current_time.tv_usec));
 
   // create and initialize the return value to zero (everything is OK)
   int return_value = EXIT_SUCCESS;


### PR DESCRIPTION
A bug that generates the same "random" name of the
device each time on first boot has been detected.
It has been observed on Raspberry Pi 3 and other
devices. The following fix improves the seed of
srand to avoid this bug. For details have a look at:

PRO-3262 Aktualizr supporting Uptane and automatic provisioning

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>