### PR TITLE
Use German Debian mirror to try and avoid 500 error

### DIFF
--- a/Dockerfile.deb-stable
+++ b/Dockerfile.deb-stable
@@ -3,6 +3,10 @@ LABEL Description="Aktualizr testing dockerfile"
 
 ENV DEBIAN_FRONTEND noninteractive
 
+RUN echo "deb http://ftp.de.debian.org/debian stable main" > /etc/apt/sources.list
+RUN echo "deb http://ftp.de.debian.org/debian stable-updates main" >> /etc/apt/sources.list
+RUN echo "deb http://security.debian.org stable/updates main" >> /etc/apt/sources.list
+
 RUN apt-get update && apt-get -y install liblzma-dev bison e2fslibs-dev libgpgme11-dev libglib2.0-dev gcc g++ make cmake git psmisc dbus libdbus-1-dev libjansson-dev libgtest-dev google-mock libssl-dev autoconf automake pkg-config libtool libexpat1-dev libboost-program-options-dev libboost-test-dev libboost-random-dev libboost-regex-dev libboost-dev libboost-system-dev libboost-thread-dev libboost-log-dev libjsoncpp-dev curl libcurl4-openssl-dev lcov
 RUN apt-get update && apt-get -y install ostree libostree-dev libarchive-dev libsodium-dev
 WORKDIR aktualizr


### PR DESCRIPTION
The Travis build is often getting 500 errors from the default Debian mirror
during the docker build.  Switch to using the German debian mirror instead.