### PR TITLE
main.cc: Handle missing configuration file

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -119,10 +119,13 @@ int main(int argc, char *argv[]) {
   }
 
   // Initialize config with default values, the update with config, then with cmd
-  std::string filename = commandline_map["config"].as<std::string>();
-  Config config(filename, commandline_map);
-
-  Aktualizr aktualizr(config);
-
-  return aktualizr.run();
+  try {
+    std::string filename = commandline_map["config"].as<std::string>();
+    Config config(filename, commandline_map);
+    Aktualizr aktualizr(config);
+    return aktualizr.run();
+  } catch(std::runtime_error e) {
+    LOGGER_LOG(LVL_error, "ERROR: " << e.what());
+    exit(EXIT_FAILURE);
+  }
 }


### PR DESCRIPTION
Gracefully terminate the application if the
configuration file is missing or if there is another
runtime unhandled exception.

Although the Aktualizr recipe in Yocto/OE layer
meta-updater deploys sota.toml as a read-only file,
it will be missing if the user forgets to specify
variable SOTA_PACKED_CREDENTIALS. This fix ensures
that in this case Aktualizr will not crash.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>