### PR TITLE
Fetch pre-built Docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,14 @@ dist: trusty
 sudo: false
 language: cpp
 env:
-  - DOCKERFILE=Dockerfile SCRIPT=src/scripts/coverage.sh
-  - DOCKERFILE=Dockerfile SCRIPT=src/scripts/test.sh DARGS="-eBUILD_ONLY=1"
-  - DOCKERFILE=Dockerfile.deb-stable SCRIPT=src/scripts/test.sh DARGS="-eBUILD_ONLY=1"
-  - DOCKERFILE=Dockerfile.deb-unstable SCRIPT=src/scripts/test.sh DARGS="-eBUILD_ONLY=1"
+  - DOCKERFILE=Dockerfile CACHE=latest SCRIPT=src/scripts/coverage.sh
+  - DOCKERFILE=Dockerfile CACHE=latest SCRIPT=src/scripts/test.sh DARGS="-eBUILD_ONLY=1"
+  - DOCKERFILE=Dockerfile.deb-stable CACHE=latest-deb-stable SCRIPT=src/scripts/test.sh DARGS="-eBUILD_ONLY=1"
+  - DOCKERFILE=Dockerfile.deb-unstable CACHE=latest-deb-unstable SCRIPT=src/scripts/test.sh DARGS="-eBUILD_ONLY=1"
 services:
   - docker
 script:
-  - docker build -t advancedtelematic/aktualizr -f ${DOCKERFILE} .
+  - docker pull advancedtelematic/aktualizr:$CACHE
+  - docker build --cache-from advancedtelematic/aktualizr:$CACHE -t advancedtelematic/aktualizr -f ${DOCKERFILE} .
   - ci_env=`bash <(curl -s https://codecov.io/env)`
   - docker run $ci_env --rm $DARGS -it advancedtelematic/aktualizr ${SCRIPT}


### PR DESCRIPTION
These images are build using an internal CI system at ATS, and pushed to
Dockerhub.  They are only used as a cache to speed up the build process, and
the correctness of the build does not depend on them being up-to-date.