### PR TITLE
Only build the master branch in CI by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 dist: trusty
 sudo: false
 language: cpp
+branches:
+  only:
+    - master
 env:
   - DOCKERFILE=Dockerfile CACHE=latest SCRIPT=src/scripts/coverage.sh
   - DOCKERFILE=Dockerfile CACHE=latest SCRIPT=src/scripts/test.sh DARGS="-eBUILD_ONLY=1"


### PR DESCRIPTION
Travis will still build PRs automatically, but we won't have a duplicate build
for both the branch and the PR.