### PR TITLE
Bugfix/pro 3562/ci check format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,8 +56,8 @@ add_custom_target(check-format)
 
 # clang-check and clang-format
 # The .clang-format file requires clang-format-3.8
-find_program(CLANG_FORMAT NAMES clang-format clang-format-3.8)
-find_program(CLANG_CHECK NAMES clang-check clang-check-3.8 clang-check-3.7 clang-check-3.6 clang-check-3.5 clang-check-3.4)
+find_program(CLANG_FORMAT NAMES clang-format-3.8 clang-format)
+find_program(CLANG_CHECK NAMES clang-check-3.8 clang-check)
 
 ############### BUILD RULES
 include_directories(${PROJECT_SOURCE_DIR}/src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
 
 ################ QA RULES
 add_custom_target(qa)
+add_custom_target(check-format)
 
 # clang-check and clang-format
 # The .clang-format file requires clang-format-3.8

--- a/Dockerfile.deb-stable
+++ b/Dockerfile.deb-stable
@@ -7,7 +7,7 @@ RUN echo "deb http://ftp.de.debian.org/debian stable main" > /etc/apt/sources.li
 RUN echo "deb http://ftp.de.debian.org/debian stable-updates main" >> /etc/apt/sources.list
 RUN echo "deb http://security.debian.org stable/updates main" >> /etc/apt/sources.list
 
-RUN apt-get update && apt-get -y install liblzma-dev bison e2fslibs-dev libgpgme11-dev libglib2.0-dev gcc g++ make cmake git psmisc dbus libdbus-1-dev libjansson-dev libgtest-dev google-mock libssl-dev autoconf automake pkg-config libtool libexpat1-dev libboost-program-options-dev libboost-test-dev libboost-random-dev libboost-regex-dev libboost-dev libboost-system-dev libboost-thread-dev libboost-log-dev libjsoncpp-dev curl libcurl4-openssl-dev lcov
+RUN apt-get update && apt-get -y install liblzma-dev bison e2fslibs-dev libgpgme11-dev libglib2.0-dev gcc g++ make cmake git psmisc dbus libdbus-1-dev libjansson-dev libgtest-dev google-mock libssl-dev autoconf automake pkg-config libtool libexpat1-dev libboost-program-options-dev libboost-test-dev libboost-random-dev libboost-regex-dev libboost-dev libboost-system-dev libboost-thread-dev libboost-log-dev libjsoncpp-dev curl libcurl4-openssl-dev lcov clang clang-format-3.8
 RUN apt-get update && apt-get -y install ostree libostree-dev libarchive-dev libsodium-dev
 WORKDIR aktualizr
 ADD . src

--- a/README.md
+++ b/README.md
@@ -60,17 +60,19 @@ The following debian packages are used in the project:
  - curl (>= 7.47)
  - libcurl4-openssl-dev (>= 7.47)
  - cmake (>= 3.5.1)
- - lcov (when building for code coverage)
  - google-mock
  - libostree-dev
  - valgrind
  - libjansson-dev
- - python3-dev (when building tests)
  - libssl-dev
  - libarchive-dev
  - libsodium-dev
  - clang (optional)
  - clang-format (optional)
+ - python3-dev (when building tests)
+ - python-virtualenv (when building tests)
+ - libdbus-1-dev (when building tests)
+ - lcov (when building for code coverage)
 
 ### Building
 

--- a/scripts/check-formatting.sh
+++ b/scripts/check-formatting.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+set -euo pipefail
+
+CLANG_FORMAT=$1
+shift
+FILES=$@
+
+FAIL=0
+diff -u <(cat ${FILES}) <(${CLANG_FORMAT} -style=file ${FILES}) > /dev/null || FAIL=1
+if [ ${FAIL} -eq 1 ]; then
+    echo "${CLANG_FORMAT} found unformatted code! Run 'make qa' before continuing."
+    exit 1
+fi
+

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,6 +3,7 @@ set -e
 mkdir -p build-test
 cd build-test
 cmake -DBUILD_GENIVI=ON -DBUILD_OSTREE=ON -DBUILD_TESTING=ON ../src
+make check-format
 make -j8
 if [ -n "$BUILD_ONLY" ]; then
   echo "Skipping test run because of BUILD_ONLY environment variable"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,6 +84,13 @@ if(BUILD_GENIVI)
 endif(BUILD_GENIVI)
 
 ################ QA RULES
+add_custom_target(check-format-src
+    COMMAND ../scripts/check-formatting.sh ${CLANG_FORMAT} main.cc ${SOURCES} ${HEADERS}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMENT "Checking clang-format on src"
+    VERBATIM)
+add_dependencies(check-format check-format-src)
+
 if(CLANG_FORMAT)
     add_custom_target(format-src
         COMMAND ${CLANG_FORMAT} -i -style=file main.cc ${SOURCES} ${HEADERS}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -219,6 +219,13 @@ set(ALL_TEST_SRCS
     uptane_test.cc
     utils_test.cc)
 
+add_custom_target(check-format-tests
+    COMMAND ../scripts/check-formatting.sh ${CLANG_FORMAT} ${ALL_TEST_SRCS}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMENT "Checking clang-format on tests"
+    VERBATIM)
+add_dependencies(check-format check-format-tests)
+
 if(CLANG_FORMAT)
     add_custom_target(format-tests
         COMMAND ${CLANG_FORMAT} -i -style=file ${ALL_TEST_SRCS}


### PR DESCRIPTION
Solved by running a new make target (check-format) in test.sh, which fails if clang-format produces any output.