### PR TITLE
Improve module isolation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,11 +27,11 @@ find_package(CURL REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(Threads REQUIRED)
 find_package(PkgConfig REQUIRED)
+find_package(LibArchive REQUIRED)
 pkg_search_module(SODIUM libsodium REQUIRED)
 
 if(BUILD_OSTREE)
     find_package(OSTree REQUIRED)
-    find_package(LibArchive REQUIRED)
     add_definitions(-DBUILD_OSTREE)
 endif(BUILD_OSTREE)
 

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -87,9 +87,7 @@ SendUpdateReport SendUpdateReport::fromJson(const std::string& json_str) {
   return SendUpdateReport(data::UpdateReport::fromJson(Json::FastWriter().write(json["fields"][0])));
 }
 
-#ifdef BUILD_OSTREE
-OstreeInstall::OstreeInstall(std::vector<OstreePackage> packages_in) : packages(packages_in) {
-  variant = "OstreeInstall";
+UptaneInstall::UptaneInstall(std::vector<Uptane::Target> packages_in) : packages(packages_in) {
+  variant = "UptaneInstall";
 }
-#endif
 };

--- a/src/commands.h
+++ b/src/commands.h
@@ -8,9 +8,7 @@
 
 #include "channel.h"
 #include "types.h"
-#ifdef BUILD_OSTREE
-#include "ostree.h"
-#endif
+#include "uptane/tuf.h"
 
 namespace command {
 
@@ -61,12 +59,10 @@ class SendUpdateReport : public BaseCommand {
   static SendUpdateReport fromJson(const std::string& json_str);
 };
 
-#ifdef BUILD_OSTREE
-class OstreeInstall : public BaseCommand {
+class UptaneInstall : public BaseCommand {
  public:
-  OstreeInstall(std::vector<OstreePackage>);
-  std::vector<OstreePackage> packages;
+  UptaneInstall(std::vector<Uptane::Target>);
+  std::vector<Uptane::Target> packages;
 };
-#endif
 };
 #endif

--- a/src/config.h
+++ b/src/config.h
@@ -41,18 +41,6 @@ struct DbusConfig {
 struct DbusConfig {};
 #endif
 
-struct DeviceConfig {
-  DeviceConfig()
-      : uuid("123e4567-e89b-12d3-a456-426655440000"),
-        packages_dir("/tmp/"),
-        certificates_directory("/tmp/aktualizr/"),
-        package_manager(PMOFF) {}
-  std::string uuid;
-  boost::filesystem::path packages_dir;
-  boost::filesystem::path certificates_directory;
-  PackageManager package_manager;
-};
-
 struct GatewayConfig {
   GatewayConfig() : http(true), rvi(false), socket(false), dbus(false) {}
   bool http;
@@ -79,7 +67,9 @@ struct RviConfig {
         device_cert("device.crt"),
         ca_cert("ca.pem"),
         cert_dir(""),
-        cred_dir("") {}
+        cred_dir(""),
+        packages_dir("/tmp/"),
+        uuid("123e4567-e89b-12d3-a456-426655440000") {}
   std::string node_host;
   std::string node_port;
   std::string device_key;
@@ -87,10 +77,18 @@ struct RviConfig {
   std::string ca_cert;
   std::string cert_dir;
   std::string cred_dir;
+  boost::filesystem::path packages_dir;
+  std::string uuid;
 };
 
 struct TlsConfig {
-  TlsConfig() : server(""), ca_file("ca.pem"), pkey_file("pkey.pem"), client_certificate("client.pem") {}
+  TlsConfig()
+      : certificates_directory("/tmp/aktualizr"),
+        server(""),
+        ca_file("ca.pem"),
+        pkey_file("pkey.pem"),
+        client_certificate("client.pem") {}
+  boost::filesystem::path certificates_directory;
   std::string server;
   std::string ca_file;
   std::string pkey_file;
@@ -150,13 +148,8 @@ class Config {
 
   void updateFromTomlString(const std::string& contents);
   void postUpdateValues();
-  bool isProvisioned() {
-    return (boost::filesystem::exists(device.certificates_directory / tls.client_certificate) &&
-            boost::filesystem::exists(device.certificates_directory / tls.ca_file));
-  };
 
   // config data structures
-  DeviceConfig device;
   DbusConfig dbus;
   GatewayConfig gateway;
   RviConfig rvi;
@@ -170,6 +163,10 @@ class Config {
   void updateFromPropertyTree(const boost::property_tree::ptree& pt);
   void updateFromToml(const std::string& filename);
   void updateFromCommandLine(const boost::program_options::variables_map& cmd);
+  bool isUnpacked() {
+    return (boost::filesystem::exists(tls.certificates_directory / "autoprov.url") &&
+            boost::filesystem::exists(tls.certificates_directory / "autoprov_credentials.p12"));
+  };
 };
 
 #endif  // CONFIG_H_

--- a/src/events.cc
+++ b/src/events.cc
@@ -64,12 +64,9 @@ UptaneTimestampUpdated::UptaneTimestampUpdated() { variant = "UptaneTimestampUpd
 
 std::string UptaneTimestampUpdated::toJson() { return Json::FastWriter().write(toBaseJson()); }
 
-#ifdef BUILD_OSTREE
-UptaneTargetsUpdated::UptaneTargetsUpdated(std::vector<OstreePackage> packages_in) : packages(packages_in) {
+UptaneTargetsUpdated::UptaneTargetsUpdated(std::vector<Uptane::Target> packages_in) : packages(packages_in) {
   variant = "UptaneTargetsUpdated";
 }
 
 std::string UptaneTargetsUpdated::toJson() { return Json::FastWriter().write(toBaseJson()); }
-
-#endif
 };

--- a/src/events.h
+++ b/src/events.h
@@ -11,6 +11,7 @@
 #ifdef BUILD_OSTREE
 #include "ostree.h"
 #endif
+#include "uptane/tuf.h"
 
 namespace event {
 
@@ -58,15 +59,13 @@ class UptaneTimestampUpdated : public BaseEvent {
   virtual std::string toJson();
 };
 
-#ifdef BUILD_OSTREE
 class UptaneTargetsUpdated : public BaseEvent {
  public:
-  std::vector<OstreePackage> packages;
+  std::vector<Uptane::Target> packages;
   virtual std::string toJson();
 
-  UptaneTargetsUpdated(std::vector<OstreePackage> packages_in);
+  UptaneTargetsUpdated(std::vector<Uptane::Target> packages_in);
 };
-#endif
 };
 
 #endif

--- a/src/eventsinterpreter.cc
+++ b/src/eventsinterpreter.cc
@@ -31,13 +31,10 @@ void EventsInterpreter::run() {
     if (event->variant == "UpdateAvailable") {
       *commands_channel << boost::make_shared<command::StartDownload>(
           static_cast<event::UpdateAvailable*>(event.get())->update_vailable.update_id);
-    }
-#ifdef BUILD_OSTREE
-    else if (event->variant == "UptaneTargetsUpdated") {
-      *commands_channel << boost::make_shared<command::OstreeInstall>(
+    } else if (event->variant == "UptaneTargetsUpdated") {
+      *commands_channel << boost::make_shared<command::UptaneInstall>(
           static_cast<event::UptaneTargetsUpdated*>(event.get())->packages);
     }
-#endif
     if (event->variant == "UptaneTimestampUpdated") {
       // These events indicates the end of pooling cycle
       if (!config.uptane.polling) {

--- a/src/ostree.cc
+++ b/src/ostree.cc
@@ -93,7 +93,7 @@ OstreePackage::OstreePackage(const std::string &ecu_serial_in, const std::string
   if (branch_name.empty() || refhash.empty()) throw std::runtime_error("malformed OSTree target name: " + ref_name);
 }
 
-data::InstallOutcome OstreePackage::install(const data::PackageManagerCredentials &cred, OstreeConfig config) {
+data::InstallOutcome OstreePackage::install(const data::PackageManagerCredentials &cred, OstreeConfig config) const {
   const char remote[] = "aktualizr-remote";
   const char *const refs[] = {branch_name.c_str()};
   const char *const commit_ids[] = {refhash.c_str()};
@@ -216,7 +216,7 @@ OstreePackage OstreePackage::fromJson(const Json::Value &json) {
                        json["pull_uri"].asString());
 }
 
-Json::Value OstreePackage::toEcuVersion(const Json::Value &custom) {
+Json::Value OstreePackage::toEcuVersion(const Json::Value &custom) const {
   Json::Value installed_image;
   installed_image["filepath"] = ref_name;
   installed_image["fileinfo"]["length"] = 0;

--- a/src/ostree.h
+++ b/src/ostree.h
@@ -26,9 +26,9 @@ class OstreePackage {
   std::string refhash;
   std::string description;
   std::string pull_uri;
-  data::InstallOutcome install(const data::PackageManagerCredentials &cred, OstreeConfig config);
+  data::InstallOutcome install(const data::PackageManagerCredentials &cred, OstreeConfig config) const;
 
-  Json::Value toEcuVersion(const Json::Value &custom);
+  Json::Value toEcuVersion(const Json::Value &custom) const;
   static OstreePackage getEcu(const std::string &ecu_serial, const std::string &ostree_sysroot);
   static OstreePackage fromJson(const Json::Value &json);
 };

--- a/src/sotarviclient.cc
+++ b/src/sotarviclient.cc
@@ -55,7 +55,7 @@ SotaRVIClient::SotaRVIClient(const Config &config_in, event::Channel *events_cha
   Json::Value json;
   json["dev"]["key"] = config.rvi.device_key;
   json["dev"]["cert"] = config.rvi.device_cert;
-  json["dev"]["id"] = std::string("genivi.org/device/") + config.device.uuid;
+  json["dev"]["id"] = std::string("genivi.org/device/") + config.rvi.uuid;
   json["ca"]["cert"] = config.rvi.ca_cert;
   json["ca"]["dir"] = config.rvi.cert_dir;
   json["creddir"] = config.rvi.cred_dir;
@@ -138,7 +138,7 @@ void SotaRVIClient::run() {
 
 void SotaRVIClient::startDownload(const data::UpdateRequestId &update_id) {
   Json::Value value;
-  value["device"] = config.device.uuid;
+  value["device"] = config.rvi.uuid;
   value["update_id"] = update_id;
   value["services"] = services;
   Json::Value params(Json::arrayValue);
@@ -151,7 +151,7 @@ void SotaRVIClient::invokeAck(const std::string &update_id) {
   std::vector<int> chunks = chunks_map[update_id];
 
   Json::Value value;
-  value["device"] = config.device.uuid;
+  value["device"] = config.rvi.uuid;
   value["update_id"] = update_id;
   value["chunks"] = Json::arrayValue;
 
@@ -169,7 +169,7 @@ void SotaRVIClient::saveChunk(const Json::Value &chunk_json) {
 
   std::string output = Utils::fromBase64(b64_text);
 
-  std::ofstream update_file((config.device.packages_dir / chunk_json["update_id"].asString()).string().c_str(),
+  std::ofstream update_file((config.rvi.packages_dir / chunk_json["update_id"].asString()).string().c_str(),
                             std::ios::out | std::ios::app | std::ios::binary);
   update_file << output;
   update_file.close();
@@ -182,14 +182,14 @@ void SotaRVIClient::downloadComplete(const Json::Value &parameters) {
   data::DownloadComplete download_complete;
   download_complete.update_id = parameters["update_id"].asString();
   download_complete.signature = parameters["signature"].asString();
-  download_complete.update_image = (config.device.packages_dir / download_complete.update_id).string();
+  download_complete.update_image = (config.rvi.packages_dir / download_complete.update_id).string();
   sendEvent(boost::make_shared<event::DownloadComplete>(download_complete));
 }
 
 void SotaRVIClient::sendUpdateReport(data::UpdateReport update_report) {
   Json::Value params(Json::arrayValue);
   Json::Value report;
-  report["device"] = config.device.uuid;
+  report["device"] = config.rvi.uuid;
   report["update_report"] = update_report.toJson();
   params.append(report);
 

--- a/src/sotauptaneclient.h
+++ b/src/sotauptaneclient.h
@@ -20,14 +20,18 @@ class SotaUptaneClient {
 
   void putManifest(SotaUptaneClient::ServiceType service, const std::string &manifest);
   Json::Value sign(const Json::Value &in_data);
-  void OstreeInstall(std::vector<OstreePackage> packages);
-  std::vector<OstreePackage> getAvailableUpdates();
+  void OstreeInstall(const OstreePackage &package);
   void run(command::Channel *commands_channel);
   void runForever(command::Channel *commands_channel);
 
  private:
   void reportHWInfo();
   void reportInstalledPackages();
+  std::vector<Uptane::Target> getUpdates();
+  bool isInstalled(const Uptane::Target &target);
+  OstreePackage uptaneToOstree(const Uptane::Target &target);
+  std::vector<Uptane::Target> findOstree(const std::vector<Uptane::Target> &targets);
+  std::vector<Uptane::Target> findForEcu(const std::vector<Uptane::Target> &targets, std::string ecu_id);
   Config config;
   event::Channel *events_channel;
   Uptane::Repository uptane_repo;

--- a/src/uptane/tuf.cc
+++ b/src/uptane/tuf.cc
@@ -86,9 +86,8 @@ std::ostream &Uptane::operator<<(std::ostream &os, const Hash &h) {
 Target::Target(const std::string &filename, const Json::Value &content) : filename_(filename), ecu_identifier_("") {
   if (content.isMember("custom")) {
     Json::Value custom = content["custom"];
-    if (custom.isMember("ecuIdentifier")) {
-      ecu_identifier_ = content["custom"]["ecuIdentifier"].asString();
-    }
+    if (custom.isMember("ecuIdentifier")) ecu_identifier_ = custom["ecuIdentifier"].asString();
+    if (custom.isMember("targetFormat")) type_ = custom["targetFormat"].asString();
   }
 
   length_ = content["length"].asInt64();

--- a/src/uptane/tuf.h
+++ b/src/uptane/tuf.h
@@ -110,6 +110,7 @@ class Target {
 
   std::string ecu_identifier() const { return ecu_identifier_; }
   std::string filename() const { return filename_; }
+  std::string format() const { return type_; }
 
   bool MatchWith(const Hash &hash) const;
 
@@ -134,6 +135,7 @@ class Target {
 
  private:
   std::string filename_;
+  std::string type_;
   std::string ecu_identifier_;
   std::vector<Hash> hashes_;
   int64_t length_;

--- a/src/uptane/tufrepository.cc
+++ b/src/uptane/tufrepository.cc
@@ -133,7 +133,7 @@ void TufRepository::saveTarget(const Target& target) {
   }
 }
 
-std::vector<Target> TufRepository::fetchTargets() {
+std::pair<uint32_t, std::vector<Target>> TufRepository::fetchTargets() {
   targets_.clear();  // TODO, this is used to signal 'no new updates'
   Json::Value targets_json = fetchAndCheckRole(Role::Targets());
   Json::Value target_list = targets_json["targets"];
@@ -141,6 +141,6 @@ std::vector<Target> TufRepository::fetchTargets() {
     Target t(t_it.key().asString(), *t_it);
     targets_.push_back(t);
   }
-  return targets_;
+  return std::pair<uint32_t, std::vector<Target>>(targets_json["version"].asInt(), targets_);
 }
 };

--- a/src/uptane/tufrepository.cc
+++ b/src/uptane/tufrepository.cc
@@ -37,9 +37,9 @@ TufRepository::TufRepository(const std::string& name, const std::string& base_ur
       base_url_(base_url) {
   boost::filesystem::create_directories(path_);
   boost::filesystem::create_directories(path_ / "targets");
-  http_.authenticate((config_.device.certificates_directory / config_.tls.client_certificate).string(),
-                     (config_.device.certificates_directory / config_.tls.ca_file).string(),
-                     (config_.device.certificates_directory / config_.tls.pkey_file).string());
+  http_.authenticate((config_.tls.certificates_directory / config_.tls.client_certificate).string(),
+                     (config_.tls.certificates_directory / config_.tls.ca_file).string(),
+                     (config_.tls.certificates_directory / config_.tls.pkey_file).string());
   LOGGER_LOG(LVL_debug, "TufRepository looking for root.json in:" << path_);
   if (boost::filesystem::exists(path_ / "root.json")) {
     // Bootstrap root.json (security assumption: the filesystem contents are not modified)
@@ -133,7 +133,7 @@ void TufRepository::saveTarget(const Target& target) {
   }
 }
 
-std::pair<uint32_t, std::vector<Target>> TufRepository::fetchTargets() {
+std::pair<uint32_t, std::vector<Target> > TufRepository::fetchTargets() {
   targets_.clear();  // TODO, this is used to signal 'no new updates'
   Json::Value targets_json = fetchAndCheckRole(Role::Targets());
   Json::Value target_list = targets_json["targets"];
@@ -141,6 +141,6 @@ std::pair<uint32_t, std::vector<Target>> TufRepository::fetchTargets() {
     Target t(t_it.key().asString(), *t_it);
     targets_.push_back(t);
   }
-  return std::pair<uint32_t, std::vector<Target>>(targets_json["version"].asInt(), targets_);
+  return std::pair<uint32_t, std::vector<Target> >(targets_json["version"].asInt(), targets_);
 }
 };

--- a/src/uptane/tufrepository.h
+++ b/src/uptane/tufrepository.h
@@ -5,6 +5,7 @@
 
 #include <map>
 #include <string>
+#include <utility>
 
 #include <json/json.h>
 #include "config.h"
@@ -36,7 +37,7 @@ class TufRepository {
   Json::Value getJSON(const std::string &role);
   Json::Value fetchAndCheckRole(Role role, Version fetch_version = Version());
   std::vector<Target> getTargets() { return targets_; }
-  std::vector<Target> fetchTargets();
+  std::pair<uint32_t, std::vector<Target>> fetchTargets();
   void saveTarget(const Target &target);
   std::string downloadTarget(Target target);
 

--- a/src/uptane/tufrepository.h
+++ b/src/uptane/tufrepository.h
@@ -37,7 +37,7 @@ class TufRepository {
   Json::Value getJSON(const std::string &role);
   Json::Value fetchAndCheckRole(Role role, Version fetch_version = Version());
   std::vector<Target> getTargets() { return targets_; }
-  std::pair<uint32_t, std::vector<Target>> fetchTargets();
+  std::pair<uint32_t, std::vector<Target> > fetchTargets();
   void saveTarget(const Target &target);
   std::string downloadTarget(Target target);
 

--- a/src/uptane/uptanerepository.cc
+++ b/src/uptane/uptanerepository.cc
@@ -62,10 +62,10 @@ void Repository::refresh() {
   image.fetchAndCheckRole(Role::Timestamp());
 }
 
-std::pair<uint32_t, std::vector<Uptane::Target>> Repository::getTargets() {
+std::pair<uint32_t, std::vector<Uptane::Target> > Repository::getTargets() {
   refresh();
 
-  std::pair<uint32_t, std::vector<Uptane::Target>> director_targets_pair = director.fetchTargets();
+  std::pair<uint32_t, std::vector<Uptane::Target> > director_targets_pair = director.fetchTargets();
   std::vector<Uptane::Target> director_targets = director_targets_pair.second;
   uint32_t version = director_targets_pair.first;
   std::vector<Uptane::Target> image_targets = image.fetchTargets().second;
@@ -89,14 +89,14 @@ std::pair<uint32_t, std::vector<Uptane::Target>> Repository::getTargets() {
     }
     transport.sendTargets(secondary_targets);
   }
-  return std::pair<uint32_t, std::vector<Uptane::Target>>(version, primary_targets);
+  return std::pair<uint32_t, std::vector<Uptane::Target> >(version, primary_targets);
 }
 
 bool Repository::deviceRegister() {
-  bool pkey_exists = boost::filesystem::exists(config.device.certificates_directory / config.tls.pkey_file);
+  bool pkey_exists = boost::filesystem::exists(config.tls.certificates_directory / config.tls.pkey_file);
   bool certificate_exists =
-      boost::filesystem::exists(config.device.certificates_directory / config.tls.client_certificate);
-  bool ca_exists = boost::filesystem::exists(config.device.certificates_directory / config.tls.ca_file);
+      boost::filesystem::exists(config.tls.certificates_directory / config.tls.client_certificate);
+  bool ca_exists = boost::filesystem::exists(config.tls.certificates_directory / config.tls.ca_file);
 
   if (pkey_exists && certificate_exists && ca_exists) {
     LOGGER_LOG(LVL_trace, "Device already registered, proceeding");
@@ -108,12 +108,12 @@ bool Repository::deviceRegister() {
     return false;
   }
 
-  std::string bootstrap_pkey_pem = (config.device.certificates_directory / "bootstrap_pkey.pem").string();
-  std::string bootstrap_cert_pem = (config.device.certificates_directory / "bootstrap_cert.pem").string();
-  std::string bootstrap_ca_pem = (config.device.certificates_directory / "bootstrap_ca.pem").string();
-  FILE *reg_p12 = fopen((config.device.certificates_directory / config.provision.p12_path).c_str(), "rb");
+  std::string bootstrap_pkey_pem = (config.tls.certificates_directory / "bootstrap_pkey.pem").string();
+  std::string bootstrap_cert_pem = (config.tls.certificates_directory / "bootstrap_cert.pem").string();
+  std::string bootstrap_ca_pem = (config.tls.certificates_directory / "bootstrap_ca.pem").string();
+  FILE *reg_p12 = fopen((config.tls.certificates_directory / config.provision.p12_path).c_str(), "rb");
   if (!reg_p12) {
-    LOGGER_LOG(LVL_error, "Could not open " << config.device.certificates_directory / config.provision.p12_path);
+    LOGGER_LOG(LVL_error, "Could not open " << config.tls.certificates_directory / config.provision.p12_path);
     return false;
   }
 
@@ -136,9 +136,9 @@ bool Repository::deviceRegister() {
   }
 
   FILE *device_p12 = fmemopen(const_cast<char *>(response.body.c_str()), response.body.size(), "rb");
-  if (!Crypto::parseP12(device_p12, "", (config.device.certificates_directory / config.tls.pkey_file).string(),
-                        (config.device.certificates_directory / config.tls.client_certificate).string(),
-                        (config.device.certificates_directory / config.tls.ca_file).string())) {
+  if (!Crypto::parseP12(device_p12, "", (config.tls.certificates_directory / config.tls.pkey_file).string(),
+                        (config.tls.certificates_directory / config.tls.client_certificate).string(),
+                        (config.tls.certificates_directory / config.tls.ca_file).string())) {
     return false;
   }
   fclose(device_p12);
@@ -148,9 +148,9 @@ bool Repository::deviceRegister() {
 }
 
 bool Repository::authenticate() {
-  return http.authenticate((config.device.certificates_directory / config.tls.client_certificate).string(),
-                           (config.device.certificates_directory / config.tls.ca_file).string(),
-                           (config.device.certificates_directory / config.tls.pkey_file).string());
+  return http.authenticate((config.tls.certificates_directory / config.tls.client_certificate).string(),
+                           (config.tls.certificates_directory / config.tls.ca_file).string(),
+                           (config.tls.certificates_directory / config.tls.pkey_file).string());
 }
 
 bool Repository::ecuRegister() {
@@ -172,8 +172,8 @@ bool Repository::ecuRegister() {
   all_ecus["ecus"].append(primary_ecu);
   std::vector<SecondaryConfig>::iterator it;
   for (it = registered_secondaries.begin(); it != registered_secondaries.end(); ++it) {
-    std::string pub_path = (config.device.certificates_directory / (it->ecu_serial + ".pub")).string();
-    std::string priv_path = (config.device.certificates_directory / (it->ecu_serial + ".priv")).string();
+    std::string pub_path = (config.tls.certificates_directory / (it->ecu_serial + ".pub")).string();
+    std::string priv_path = (config.tls.certificates_directory / (it->ecu_serial + ".priv")).string();
     Crypto::generateRSAKeyPairIfMissing(pub_path, priv_path);
     transport.sendPrivateKey(it->ecu_serial, Utils::readFile(priv_path));
     Json::Value ecu;

--- a/src/uptane/uptanerepository.h
+++ b/src/uptane/uptanerepository.h
@@ -15,13 +15,12 @@ namespace Uptane {
 class Repository {
  public:
   Repository(const Config &config);
-  void updateRoot(Version version = Version());
   void putManifest();
   void putManifest(const Json::Value &);
   void addSecondary(const std::string &ecu_serial, const std::string &hardware_identifier);
 
-  void refresh();
-  std::vector<Uptane::Target> getNewTargets();
+  // pair of (Version, targets[])
+  std::pair<uint32_t, std::vector<Uptane::Target>> getTargets();
   bool deviceRegister();
   bool ecuRegister();
   bool authenticate();
@@ -41,6 +40,8 @@ class Repository {
   std::vector<Secondary> secondaries;
   TestBusPrimary transport;
   friend class TestBusSecondary;
+  void updateRoot(Version version = Version());
+  void refresh();
 };
 };
 

--- a/src/uptane/uptanerepository.h
+++ b/src/uptane/uptanerepository.h
@@ -20,10 +20,11 @@ class Repository {
   void addSecondary(const std::string &ecu_serial, const std::string &hardware_identifier);
 
   // pair of (Version, targets[])
-  std::pair<uint32_t, std::vector<Uptane::Target>> getTargets();
+  std::pair<uint32_t, std::vector<Uptane::Target> > getTargets();
   bool deviceRegister();
   bool ecuRegister();
   bool authenticate();
+  void updateRoot(Version version = Version());
 
  private:
   struct SecondaryConfig {
@@ -40,7 +41,6 @@ class Repository {
   std::vector<Secondary> secondaries;
   TestBusPrimary transport;
   friend class TestBusSecondary;
-  void updateRoot(Version version = Version());
   void refresh();
 };
 };

--- a/tests/config_test.cc
+++ b/tests/config_test.cc
@@ -16,8 +16,8 @@ TEST(config, config_initialized_values) {
   EXPECT_EQ(conf.uptane.polling, true);
   EXPECT_EQ(conf.uptane.polling_sec, 10u);
 
-  EXPECT_EQ(conf.device.uuid, "123e4567-e89b-12d3-a456-426655440000");
-  EXPECT_EQ(conf.device.packages_dir, "/tmp/");
+  EXPECT_EQ(conf.rvi.uuid, "123e4567-e89b-12d3-a456-426655440000");
+  EXPECT_EQ(conf.rvi.packages_dir, "/tmp/");
 
   EXPECT_EQ(conf.gateway.http, true);
   EXPECT_EQ(conf.gateway.rvi, false);
@@ -26,8 +26,8 @@ TEST(config, config_initialized_values) {
 TEST(config, config_toml_parsing) {
   Config conf("tests/config_tests.toml");
 
-  EXPECT_EQ(conf.device.uuid, "bc50fa11-eb93-41c0-b0fa-5ce56affa63e");
-  EXPECT_EQ(conf.device.packages_dir, "/tmp/packages_dir");
+  EXPECT_EQ(conf.rvi.uuid, "bc50fa11-eb93-41c0-b0fa-5ce56affa63e");
+  EXPECT_EQ(conf.rvi.packages_dir, "/tmp/packages_dir");
 
   EXPECT_EQ(conf.gateway.dbus, true);
   EXPECT_EQ(conf.gateway.http, false);
@@ -79,8 +79,8 @@ TEST(config, config_toml_parsing_empty_file) {
   EXPECT_EQ(conf.uptane.polling, true);
   EXPECT_EQ(conf.uptane.polling_sec, 10u);
 
-  EXPECT_EQ(conf.device.uuid, "123e4567-e89b-12d3-a456-426655440000");
-  EXPECT_EQ(conf.device.packages_dir, "/tmp/");
+  EXPECT_EQ(conf.rvi.uuid, "123e4567-e89b-12d3-a456-426655440000");
+  EXPECT_EQ(conf.rvi.packages_dir, "/tmp/");
 
   EXPECT_EQ(conf.gateway.http, true);
   EXPECT_EQ(conf.gateway.rvi, false);
@@ -104,28 +104,15 @@ TEST(config, config_cmdl_parsing) {
   EXPECT_EQ(conf.gateway.socket, true);
 }
 
-TEST(config, config_is_provisioned) {
-  Config conf;
-  conf.device.certificates_directory = "tests/test_data";
-  conf.tls.client_certificate = "cred.p12";
-  conf.tls.ca_file = "cred.p12";
-  EXPECT_TRUE(conf.isProvisioned());
-  conf.tls.ca_file = "nonexistent";
-  EXPECT_FALSE(conf.isProvisioned());
-  conf.tls.client_certificate = "nonexistent";
-  conf.tls.ca_file = "cred.p12";
-  EXPECT_FALSE(conf.isProvisioned());
-}
-
 TEST(config, config_extract_credentials) {
   system("rm -rf tests/test_data/prov");
   Config conf;
-  conf.device.certificates_directory = "tests/test_data/prov";
+  conf.tls.certificates_directory = "tests/test_data/prov";
   conf.provision.provision_path = "tests/test_data/credentials.zip";
   conf.postUpdateValues();
   EXPECT_EQ(conf.tls.server, "9c8e58a5-3777-40db-99ad-8e1dae1622fe.tcpgw.prod01.advancedtelematic.com");
   EXPECT_EQ(boost::algorithm::hex(Crypto::sha256digest(
-                Utils::readFile((conf.device.certificates_directory / conf.provision.p12_path).string()))),
+                Utils::readFile((conf.tls.certificates_directory / conf.provision.p12_path).string()))),
             "31DC21BEF3EC17A41438E6183820556790A738A88E8A08FCB59BE6D54064807E");
 }
 

--- a/tests/config_tests.toml
+++ b/tests/config_tests.toml
@@ -1,10 +1,5 @@
-[device]
-uuid = "bc50fa11-eb93-41c0-b0fa-5ce56affa63e"
-vin = "64285c3c-ca04-4d58-b8d7-f0e002483647"
-packages_dir = "/tmp/packages_dir"
-package_manager = "off"
+[tls]
 certificates_directory = "/tmp/aktualizr"
-system_info = "system_info.sh"
 
 [gateway]
 dbus = true
@@ -21,6 +16,8 @@ socket_events = "DownloadComplete, DownloadFailed, NoUpdateRequests"
 websocket_server = "127.0.0.1:3012"
 
 [rvi]
+uuid = "bc50fa11-eb93-41c0-b0fa-5ce56affa63e"
+packages_dir = "/tmp/packages_dir"
 node_host = "rvi.example.com"
 node_port = 9999
 client_config = "my/rvi_conf.json"

--- a/tests/config_tests_prov.toml
+++ b/tests/config_tests_prov.toml
@@ -1,11 +1,3 @@
-[device]
-uuid = "bc50fa11-eb93-41c0-b0fa-5ce56affa63e"
-vin = "64285c3c-ca04-4d58-b8d7-f0e002483647"
-packages_dir = "/tmp/packages_dir"
-package_manager = "off"
-certificates_directory = "tests/certs/"
-system_info = "system_info.sh"
-
 [gateway]
 dbus = true
 http = false
@@ -21,15 +13,18 @@ socket_events_path = "/tmp/sota-events.socket"
 socket_events = "DownloadComplete, DownloadFailed, NoUpdateRequests"
 
 [rvi]
+uuid = "bc50fa11-eb93-41c0-b0fa-5ce56affa63e"
 node_host = "rvi.example.com"
 node_port = 9999
 client_config = "my/rvi_conf.json"
+packages_dir = "/tmp/packages_dir"
 
 [provision]
 p12_path = "cred.p12"
 p12_password = ""
 
 [tls]
+certificates_directory = "tests/certs/"
 server = "https://7d0a4914-c392-4ccd-a8f9-3d4ed969da07.tcpgw.prod01.advancedtelematic.com:8000"
 ca_file = "ca.pem"
 client_certificate = "client.pem"

--- a/tests/config_tests_prov_bad.toml
+++ b/tests/config_tests_prov_bad.toml
@@ -1,21 +1,3 @@
-[auth]
-server = "https://example.com/auth"
-client_id = "thisisaclientid"
-client_secret = "thisisaclientsecret"
-
-[core]
-server = "https://example.com/core"
-polling = false
-polling_sec = 91
-
-[device]
-uuid = "bc50fa11-eb93-41c0-b0fa-5ce56affa63e"
-vin = "64285c3c-ca04-4d58-b8d7-f0e002483647"
-packages_dir = "/tmp/packages_dir"
-package_manager = "off"
-certificates_directory = "/tmp/aktualizr"
-system_info = "system_info.sh"
-
 [gateway]
 dbus = true
 http = false
@@ -31,6 +13,8 @@ socket_events_path = "/tmp/sota-events.socket"
 socket_events = "DownloadComplete, DownloadFailed, NoUpdateRequests"
 
 [rvi]
+packages_dir = "/tmp/packages_dir"
+uuid = "bc50fa11-eb93-41c0-b0fa-5ce56affa63e"
 node_host = "rvi.example.com"
 node_port = 9999
 client_config = "my/rvi_conf.json"
@@ -40,12 +24,12 @@ p12_path = "config/cred.p12"
 p12_password = ""
 
 [tls]
+certificates_directory = "/tmp/aktualizr"
 server = "https://7d0a4914-c392-4ccd-a8f9-3d4ed969da07.tcpgw.prod01.advancedtelematic.com:8000"
 ca_file = "ca.pem"
 client_certificate = "client.pem"
 
 [uptane]
-#primary_ecu_serial = "$SOTA_DEVICE_ID"
 metadata_path = "/tmp/aktualizr/metadata"
 private_key_path = "ecukey.pem"
 public_key_path = "ecukey.pub"

--- a/tests/events_test.cc
+++ b/tests/events_test.cc
@@ -79,8 +79,13 @@ TEST(event, UptaneTimestampUpdated_event_to_json) {
 #ifdef BUILD_OSTREE
 
 TEST(event, UptaneTargetsUpdated_event_to_json) {
-  OstreePackage package("test1", "test2", "test3", "test4");
-  std::vector<OstreePackage> packages;
+  Json::Value target_json;
+  target_json["ecu_serial"] = "test1";
+  target_json["ref_name"] = "test2";
+  target_json["description"] = "test3";
+  target_json["pull_uri"] = "test4";
+  Uptane::Target package("test_package", target_json);
+  std::vector<Uptane::Target> packages;
   packages.push_back(package);
 
   event::UptaneTargetsUpdated event(packages);

--- a/tests/missing_ostree_repo.toml
+++ b/tests/missing_ostree_repo.toml
@@ -1,4 +1,4 @@
-[device]
+[tls]
 certificates_directory = "sota-prov"
 
 [ostree]

--- a/tests/rvisotaclient_test.cc
+++ b/tests/rvisotaclient_test.cc
@@ -139,12 +139,12 @@ TEST(SaveTest, file_saved) {
   } catch (std::string result) {
     EXPECT_EQ(result, "ack called");
   }
-  std::ifstream saved_file((conf.device.packages_dir / "test_update_id").string().c_str());
+  std::ifstream saved_file((conf.rvi.packages_dir / "test_update_id").string().c_str());
   std::string content;
   saved_file >> content;
   std::cout << content;
   saved_file.close();
-  remove((conf.device.packages_dir / "test_update_id").string().c_str());
+  remove((conf.rvi.packages_dir / "test_update_id").string().c_str());
   EXPECT_EQ(content, "testmessage");
 }
 

--- a/tests/uptane_test.cc
+++ b/tests/uptane_test.cc
@@ -138,7 +138,6 @@ TEST(uptane, get_json) {
   config.uptane.metadata_path = "tests/test_data/";
   config.uptane.director_server = tls_server + "/director";
   config.uptane.repo_server = tls_server + "/repo";
-  config.device.uuid = "device_id";
 
   config.uptane.metadata_path = "tests/test_data/";
   Uptane::TufRepository repo("director", tls_server + "/director", config);
@@ -160,7 +159,6 @@ TEST(uptane, verify) {
   config.uptane.metadata_path = "tests/test_data/";
   config.uptane.director_server = tls_server + "/director";
   config.uptane.repo_server = tls_server + "/repo";
-  config.device.uuid = "device_id";
 
   Uptane::TufRepository repo("director", tls_server + "/director", config);
   repo.updateRoot(Uptane::Version());
@@ -173,7 +171,6 @@ TEST(uptane, verify_data_bad) {
   config.uptane.metadata_path = "tests/test_data/";
   config.uptane.director_server = tls_server + "/director";
   config.uptane.repo_server = tls_server + "/repo";
-  config.device.uuid = "device_id";
 
   Uptane::TufRepository repo("director", tls_server + "/director", config);
   Json::Value data_json = repo.getJSON("root");
@@ -191,7 +188,6 @@ TEST(uptane, verify_data_unknow_type) {
   config.uptane.metadata_path = "tests/test_data/";
   config.uptane.director_server = tls_server + "/director";
   config.uptane.repo_server = tls_server + "/repo";
-  config.device.uuid = "device_id";
 
   Uptane::TufRepository repo("director", tls_server + "/director", config);
   Json::Value data_json = repo.getJSON("root");
@@ -210,7 +206,6 @@ TEST(uptane, verify_data_bed_keyid) {
   config.uptane.metadata_path = "tests/test_data/";
   config.uptane.director_server = tls_server + "/director";
   config.uptane.repo_server = tls_server + "/repo";
-  config.device.uuid = "device_id";
 
   Uptane::TufRepository repo("director", tls_server + "/director", config);
   Json::Value data_json = repo.getJSON("root");
@@ -228,7 +223,6 @@ TEST(uptane, verify_data_bed_threshold) {
   config.uptane.metadata_path = "tests/test_data/";
   config.uptane.director_server = tls_server + "/director";
   config.uptane.repo_server = tls_server + "/repo";
-  config.device.uuid = "device_id";
 
   Uptane::TufRepository repo("director", tls_server + "/director", config);
   Json::Value data_json = repo.getJSON("root");
@@ -244,9 +238,8 @@ TEST(uptane, sign) {
   Config config;
   config.uptane.metadata_path = "tests/test_data/";
   config.uptane.director_server = tls_server + "/director";
-  config.device.certificates_directory = "tests/test_data/";
+  config.tls.certificates_directory = "tests/test_data/";
   config.uptane.repo_server = tls_server + "/repo";
-  config.device.uuid = "device_id";
   config.uptane.private_key_path = "priv.key";
   config.uptane.public_key_path = "public.key";
 
@@ -257,8 +250,8 @@ TEST(uptane, sign) {
 
   std::cout << "privatekey full path: " << config.uptane.private_key_path << "\n";
   Json::Value signed_json =
-      Crypto::signTuf((config.device.certificates_directory / config.uptane.private_key_path).string(),
-                      (config.device.certificates_directory / config.uptane.public_key_path).string(), tosign_json);
+      Crypto::signTuf((config.tls.certificates_directory / config.uptane.private_key_path).string(),
+                      (config.tls.certificates_directory / config.uptane.public_key_path).string(), tosign_json);
   EXPECT_EQ(signed_json["signed"]["mykey"].asString(), "value");
   EXPECT_EQ(signed_json["signatures"][0]["keyid"].asString(),
             "6a809c62b4f6c2ae11abfb260a6a9a57d205fc2887ab9c83bd6be0790293e187");
@@ -268,29 +261,29 @@ TEST(uptane, sign) {
 TEST(SotaUptaneClientTest, device_registered) {
   Config conf("tests/config_tests_prov.toml");
 
-  boost::filesystem::remove(conf.device.certificates_directory / conf.tls.client_certificate);
-  boost::filesystem::remove(conf.device.certificates_directory / conf.tls.ca_file);
-  boost::filesystem::remove(conf.device.certificates_directory / conf.tls.pkey_file);
-  boost::filesystem::remove(conf.device.certificates_directory / "bootstrap_ca.pem");
-  boost::filesystem::remove(conf.device.certificates_directory / "bootstrap_cert.pem");
-  boost::filesystem::remove(conf.device.certificates_directory / "bootstrap_pkey.pem");
+  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.client_certificate);
+  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.ca_file);
+  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.pkey_file);
+  boost::filesystem::remove(conf.tls.certificates_directory / "bootstrap_ca.pem");
+  boost::filesystem::remove(conf.tls.certificates_directory / "bootstrap_cert.pem");
+  boost::filesystem::remove(conf.tls.certificates_directory / "bootstrap_pkey.pem");
 
   Uptane::Repository uptane(conf);
 
   bool result = uptane.deviceRegister();
   EXPECT_EQ(result, true);
-  EXPECT_EQ(boost::filesystem::exists(conf.device.certificates_directory / conf.tls.client_certificate), true);
-  EXPECT_EQ(boost::filesystem::exists(conf.device.certificates_directory / conf.tls.ca_file), true);
-  EXPECT_EQ(boost::filesystem::exists(conf.device.certificates_directory / conf.tls.pkey_file), true);
+  EXPECT_EQ(boost::filesystem::exists(conf.tls.certificates_directory / conf.tls.client_certificate), true);
+  EXPECT_EQ(boost::filesystem::exists(conf.tls.certificates_directory / conf.tls.ca_file), true);
+  EXPECT_EQ(boost::filesystem::exists(conf.tls.certificates_directory / conf.tls.pkey_file), true);
 }
 
 TEST(SotaUptaneClientTest, device_registered_fail) {
   Config conf("tests/config_tests_prov.toml");
 
-  boost::filesystem::remove(conf.device.certificates_directory / conf.tls.client_certificate);
-  boost::filesystem::remove(conf.device.certificates_directory / conf.tls.ca_file);
-  boost::filesystem::remove(conf.device.certificates_directory / "bootstrap_ca.pem");
-  boost::filesystem::remove(conf.device.certificates_directory / "bootstrap_cert.pem");
+  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.client_certificate);
+  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.ca_file);
+  boost::filesystem::remove(conf.tls.certificates_directory / "bootstrap_ca.pem");
+  boost::filesystem::remove(conf.tls.certificates_directory / "bootstrap_cert.pem");
   conf.provision.p12_path = "nonexistent";
 
   Uptane::Repository uptane(conf);
@@ -303,9 +296,8 @@ TEST(SotaUptaneClientTest, device_registered_putmanifest) {
   Config config;
   config.uptane.metadata_path = "tests/test_data/";
   config.uptane.repo_server = tls_server + "/director";
-  config.device.certificates_directory = "tests/test_data/";
+  config.tls.certificates_directory = "tests/test_data/";
   config.uptane.repo_server = tls_server + "/repo";
-  config.device.uuid = "device_id";
   config.uptane.primary_ecu_serial = "testecuserial";
   config.uptane.private_key_path = "private.key";
 
@@ -339,9 +331,8 @@ TEST(SotaUptaneClientTest, device_ecu_register) {
   Config config;
   config.uptane.metadata_path = "tests/";
   config.uptane.repo_server = tls_server + "/director";
-  config.device.certificates_directory = "tests/test_data/";
+  config.tls.certificates_directory = "tests/test_data/";
   config.uptane.repo_server = tls_server + "/repo";
-  config.device.uuid = "device_id";
   config.tls.server = tls_server;
 
   config.uptane.primary_ecu_serial = "testecuserial";
@@ -358,18 +349,17 @@ TEST(SotaUptaneClientTest, RunForeverNoUpdates) {
   Config conf("tests/config_tests_prov.toml");
   conf.uptane.metadata_path = "tests/test_data";
   conf.uptane.director_server = tls_server + "/director";
-  conf.device.certificates_directory = "tests/test_data/";
+  conf.tls.certificates_directory = "tests/test_data/";
   conf.uptane.repo_server = tls_server + "/repo";
-  conf.device.uuid = "device_id";
   conf.uptane.primary_ecu_serial = "CA:FE:A6:D2:84:9D";
   conf.uptane.private_key_path = "private.key";
 
-  boost::filesystem::remove(conf.device.certificates_directory / conf.tls.client_certificate);
-  boost::filesystem::remove(conf.device.certificates_directory / conf.tls.ca_file);
-  boost::filesystem::remove(conf.device.certificates_directory / conf.tls.pkey_file);
-  boost::filesystem::remove(conf.device.certificates_directory / "bootstrap_ca.pem");
-  boost::filesystem::remove(conf.device.certificates_directory / "bootstrap_cert.pem");
-  boost::filesystem::remove(conf.device.certificates_directory / "bootstrap_pkey.pem");
+  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.client_certificate);
+  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.ca_file);
+  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.pkey_file);
+  boost::filesystem::remove(conf.tls.certificates_directory / "bootstrap_ca.pem");
+  boost::filesystem::remove(conf.tls.certificates_directory / "bootstrap_cert.pem");
+  boost::filesystem::remove(conf.tls.certificates_directory / "bootstrap_pkey.pem");
   boost::filesystem::remove(metadata_path + "director/timestamp.json");
   boost::filesystem::remove(metadata_path + "repo/timestamp.json");
 
@@ -399,9 +389,8 @@ TEST(SotaUptaneClientTest, RunForeverHasUpdates) {
   Config conf("tests/config_tests_prov.toml");
   conf.uptane.metadata_path = "tests/test_data";
   conf.uptane.director_server = tls_server + "/director";
-  conf.device.certificates_directory = "tests/test_data/";
+  conf.tls.certificates_directory = "tests/test_data/";
   conf.uptane.repo_server = tls_server + "/repo";
-  conf.device.uuid = "device_id";
   conf.uptane.primary_ecu_serial = "CA:FE:A6:D2:84:9D";
   conf.uptane.private_key_path = "private.key";
 
@@ -414,12 +403,12 @@ TEST(SotaUptaneClientTest, RunForeverHasUpdates) {
   ecu_config.firmware_path = "tests/test_data/firmware.txt";
   conf.uptane.secondaries.push_back(ecu_config);
 
-  boost::filesystem::remove(conf.device.certificates_directory / conf.tls.client_certificate);
-  boost::filesystem::remove(conf.device.certificates_directory / conf.tls.ca_file);
-  boost::filesystem::remove(conf.device.certificates_directory / conf.tls.pkey_file);
-  boost::filesystem::remove(conf.device.certificates_directory / "bootstrap_ca.pem");
-  boost::filesystem::remove(conf.device.certificates_directory / "bootstrap_cert.pem");
-  boost::filesystem::remove(conf.device.certificates_directory / "bootstrap_pkey.pem");
+  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.client_certificate);
+  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.ca_file);
+  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.pkey_file);
+  boost::filesystem::remove(conf.tls.certificates_directory / "bootstrap_ca.pem");
+  boost::filesystem::remove(conf.tls.certificates_directory / "bootstrap_cert.pem");
+  boost::filesystem::remove(conf.tls.certificates_directory / "bootstrap_pkey.pem");
   boost::filesystem::remove(metadata_path + "director/timestamp.json");
   boost::filesystem::remove(metadata_path + "repo/timestamp.json");
 
@@ -449,15 +438,15 @@ TEST(SotaUptaneClientTest, RunForeverInstall) {
   conf.uptane.primary_ecu_serial = "testecuserial";
   conf.uptane.private_key_path = "private.key";
   conf.uptane.director_server = tls_server + "/director";
-  conf.device.certificates_directory = "tests/test_data/";
+  conf.tls.certificates_directory = "tests/test_data/";
   conf.uptane.repo_server = tls_server + "/repo";
 
-  boost::filesystem::remove(conf.device.certificates_directory / conf.tls.client_certificate);
-  boost::filesystem::remove(conf.device.certificates_directory / conf.tls.ca_file);
-  boost::filesystem::remove(conf.device.certificates_directory / conf.tls.pkey_file);
-  boost::filesystem::remove(conf.device.certificates_directory / "bootstrap_ca.pem");
-  boost::filesystem::remove(conf.device.certificates_directory / "bootstrap_cert.pem");
-  boost::filesystem::remove(conf.device.certificates_directory / "bootstrap_pkey.pem");
+  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.client_certificate);
+  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.ca_file);
+  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.pkey_file);
+  boost::filesystem::remove(conf.tls.certificates_directory / "bootstrap_ca.pem");
+  boost::filesystem::remove(conf.tls.certificates_directory / "bootstrap_cert.pem");
+  boost::filesystem::remove(conf.tls.certificates_directory / "bootstrap_pkey.pem");
   boost::filesystem::remove(test_manifest);
 
   conf.tls.server = tls_server;
@@ -492,9 +481,8 @@ TEST(SotaUptaneClientTest, UptaneSecondaryAdd) {
   Config config;
   config.uptane.metadata_path = "tests/";
   config.uptane.repo_server = tls_server + "/director";
-  config.device.certificates_directory = "tests/test_data/";
+  config.tls.certificates_directory = "tests/test_data/";
   config.uptane.repo_server = tls_server + "/repo";
-  config.device.uuid = "device_id";
   config.tls.server = tls_server;
 
   config.uptane.primary_ecu_serial = "testecuserial";

--- a/tests/uptane_vector_tests.cc
+++ b/tests/uptane_vector_tests.cc
@@ -46,8 +46,7 @@ bool run_test(const std::string& test_name, const Json::Value& vector) {
 
   try {
     Uptane::Repository repo(config);
-    repo.updateRoot(Uptane::Version(1));
-    repo.getNewTargets();
+    repo.getTargets();
 
   } catch (Uptane::Exception e) {
     return match_error(vector, &e);

--- a/tests/uptane_vector_tests.cc
+++ b/tests/uptane_vector_tests.cc
@@ -46,6 +46,7 @@ bool run_test(const std::string& test_name, const Json::Value& vector) {
 
   try {
     Uptane::Repository repo(config);
+    repo.updateRoot(Uptane::Version(1));
     repo.getTargets();
 
   } catch (Uptane::Exception e) {


### PR DESCRIPTION
Moves part of application logic from Uptane::Repository.
It is the beginning of a relatively big refactoring process. Final goals:
* Make Uptane::Repository a thin layer abstracting procedures related to downloading/verifying/pushing UPTANE metadata. All the installation should occur in application-related modules (mostly SotaUptaneClient).
* Partition Config so that each module uses only its own chunk.
* Make initialization procedure traceable, gather scattered initialization-related code from config.cc and uptane/uptanerepository.cc to a single class/function.
* Replace (almost) all interaction with filesystem with transactional writes to a DB (most likely sqlite3).

This PR just moves OSTree installation to SotaUptaneClient and makes Config slightly better partitioned.