### PR TITLE
main.cc: Exit if configuration file doesn't exist

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -19,6 +19,7 @@
  */
 
 /*****************************************************************************/
+#include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 #include <boost/property_tree/ini_parser.hpp>
 #include <iostream>
@@ -119,10 +120,16 @@ int main(int argc, char *argv[]) {
   }
 
   // Initialize config with default values, the update with config, then with cmd
-  std::string filename = commandline_map["config"].as<std::string>();
+  std::string sota_config_file = commandline_map["config"].as<std::string>();
+  boost::filesystem::path sota_config_path(sota_config_file);
+  if (false == boost::filesystem::exists(sota_config_path)) {
+    std::cout << "aktualizr: configuration file " << boost::filesystem::absolute(sota_config_path)
+              << " not found. Exiting." << std::endl;
+    exit(EXIT_FAILURE);
+  }
 
   try {
-    Config config(filename, commandline_map);
+    Config config(sota_config_path.string(), commandline_map);
     Aktualizr aktualizr(config);
     return aktualizr.run();
   } catch (const std::exception &ex) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -161,7 +161,6 @@ add_test(NAME feat1_test--something
 add_test(NAME feat1_test-sth
          COMMAND aktualizr -sth -c ${PROJECT_SOURCE_DIR}/config/config.toml.example)
 
-
 # calle the executable without any options
 add_test(NAME test_plain
          COMMAND aktualizr)
@@ -179,6 +178,20 @@ set_tests_properties(feat1_test--something
                      test_plain
                      test_log_invalid
                      PROPERTIES WILL_FAIL TRUE)
+
+# test the return code when running the executable with non-existing configuration file
+add_test(NAME test-no-config-check-code
+         COMMAND aktualizr -c non-existing-config.toml)
+
+set_tests_properties(test-no-config-check-code
+                     PROPERTIES WILL_FAIL TRUE)
+
+# test the error message when running the executable with non-existing configuration file
+add_test(NAME test-no-config-check-message
+         COMMAND aktualizr -c non-existing-config.toml)
+
+set_tests_properties(test-no-config-check-message
+                     PROPERTIES PASS_REGULAR_EXPRESSION  "aktualizr: configuration file .* not found. Exiting.")
 
 # Try building with various cmake options
 add_test(NAME test_build_all_off


### PR DESCRIPTION
Show user friendly error message and terminate the
application if the specified configuration file
does not exist.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>