### PR TITLE
Ci provision

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -165,7 +165,7 @@ class Config {
   void updateFromCommandLine(const boost::program_options::variables_map& cmd);
   bool isUnpacked() {
     return (boost::filesystem::exists(tls.certificates_directory / "autoprov.url") &&
-            boost::filesystem::exists(tls.certificates_directory / "autoprov_credentials.p12"));
+            boost::filesystem::exists(provision.p12_path));
   };
 };
 

--- a/src/crypto.cc
+++ b/src/crypto.cc
@@ -225,7 +225,6 @@ bool Crypto::generateRSAKeyPair(const std::string &public_key, const std::string
     BN_free(bne);
     return false;
   }
-
   RSA *r = RSA_new();
   ret = RSA_generate_key_ex(r, bits, /* number of bits for the key - 2048 is a sensible value */
                             bne,     /* exponent - RSA_F4 is defined as 0x10001L */

--- a/src/uptane/uptanerepository.cc
+++ b/src/uptane/uptanerepository.cc
@@ -37,9 +37,9 @@ void Repository::updateRoot(Version version) {
   image.updateRoot(version);
 }
 
-void Repository::putManifest() { putManifest(Json::nullValue); }
+bool Repository::putManifest() { return putManifest(Json::nullValue); }
 
-void Repository::putManifest(const Json::Value &custom) {
+bool Repository::putManifest(const Json::Value &custom) {
   Json::Value version_manifest;
   version_manifest["primary_ecu_serial"] = config.uptane.primary_ecu_serial;
   version_manifest["ecu_version_manifest"] = transport.getManifests();
@@ -52,9 +52,7 @@ void Repository::putManifest(const Json::Value &custom) {
   Json::Value tuf_signed =
       Crypto::signTuf(config.uptane.private_key_path, config.uptane.public_key_path, version_manifest);
   HttpResponse reponse = http.put(config.uptane.director_server + "/manifest", tuf_signed);
-  if (!reponse.isOk()) {
-    throw std::runtime_error("Could not put manifest");
-  }
+  return reponse.isOk();
 }
 
 void Repository::refresh() {

--- a/src/uptane/uptanerepository.cc
+++ b/src/uptane/uptanerepository.cc
@@ -51,7 +51,10 @@ void Repository::putManifest(const Json::Value &custom) {
   version_manifest["ecu_version_manifest"].append(ecu_version_signed);
   Json::Value tuf_signed =
       Crypto::signTuf(config.uptane.private_key_path, config.uptane.public_key_path, version_manifest);
-  http.put(config.uptane.director_server + "/manifest", tuf_signed);
+  HttpResponse reponse = http.put(config.uptane.director_server + "/manifest", tuf_signed);
+  if (!reponse.isOk()) {
+    throw std::runtime_error("Could not put manifest");
+  }
 }
 
 void Repository::refresh() {

--- a/src/uptane/uptanerepository.h
+++ b/src/uptane/uptanerepository.h
@@ -15,8 +15,8 @@ namespace Uptane {
 class Repository {
  public:
   Repository(const Config &config);
-  void putManifest();
-  void putManifest(const Json::Value &);
+  bool putManifest();
+  bool putManifest(const Json::Value &);
   void addSecondary(const std::string &ecu_serial, const std::string &hardware_identifier);
 
   // pair of (Version, targets[])

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,7 +27,6 @@ add_custom_target(build_tests DEPENDS aktualizr)
 add_custom_target(check COMMAND CTEST_OUTPUT_ON_FAILURE=1 ${CMAKE_CTEST_COMMAND} -E test_valgrind_uptane_vectors\\|test_build DEPENDS build_tests)
 add_custom_target(check-full COMMAND CTEST_OUTPUT_ON_FAILURE=1 ${CMAKE_CTEST_COMMAND} -E test_uptane_vectors DEPENDS build_tests)
 
-
 # Setup coverage
 if(BUILD_WITH_CODE_COVERAGE)
     include(CodeCoverage)
@@ -83,8 +82,8 @@ add_dependencies(build_tests
 if(BUILD_OSTREE)
     set_source_files_properties(${PROJECT_SOURCE_DIR}/third_party/jsoncpp/jsoncpp.cpp PROPERTIES COMPILE_FLAGS -w)
 
-    add_executable(aktualizr_test_uptane
-                  ${PROJECT_SOURCE_DIR}/third_party/jsoncpp/jsoncpp.cpp
+
+    set(OSTREE_SRC ${PROJECT_SOURCE_DIR}/third_party/jsoncpp/jsoncpp.cpp
                   ${PROJECT_SOURCE_DIR}/src/commands.cc
                   ${PROJECT_SOURCE_DIR}/src/config.cc
                   ${PROJECT_SOURCE_DIR}/src/events.cc
@@ -101,7 +100,10 @@ if(BUILD_OSTREE)
                   ${PROJECT_SOURCE_DIR}/src/uptane/testbusprimary.cc
                   ${PROJECT_SOURCE_DIR}/src/uptane/testbussecondary.cc
                   ${PROJECT_SOURCE_DIR}/src/utils.cc
-                  uptane_test.cc)
+                  fake_ostree.cc)
+
+
+    add_executable(aktualizr_test_uptane ${OSTREE_SRC} uptane_test.cc)
     target_link_libraries(aktualizr_test_uptane ${TEST_LIBS} crypto ${SODIUM_LIBRARIES})
     add_test(NAME test_uptane COMMAND  valgrind --error-exitcode=1 --show-possibly-lost=no --suppressions=${PROJECT_SOURCE_DIR}/tests/aktualizr.supp ${CMAKE_CURRENT_BINARY_DIR}/aktualizr_test_uptane WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
@@ -113,8 +115,8 @@ if(BUILD_OSTREE)
     target_link_libraries(aktualizr_tuf_tests aktualizr_static_lib ${TEST_LIBS} crypto ${SODIUM_LIBRARIES})
     add_test(NAME test_tuf COMMAND valgrind --error-exitcode=1 --show-possibly-lost=no --suppressions=${PROJECT_SOURCE_DIR}/tests/aktualizr.supp ${CMAKE_CURRENT_BINARY_DIR}/aktualizr_tuf_tests WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
-    add_executable(aktualizr_uptane_vector_tests uptane_vector_tests.cc)
-    target_link_libraries(aktualizr_uptane_vector_tests aktualizr_static_lib ${TEST_LIBS} crypto ${SODIUM_LIBRARIES})
+    add_executable(aktualizr_uptane_vector_tests  ${OSTREE_SRC} ${PROJECT_SOURCE_DIR}/src/httpclient.cc uptane_vector_tests.cc)
+    target_link_libraries(aktualizr_uptane_vector_tests ${TEST_LIBS} crypto ${SODIUM_LIBRARIES})
 
     add_test(NAME test_uptane_vectors COMMAND ${PROJECT_SOURCE_DIR}/tests/run_vector_tests.sh ${PROJECT_SOURCE_DIR}/tests/tuf-test-vectors)
     add_test(NAME test_valgrind_uptane_vectors COMMAND ${PROJECT_SOURCE_DIR}/tests/run_vector_tests.sh ${PROJECT_SOURCE_DIR}/tests/tuf-test-vectors valgrind)
@@ -125,6 +127,14 @@ if(BUILD_OSTREE)
     add_test(NAME test_ostree_invalid
         COMMAND aktualizr --config ${CMAKE_CURRENT_SOURCE_DIR}/missing_ostree_repo.toml)
     set_tests_properties(test_ostree_invalid PROPERTIES PASS_REGULAR_EXPRESSION "Could not load installed ostree package")
+
+    if(SOTA_PACKED_CREDENTIALS)
+        add_executable(aktualizr_test_uptane_ci ${OSTREE_SRC} ${PROJECT_SOURCE_DIR}/src/httpclient.cc uptane_ci_test.cc)
+        target_link_libraries(aktualizr_test_uptane_ci ${TEST_LIBS} crypto ${SODIUM_LIBRARIES})
+        add_test(NAME test_uptane_ci COMMAND valgrind --error-exitcode=1 --show-possibly-lost=no --suppressions=${PROJECT_SOURCE_DIR}/tests/aktualizr.supp ${CMAKE_CURRENT_BINARY_DIR}/aktualizr_test_uptane_ci ${SOTA_PACKED_CREDENTIALS} WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+        add_dependencies(build_tests aktualizr_test_uptane_ci)
+    endif(SOTA_PACKED_CREDENTIALS)
+
 endif(BUILD_OSTREE)
 
 
@@ -224,6 +234,8 @@ set(ALL_TEST_SRCS
     tuf_test.cc
     uptane_vector_tests.cc
     uptane_test.cc
+    uptane_ci_test.cc
+    fake_ostree.cc
     utils_test.cc)
 
 add_custom_target(check-format-tests

--- a/tests/config_test.cc
+++ b/tests/config_test.cc
@@ -108,7 +108,8 @@ TEST(config, config_extract_credentials) {
   Config conf;
   conf.tls.certificates_directory = "tests/tmp_data/prov";
   conf.provision.provision_path = "tests/test_data/credentials.zip";
-  system("rm -rf tests/test_data/prov");
+
+  boost::filesystem::remove_all("tests/tmp_data/prov");
   conf.tls.server.clear();
   conf.postUpdateValues();
   EXPECT_EQ(conf.tls.server, "9c8e58a5-3777-40db-99ad-8e1dae1622fe.tcpgw.prod01.advancedtelematic.com");

--- a/tests/config_tests.toml
+++ b/tests/config_tests.toml
@@ -1,5 +1,5 @@
 [tls]
-certificates_directory = "/tmp/aktualizr"
+certificates_directory = "tests/tmp_data/"
 
 [gateway]
 dbus = true

--- a/tests/fake_ostree.cc
+++ b/tests/fake_ostree.cc
@@ -1,0 +1,53 @@
+#include "ostree.h"
+
+OstreePackage::OstreePackage(const std::string &ecu_serial_in, const std::string &ref_name_in,
+                             const std::string &desc_in, const std::string &treehub_in)
+    : ecu_serial(ecu_serial_in), ref_name(ref_name_in), description(desc_in), pull_uri(treehub_in) {}
+
+data::InstallOutcome OstreePackage::install(const data::PackageManagerCredentials &cred, OstreeConfig config) const {
+  (void)cred;
+  (void)config;
+  return data::InstallOutcome(data::OK, "Good");
+}
+
+OstreePackage OstreePackage::fromJson(const Json::Value &json) {
+  return OstreePackage(json["ecu_serial"].asString(), json["ref_name"].asString(), json["description"].asString(),
+                       json["pull_uri"].asString());
+}
+
+Json::Value OstreePackage::toEcuVersion(const Json::Value &custom) const {
+  Json::Value installed_image;
+  installed_image["filepath"] = ref_name;
+  installed_image["fileinfo"]["length"] = 0;
+  installed_image["fileinfo"]["hashes"]["sha256"] = refhash;
+  installed_image["fileinfo"]["custom"] = false;
+
+  Json::Value value;
+  value["attacks_detected"] = "";
+  value["installed_image"] = installed_image;
+  value["ecu_serial"] = ecu_serial;
+  value["previous_timeserver_time"] = "1970-01-01T00:00:00Z";
+  value["timeserver_time"] = "1970-01-01T00:00:00Z";
+  if (custom != Json::nullValue) {
+    value["custom"] = custom;
+  } else {
+    value["custom"] = false;
+  }
+  return value;
+}
+
+OstreePackage OstreePackage::getEcu(const std::string &ecu_serial,
+                                    const std::string &ostree_sysroot __attribute__((unused))) {
+  return OstreePackage(ecu_serial, "frgfdg", "dsfsdf", "sfsdfs");
+}
+
+Json::Value Ostree::getInstalledPackages(const std::string &file_path) {
+  (void)file_path;
+  Json::Value packages(Json::arrayValue);
+  Json::Value package;
+  package["name"] = "vim";
+  package["version"] = "1.0";
+  packages.append(package);
+
+  return packages;
+}

--- a/tests/run_vector_tests.sh
+++ b/tests/run_vector_tests.sh
@@ -7,11 +7,6 @@ fi
 
 . venv/bin/activate
 
-if [ ! -d "sysroot" ]; then
-curl https://s3.eu-central-1.amazonaws.com/pw-dropbox/ostree-sysroot.tar.gz -o ostree-sysroot.tar.gz
-tar -xf ostree-sysroot.tar.gz
-fi
-
 pip install -r "$1/requirements.txt"
 $1/generator.py -t uptane --signature-encoding base64 -o vectors --cjson json-subset
 $1/server.py -t uptane --signature-encoding base64 &

--- a/tests/uptane_ci_test.cc
+++ b/tests/uptane_ci_test.cc
@@ -1,0 +1,37 @@
+#include <gtest/gtest.h>
+#include <fstream>
+#include <iostream>
+
+#include <logger.h>
+#include <boost/filesystem.hpp>
+#include "uptane/uptanerepository.h"
+std::string credentials = "";
+
+TEST(SotaUptaneClientTest, OneCycleUpdate) {
+  system("rm -rf tests/tmp_data");
+  boost::property_tree::ptree pt;
+  boost::property_tree::ini_parser::read_ini("tests/config_tests.toml", pt);
+  pt.put("provision.provision_path", credentials);
+  Config config(pt);
+  Uptane::Repository repo(config);
+
+  EXPECT_TRUE(repo.deviceRegister());
+  EXPECT_TRUE(repo.ecuRegister());
+  EXPECT_TRUE(repo.putManifest());
+
+  // should not throw any exceptions
+  repo.getTargets();
+}
+
+#ifndef __NO_MAIN__
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  loggerSetSeverity(LVL_trace);
+
+  if (argc != 2) {
+    exit(EXIT_FAILURE);
+  }
+  credentials = argv[1];
+  return RUN_ALL_TESTS();
+}
+#endif

--- a/tests/uptane_test.cc
+++ b/tests/uptane_test.cc
@@ -17,52 +17,6 @@ std::string test_manifest = "/tmp/test_aktualizr_manifest.txt";
 std::string tls_server = "https://tlsserver.com";
 std::string metadata_path = "tests/tmp_data/";
 
-OstreePackage::OstreePackage(const std::string &ecu_serial_in, const std::string &ref_name_in,
-                             const std::string &desc_in, const std::string &treehub_in)
-    : ecu_serial(ecu_serial_in), ref_name(ref_name_in), description(desc_in), pull_uri(treehub_in) {}
-
-data::InstallOutcome OstreePackage::install(const data::PackageManagerCredentials &cred, OstreeConfig config) const {
-  (void)cred;
-  (void)config;
-  return data::InstallOutcome(data::OK, "Good");
-}
-
-OstreePackage OstreePackage::fromJson(const Json::Value &json) {
-  return OstreePackage(json["ecu_serial"].asString(), json["ref_name"].asString(), json["description"].asString(),
-                       json["pull_uri"].asString());
-}
-
-Json::Value OstreePackage::toEcuVersion(const Json::Value &custom) const {
-  Json::Value installed_image;
-  installed_image["filepath"] = ref_name;
-  installed_image["fileinfo"]["length"] = 0;
-  installed_image["fileinfo"]["hashes"]["sha256"] = refhash;
-  installed_image["fileinfo"]["custom"] = false;
-
-  Json::Value value;
-  value["attacks_detected"] = "";
-  value["installed_image"] = installed_image;
-  value["ecu_serial"] = ecu_serial;
-  value["previous_timeserver_time"] = "1970-01-01T00:00:00Z";
-  value["timeserver_time"] = "1970-01-01T00:00:00Z";
-  if (custom != Json::nullValue) {
-    value["custom"] = custom;
-  } else {
-    value["custom"] = false;
-  }
-  return value;
-}
-
-OstreePackage OstreePackage::getEcu(const std::string &ecu_serial,
-                                    const std::string &ostree_sysroot __attribute__((unused))) {
-  return OstreePackage(ecu_serial, "frgfdg", "dsfsdf", "sfsdfs");
-}
-
-Json::Value Ostree::getInstalledPackages(const std::string &file_path) {
-  (void)file_path;
-  return Json::Value();
-}
-
 HttpClient::HttpClient() {}
 void HttpClient::setCerts(const std::string &ca, const std::string &cert, const std::string &pkey) {
   (void)ca;

--- a/tests/uptane_vector_tests.cc
+++ b/tests/uptane_vector_tests.cc
@@ -52,7 +52,7 @@ bool run_test(const std::string& test_name, const Json::Value& vector) {
   } catch (Uptane::Exception e) {
     return match_error(vector, &e);
   } catch (const std::exception& ex) {
-    std::cout << "Undefined exception: " << ex.what();
+    std::cout << "Undefined exception: " << ex.what() << "\n";
     return false;
   }
 


### PR DESCRIPTION
To run tests  You need to run cmake with `SOTA_PACKED_CREDENTIALS="path_to_file.zip"` then run tests as usual  

Big coverage decrease is because we don't run real ostree class now. May be we need to add new tests to ostree tests, but this will require download ostree repo. 