### PR TITLE
Tidy test creation

### DIFF
--- a/src/aktualizr.cc
+++ b/src/aktualizr.cc
@@ -20,11 +20,9 @@
 #include "timer.h"
 
 Aktualizr::Aktualizr(const Config &config) : config_(config) {
-  if (sodium_init() == -1) {
+  if (sodium_init() == -1) {  // Note that sodium_init doesn't require a matching 'sodium_deinit'
     throw std::runtime_error("Unable to initialize libsodium");
   }
-
-  RAND_poll();
 
   LOGGER_LOG(LVL_trace, "Seeding random number generator from /dev/random...");
   Timer timer;
@@ -43,8 +41,6 @@ Aktualizr::Aktualizr(const Config &config) : config_(config) {
   }
 #endif
 }
-
-Aktualizr::~Aktualizr() { CRYPTO_cleanup_all_ex_data(); }
 
 int Aktualizr::run() {
   command::Channel commands_channel;

--- a/src/aktualizr.h
+++ b/src/aktualizr.h
@@ -3,16 +3,13 @@
 
 #include "config.h"
 
-class Aktualizr {
+class Aktualizr : public boost::noncopyable {
  public:
   Aktualizr(const Config &config);
-  ~Aktualizr();
 
   int run();
 
  private:
-  Aktualizr(Aktualizr const &);
-  void operator=(Aktualizr const &);
   Config config_;
 };
 

--- a/src/httpclient.cc
+++ b/src/httpclient.cc
@@ -34,7 +34,6 @@ static size_t writeString(void* contents, size_t size, size_t nmemb, void* userp
 }
 
 HttpClient::HttpClient() : user_agent(std::string("Aktualizr/") + AKTUALIZR_VERSION) {
-  curl_global_init(CURL_GLOBAL_ALL);
   curl = curl_easy_init();
   headers = NULL;
   http_code = 0;

--- a/src/httpclient.h
+++ b/src/httpclient.h
@@ -24,6 +24,15 @@ struct HttpResponse {
   Json::Value getJson() { return Utils::parseJSON(body); }
 };
 
+/**
+ * Helper class to manage curl_global_init/curl_global_cleanup calls
+ */
+class CurlGlobalInitWrapper {
+ public:
+  CurlGlobalInitWrapper() { curl_global_init(CURL_GLOBAL_DEFAULT); }
+  ~CurlGlobalInitWrapper() { curl_global_cleanup(); }
+};
+
 class HttpClient {
  public:
   HttpClient();
@@ -48,6 +57,7 @@ class HttpClient {
    */
   HttpResponse post(const std::string &url, std::string data);
   HttpResponse put(const std::string &url, std::string data);
+  CurlGlobalInitWrapper manageCurlGlobalInit_;  // Must be first member to ensure curl init/shutdown happens first/last
   CURL *curl;
   curl_slist *headers;
   HttpResponse perform(CURL *curl_handler, int retry_times);

--- a/src/socketgateway.h
+++ b/src/socketgateway.h
@@ -9,7 +9,7 @@
 #include "events.h"
 #include "gateway.h"
 
-class SocketGateway : public Gateway {
+class SocketGateway : public Gateway, boost::noncopyable {
  public:
   SocketGateway(const Config &config_in, command::Channel *commands_channel_in);
   virtual ~SocketGateway();
@@ -20,9 +20,9 @@ class SocketGateway : public Gateway {
   command::Channel *commands_channel;
   std::vector<int> event_connections;
   std::vector<int> command_connections;
-  std::vector<boost::thread *> command_workers;
-  boost::thread *events_server_thread;
-  boost::thread *commands_server_thread;
+  std::vector<boost::shared_ptr<boost::thread> > command_workers;
+  boost::shared_ptr<boost::thread> events_server_thread;
+  boost::shared_ptr<boost::thread> commands_server_thread;
   int events_socket;
   int commands_socket;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_program(VALGRIND NAMES valgrind)
+
 if(NOT GTEST_ROOT )
     set(GTEST_ROOT ${PROJECT_SOURCE_DIR}/third_party/googletest/googletest)
 endif()
@@ -27,6 +29,37 @@ add_custom_target(build_tests DEPENDS aktualizr)
 add_custom_target(check COMMAND CTEST_OUTPUT_ON_FAILURE=1 ${CMAKE_CTEST_COMMAND} -E test_valgrind_uptane_vectors\\|test_build DEPENDS build_tests)
 add_custom_target(check-full COMMAND CTEST_OUTPUT_ON_FAILURE=1 ${CMAKE_CTEST_COMMAND} -E test_uptane_vectors DEPENDS build_tests)
 
+include(CMakeParseArguments)
+
+function(add_aktualizr_test)
+    set(options PROJECT_WORKING_DIRECTORY NO_VALGRIND)
+    set(oneValueArgs NAME)
+    set(multiValueArgs SOURCES ARGS)
+    cmake_parse_arguments(AKTUALIZR_TEST "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+    add_executable(t_${AKTUALIZR_TEST_NAME} ${AKTUALIZR_TEST_SOURCES})
+    target_link_libraries(t_${AKTUALIZR_TEST_NAME} aktualizr_static_lib ${TEST_LIBS})
+    if(AKTUALIZR_TEST_PROJECT_WORKING_DIRECTORY)
+        set(WD WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    else()
+        set(WD )
+    endif()
+        # Running tests that are both instrumented by gcov and valgrind at
+        # the same time is very expensive.  Disable valgrind when running
+        # under gcov, or when the test is explicitly flagged that it fails
+        # under valgrind (these should be fixed)
+        if(AKTUALIZR_TEST_NO_VALGRIND OR BUILD_WITH_CODE_COVERAGE)
+            add_test(NAME test_${AKTUALIZR_TEST_NAME}
+                    COMMAND t_${AKTUALIZR_TEST_NAME} ${AKTUALIZR_TEST_ARGS}
+                    ${WD})
+        else()
+            add_test(NAME test_${AKTUALIZR_TEST_NAME}
+                     COMMAND ${RUN_VALGRIND} ${CMAKE_CURRENT_BINARY_DIR}/t_${AKTUALIZR_TEST_NAME} ${AKTUALIZR_TEST_ARGS}
+                     ${WD})
+        endif()
+    add_dependencies(build_tests t_${AKTUALIZR_TEST_NAME})
+
+endfunction(add_aktualizr_test)
+
 # Setup coverage
 if(BUILD_WITH_CODE_COVERAGE)
     include(CodeCoverage)
@@ -36,61 +69,44 @@ if(BUILD_WITH_CODE_COVERAGE)
     add_dependencies(coverage build_tests)
 endif(BUILD_WITH_CODE_COVERAGE)
 
-# Config Test
-add_executable(aktualizr_test_config config_test.cc)
-target_link_libraries(aktualizr_test_config aktualizr_static_lib ${TEST_LIBS})
-add_test(NAME test_config COMMAND aktualizr_test_config WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+configure_file(run-valgrind.in run-valgrind @ONLY)
+SET(RUN_VALGRIND ${CMAKE_CURRENT_BINARY_DIR}/run-valgrind)
 
 
-add_executable(aktualizr_test_events events_test.cc)
-target_link_libraries(aktualizr_test_events aktualizr_static_lib ${TEST_LIBS})
-add_test(NAME test_events COMMAND aktualizr_test_events WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+add_aktualizr_test(NAME config SOURCES config_test.cc PROJECT_WORKING_DIRECTORY)
 
+add_aktualizr_test(NAME events SOURCES events_test.cc PROJECT_WORKING_DIRECTORY)
 
-add_executable(aktualizr_test_commands commands_test.cc)
-target_link_libraries(aktualizr_test_commands aktualizr_static_lib ${TEST_LIBS})
-add_test(NAME test_commands COMMAND aktualizr_test_commands WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+add_aktualizr_test(NAME commands SOURCES commands_test.cc PROJECT_WORKING_DIRECTORY)
 
+add_aktualizr_test(NAME http_client
+                   SOURCES httpclient_test.cc
+                   ARGS ${PROJECT_SOURCE_DIR}/tests/fake_http_server/
+                   PROJECT_WORKING_DIRECTORY)
 
-add_executable(aktualizr_test_http_client httpclient_test.cc)
-target_link_libraries(aktualizr_test_http_client aktualizr_static_lib ${TEST_LIBS})
-add_test(NAME test_http_client COMMAND aktualizr_test_http_client ${PROJECT_SOURCE_DIR}/tests/fake_http_server/ WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
-add_test(NAME test_valgrind_http_client COMMAND valgrind --error-exitcode=1 --show-possibly-lost=no --suppressions=${PROJECT_SOURCE_DIR}/tests/aktualizr.supp ${CMAKE_CURRENT_BINARY_DIR}/aktualizr_test_http_client ${PROJECT_SOURCE_DIR}/tests/fake_http_server/ WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+if(NOT BUILD_WITH_CODE_COVERAGE)
+    # Code coverage disables valgrind, and this test is only checking that
+    # valgrind finds memory leaks
+    add_aktualizr_test(NAME leak SOURCES leak_test.cc)
+    set_tests_properties(test_leak PROPERTIES WILL_FAIL TRUE)
+endif()
 
-add_executable(aktualizr_test_socket_gateway socketgateway_test.cc)
-target_link_libraries(aktualizr_test_socket_gateway aktualizr_static_lib ${TEST_LIBS})
-add_test(NAME test_valgrind_socket_gateway COMMAND valgrind --error-exitcode=1 --show-possibly-lost=no --suppressions=${PROJECT_SOURCE_DIR}/tests/aktualizr.supp ${CMAKE_CURRENT_BINARY_DIR}/aktualizr_test_socket_gateway ${PROJECT_SOURCE_DIR}/tests/fake_unix_socket/ WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+add_aktualizr_test(NAME socket_gateway
+                   SOURCES socketgateway_test.cc
+                   ARGS ${PROJECT_SOURCE_DIR}/tests/fake_unix_socket/)
 
-add_executable(aktualizr_test_crypto crypto_test.cc)
-target_link_libraries(aktualizr_test_crypto aktualizr_static_lib ${TEST_LIBS} crypto ${SODIUM_LIBRARIES})
-add_test(NAME test_crypto COMMAND aktualizr_test_crypto WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+add_aktualizr_test(NAME timer SOURCES timer_test.cc)
 
-add_executable(aktualizr_test_timer timer_test.cc)
-target_link_libraries(aktualizr_test_timer aktualizr_static_lib ${TEST_LIBS} crypto ${SODIUM_LIBRARIES})
-add_test(NAME test_timer COMMAND aktualizr_test_timer)
+add_aktualizr_test(NAME utils SOURCES utils_test.cc)
 
-add_executable(aktualizr_test_utils utils_test.cc)
-target_link_libraries(aktualizr_test_utils aktualizr_static_lib ${TEST_LIBS} crypto ${SODIUM_LIBRARIES})
-add_test(NAME test_utils COMMAND valgrind --error-exitcode=1 --show-possibly-lost=no --suppressions=${PROJECT_SOURCE_DIR}/tests/aktualizr.supp ${CMAKE_CURRENT_BINARY_DIR}/aktualizr_test_utils)
+add_aktualizr_test(NAME fsstorage SOURCES fsstorage_test.cc PROJECT_WORKING_DIRECTORY)
 
-add_executable(aktualizr_test_fsstorage fsstorage_test.cc)
-target_link_libraries(aktualizr_test_fsstorage aktualizr_static_lib ${TEST_LIBS} crypto ${SODIUM_LIBRARIES})
-add_test(NAME test_fsstorage COMMAND aktualizr_test_fsstorage WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
-
-add_dependencies(build_tests
-        aktualizr_test_config
-        aktualizr_test_events
-        aktualizr_test_commands
-        aktualizr_test_http_client
-        aktualizr_test_socket_gateway
-        aktualizr_test_crypto
-        aktualizr_test_timer
-        aktualizr_test_utils
-        aktualizr_test_fsstorage)
+add_aktualizr_test(NAME crypto
+                   SOURCES crypto_test.cc
+                   PROJECT_WORKING_DIRECTORY NO_VALGRIND)
 
 if(BUILD_OSTREE)
     set_source_files_properties(${PROJECT_SOURCE_DIR}/third_party/jsoncpp/jsoncpp.cpp PROPERTIES COMPILE_FLAGS -w)
-
 
     set(OSTREE_SRC ${PROJECT_SOURCE_DIR}/third_party/jsoncpp/jsoncpp.cpp
                   ${PROJECT_SOURCE_DIR}/src/bootstrap.cc
@@ -113,55 +129,46 @@ if(BUILD_OSTREE)
                   ${PROJECT_SOURCE_DIR}/src/fsstorage.cc
                   fake_ostree.cc)
 
+    add_aktualizr_test(NAME uptane SOURCES uptane_test.cc ${OSTREE_SRC}
+                       PROJECT_WORKING_DIRECTORY NO_VALGRIND)
 
-    add_executable(aktualizr_test_uptane ${OSTREE_SRC} uptane_test.cc)
-    target_link_libraries(aktualizr_test_uptane ${TEST_LIBS} crypto ${SODIUM_LIBRARIES})
-    add_test(NAME test_uptane COMMAND  valgrind --error-exitcode=1 --show-possibly-lost=no --suppressions=${PROJECT_SOURCE_DIR}/tests/aktualizr.supp ${CMAKE_CURRENT_BINARY_DIR}/aktualizr_test_uptane WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    add_aktualizr_test(NAME ostree SOURCES ostree_test.cc PROJECT_WORKING_DIRECTORY NO_VALGRIND)
 
-    add_executable(aktualizr_test_ostree ostree_test.cc)
-    target_link_libraries(aktualizr_test_ostree aktualizr_static_lib ${TEST_LIBS} crypto)
-    add_test(NAME test_ostree COMMAND aktualizr_test_ostree WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    add_aktualizr_test(NAME tuf SOURCES tuf_test.cc PROJECT_WORKING_DIRECTORY)
 
-    add_executable(aktualizr_tuf_tests tuf_test.cc)
-    target_link_libraries(aktualizr_tuf_tests aktualizr_static_lib ${TEST_LIBS} crypto ${SODIUM_LIBRARIES})
-    add_test(NAME test_tuf COMMAND valgrind --error-exitcode=1 --show-possibly-lost=no --suppressions=${PROJECT_SOURCE_DIR}/tests/aktualizr.supp ${CMAKE_CURRENT_BINARY_DIR}/aktualizr_tuf_tests WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
-
-    add_executable(aktualizr_uptane_vector_tests  ${OSTREE_SRC} ${PROJECT_SOURCE_DIR}/src/httpclient.cc uptane_vector_tests.cc)
+    add_executable(aktualizr_uptane_vector_tests uptane_vector_tests.cc ${OSTREE_SRC} ${PROJECT_SOURCE_DIR}/src/httpclient.cc)
     target_link_libraries(aktualizr_uptane_vector_tests ${TEST_LIBS} crypto ${SODIUM_LIBRARIES})
 
     add_test(NAME test_uptane_vectors COMMAND ${PROJECT_SOURCE_DIR}/tests/run_vector_tests.sh ${PROJECT_SOURCE_DIR}/tests/tuf-test-vectors)
     add_test(NAME test_valgrind_uptane_vectors COMMAND ${PROJECT_SOURCE_DIR}/tests/run_vector_tests.sh ${PROJECT_SOURCE_DIR}/tests/tuf-test-vectors valgrind)
-
-
-    add_dependencies(build_tests aktualizr_test_uptane aktualizr_test_ostree aktualizr_tuf_tests aktualizr_uptane_vector_tests)
+    add_dependencies(build_tests aktualizr_uptane_vector_tests)
 
     add_test(NAME test_ostree_invalid
         COMMAND aktualizr --config ${CMAKE_CURRENT_SOURCE_DIR}/missing_ostree_repo.toml)
     set_tests_properties(test_ostree_invalid PROPERTIES PASS_REGULAR_EXPRESSION "Could not find OSTree sysroot at:")
 
     if(SOTA_PACKED_CREDENTIALS)
-        add_executable(aktualizr_test_uptane_ci ${OSTREE_SRC} ${PROJECT_SOURCE_DIR}/src/httpclient.cc uptane_ci_test.cc)
-        target_link_libraries(aktualizr_test_uptane_ci ${TEST_LIBS} crypto ${SODIUM_LIBRARIES})
-        add_test(NAME test_uptane_ci COMMAND valgrind --error-exitcode=1 --show-possibly-lost=no --suppressions=${PROJECT_SOURCE_DIR}/tests/aktualizr.supp ${CMAKE_CURRENT_BINARY_DIR}/aktualizr_test_uptane_ci ${SOTA_PACKED_CREDENTIALS} WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
-        add_dependencies(build_tests aktualizr_test_uptane_ci)
+        add_aktualizr_test(NAME uptane_ci SOURCES uptane_ci_test.cc ${OSTREE_SRC} ${PROJECT_SOURCE_DIR}/src/httpclient.cc )
     endif(SOTA_PACKED_CREDENTIALS)
 
 endif(BUILD_OSTREE)
 
 
 if(BUILD_GENIVI)
+    add_aktualizr_test(NAME rvi_client SOURCES rvisotaclient_test.cc PROJECT_WORKING_DIRECTORY)
+
     add_executable(aktualizr_test_dbusgateway dbusgateway_test.cc)
     target_link_libraries(aktualizr_test_dbusgateway aktualizr_static_lib ${TEST_LIBS} ${LIBDBUS_LIBRARIES})
-    add_test(NAME test_valgrind_dbusgateway COMMAND valgrind --error-exitcode=1 --show-possibly-lost=no --suppressions=${PROJECT_SOURCE_DIR}/tests/aktualizr.supp dbus-run-session --config-file ${PROJECT_SOURCE_DIR}/tests/session.conf bash -c "${CMAKE_CURRENT_BINARY_DIR}/aktualizr_test_dbusgateway ${PROJECT_SOURCE_DIR}/tests/fake_dbus_tools/" WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
-
-    add_executable(aktualizr_test_rvi_client rvisotaclient_test.cc)
-    target_link_libraries(aktualizr_test_rvi_client aktualizr_static_lib ${TEST_LIBS})
-    add_test(NAME test_rvi_client COMMAND aktualizr_test_rvi_client WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    add_test(NAME test_dbusgateway
+             COMMAND dbus-run-session --config-file ${PROJECT_SOURCE_DIR}/tests/session.conf -- ${CMAKE_CURRENT_BINARY_DIR}/aktualizr_test_dbusgateway ${PROJECT_SOURCE_DIR}/tests/fake_dbus_tools/
+             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
     add_executable(aktualizr_test_swm swm_test.cc)
     target_link_libraries(aktualizr_test_swm aktualizr_static_lib ${TEST_LIBS} ${LIBDBUS_LIBRARIES})
-    add_test(NAME test_swm COMMAND dbus-run-session --config-file ${PROJECT_SOURCE_DIR}/tests/session.conf bash -c "${CMAKE_CURRENT_BINARY_DIR}/aktualizr_test_swm ${PROJECT_SOURCE_DIR}/tests/fake_dbus_tools/" WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
-    add_dependencies(build_tests aktualizr_test_dbusgateway aktualizr_test_rvi_client aktualizr_test_swm)
+    add_test(NAME test_swm
+             COMMAND dbus-run-session --config-file ${PROJECT_SOURCE_DIR}/tests/session.conf -- ${CMAKE_CURRENT_BINARY_DIR}/aktualizr_test_swm ${PROJECT_SOURCE_DIR}/tests/fake_dbus_tools/
+             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    add_dependencies(build_tests aktualizr_test_dbusgateway aktualizr_test_swm)
 
 endif(BUILD_GENIVI)
 

--- a/tests/aktualizr.supp
+++ b/tests/aktualizr.supp
@@ -1,4 +1,25 @@
 {
+   gobject Static Type initialization
+   Memcheck:Leak
+   ...
+   fun:g_type_register_static
+   ...
+}
+{
+   gobject Static Type initialization
+   Memcheck:Leak
+   ...
+   fun:g_type_register_fundamental
+   ...
+}
+{
+   gobject Static Interface initialization
+   Memcheck:Leak
+   ...
+   fun:g_type_add_interface_static
+   ...
+}
+{
    ignore_externa_libs_Cond
    Memcheck:Cond
    ...

--- a/tests/dbusgateway_test.cc
+++ b/tests/dbusgateway_test.cc
@@ -132,7 +132,11 @@ int main(int argc, char** argv) {
   if (argc >= 2) {
     fake_path = argv[1];
     std::string cmd = "python " + fake_path + "dbus_recieve.py &";
-    EXPECT_EQ(0, system(cmd.c_str()));
+    int res = system(cmd.c_str());
+    EXPECT_EQ(res, 0);
+    if (res) {
+      return 1;
+    }
     sleep(2);
   }
   return RUN_ALL_TESTS();

--- a/tests/leak_test.cc
+++ b/tests/leak_test.cc
@@ -1,0 +1,15 @@
+#include <gtest/gtest.h>
+
+/**
+ * A test case that leaks memory, to check that we can spot this in valgrind
+ */
+TEST(Leak, ThisTestLeaks) {
+  EXPECT_TRUE(new int[45]);
+}
+
+#ifndef __NO_MAIN__
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+#endif

--- a/tests/run-valgrind.in
+++ b/tests/run-valgrind.in
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+@VALGRIND@ --error-exitcode=1 \
+    --leak-check=yes \
+    --show-possibly-lost=yes \
+    "--suppressions=@PROJECT_SOURCE_DIR@/tests/aktualizr.supp" \
+    $1 $2 $3 $4 $5 $6 $7 $8 $9


### PR DESCRIPTION
This series of changes fixes several memory leaks that were discovered by the final change, which runs most of the tests under valgrind.

The biggest change is add_aktualizr_test, which massively reduces the copy/paste required to introduce new tests.