### PR TITLE
A linear restartable initialization process

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,10 +8,8 @@ set(SOURCES ${PROJECT_SOURCE_DIR}/third_party/jsoncpp/jsoncpp.cpp
             config.cc
             crypto.cc
             events.cc
-            fsstorage.cc
-            commands.cc
-            types.cc
             eventsinterpreter.cc
+            fsstorage.cc
             gatewaymanager.cc
             httpclient.cc
             logger.cc
@@ -23,32 +21,32 @@ set(SOURCES ${PROJECT_SOURCE_DIR}/third_party/jsoncpp/jsoncpp.cpp
 # set headers used for clang format
 set(HEADERS
             aktualizr.h
-            logger.h
-            httpclient.h
-            sotauptaneclient.h
-            config.h
+            bootstrap.h
             channel.h
-            events.h
             commands.h
-            invstorage.h
-            fsstorage.h
-            types.h
-            eventsinterpreter.h
-            gatewaymanager.h
-            socketgateway.h
+            config.h
             crypto.h
+            events.h
+            eventsinterpreter.h
+            fsstorage.h
+            gatewaymanager.h
+            httpclient.h
+            invstorage.h
+            logger.h
             openssl_compat.h
             ostree.h
+            socketgateway.h
+            sotauptaneclient.h
             timer.h
+            types.h
             utils.h
-            bootstrap.h
-            uptane/tuf.h
-            uptane/tufrepository.h
-            uptane/uptanerepository.h
-            uptane/secondary.h
+            uptane/exceptions.h
             uptane/testbusprimary.h
             uptane/testbussecondary.h
-            uptane/exceptions.h)
+            uptane/tuf.h
+            uptane/tufrepository.h
+            uptane/secondary.h
+            uptane/uptanerepository.h)
 
 if(BUILD_GENIVI)
     list(APPEND SOURCES dbusgateway/dbusgateway.cc
@@ -61,6 +59,7 @@ endif(BUILD_GENIVI)
 if (BUILD_OSTREE)
     list(APPEND SOURCES ostree.cc
                         sotauptaneclient.cc
+                        uptane/initialize.cc
                         uptane/role.cc
                         uptane/root.cc
                         uptane/tuf.cc

--- a/src/config.cc
+++ b/src/config.cc
@@ -144,60 +144,13 @@ void Config::postUpdateValues() {
     }
   }
 
-  if (uptane.repo_server.empty()) {
-    uptane.repo_server = tls.server + "/repo";
-  }
-  if (uptane.director_server.empty()) {
-    uptane.director_server = tls.server + "/director";
-  }
-  if (uptane.ostree_server.empty()) {
-    uptane.ostree_server = tls.server + "/treehub";
-  }
-  std::string ecu_serial_filename = "primary_ecu_serial";
+  if (provision.server.empty()) provision.server = tls.server;
 
-  if (!uptane.primary_ecu_serial.empty()) {
-    Utils::writeFile((tls.certificates_directory / ecu_serial_filename).string(), uptane.primary_ecu_serial);
-  } else {
-    if (boost::filesystem::exists(tls.certificates_directory / ecu_serial_filename)) {
-      uptane.primary_ecu_serial = Utils::readFile((tls.certificates_directory / ecu_serial_filename).string());
-    } else {
-      uptane.primary_ecu_serial = Utils::randomUuid();
-      Utils::writeFile((tls.certificates_directory / ecu_serial_filename).string(), uptane.primary_ecu_serial);
-    }
-  }
+  if (uptane.repo_server.empty()) uptane.repo_server = tls.server + "/repo";
 
-  std::string device_id_filename = "device_id";
-  if (!uptane.device_id.empty()) {
-    Utils::writeFile((tls.certificates_directory / device_id_filename).string(), uptane.device_id);
-  } else {
-    if (boost::filesystem::exists(tls.certificates_directory / device_id_filename)) {
-      uptane.device_id = Utils::readFile((tls.certificates_directory / device_id_filename).string());
-    } else {
-      uptane.device_id = Utils::genPrettyName();
-      Utils::writeFile((tls.certificates_directory / device_id_filename).string(), uptane.device_id);
-    }
-  }
-  if (uptane.primary_ecu_hardware_id.empty()) {
-    char hostname[200];
-    gethostname(hostname, 200);
-    uptane.primary_ecu_hardware_id = hostname;
-  }
+  if (uptane.director_server.empty()) uptane.director_server = tls.server + "/director";
 
-  std::vector<Uptane::SecondaryConfig>::iterator it;
-  int index = 0;
-  for (it = uptane.secondaries.begin(); it != uptane.secondaries.end(); ++it) {
-    if (it->ecu_hardware_id.empty()) {
-      it->ecu_hardware_id = Utils::intToString(index++) + "-" + uptane.primary_ecu_hardware_id;
-    }
-    if (it->ecu_serial.empty()) {
-      if (boost::filesystem::exists(tls.certificates_directory / it->ecu_hardware_id)) {
-        it->ecu_serial = Utils::readFile((tls.certificates_directory / it->ecu_hardware_id).string());
-      } else {
-        it->ecu_serial = Utils::intToString(index++) + "-" + uptane.primary_ecu_serial;
-        Utils::writeFile((tls.certificates_directory / it->ecu_hardware_id).string(), it->ecu_serial);
-      }
-    }
-  }
+  if (uptane.ostree_server.empty()) uptane.ostree_server = tls.server + "/treehub";
 
   uptane.public_key_path = (tls.certificates_directory / uptane.public_key_path).string();
   uptane.private_key_path = (tls.certificates_directory / uptane.private_key_path).string();

--- a/src/config.h
+++ b/src/config.h
@@ -96,7 +96,8 @@ struct TlsConfig {
 };
 
 struct ProvisionConfig {
-  ProvisionConfig() : p12_password(""), expiry_days("36000"), provision_path() {}
+  ProvisionConfig() : server(), p12_password(""), expiry_days("36000"), provision_path() {}
+  std::string server;
   std::string p12_password;
   std::string expiry_days;
   std::string provision_path;

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -83,8 +83,7 @@ class Crypto {
   static std::string sha256digest(const std::string &text);
   static std::string sha512digest(const std::string &text);
   static std::string RSAPSSSign(const std::string &private_key, const std::string &digest);
-  static Json::Value signTuf(const std::string &private_key_path, const std::string &public_key_path,
-                             const Json::Value &in_data);
+  static Json::Value signTuf(const std::string &private_key, const std::string &public_key, const Json::Value &in_data);
   static bool VerifySignature(const PublicKey &public_key, const std::string &signature, const std::string &message);
   static bool parseP12(FILE *p12_fp, const std::string &p12_password, std::string *out_pkey, std::string *out_cert,
                        std::string *out_ca);

--- a/src/fsstorage.cc
+++ b/src/fsstorage.cc
@@ -3,7 +3,7 @@
 #include <boost/scoped_array.hpp>
 #include <iostream>
 
-#include "logger.h"
+//#include "logger.h"
 #include "utils.h"
 
 FSStorage::FSStorage(const Config& config) : config_(config) {
@@ -15,46 +15,33 @@ FSStorage::~FSStorage() {
   // TODO: clear director_files, image_files
 }
 
-void FSStorage::storeEcu(bool is_primary, const std::string& hardware_id __attribute__((unused)),
-                         const std::string& ecu_id, const std::string& public_key, const std::string& private_key) {
-  boost::filesystem::path public_key_path;
-  boost::filesystem::path private_key_path;
-
-  if (is_primary) {
-    public_key_path = config_.uptane.public_key_path;
-    private_key_path = config_.uptane.private_key_path;
-  } else {
-    public_key_path = config_.tls.certificates_directory / (ecu_id + ".pub");
-    private_key_path = config_.tls.certificates_directory / (ecu_id + ".priv");
-  }
+void FSStorage::storePrimaryKeys(const std::string& public_key, const std::string& private_key) {
+  boost::filesystem::path public_key_path = config_.tls.certificates_directory / config_.uptane.public_key_path;
+  boost::filesystem::path private_key_path = config_.tls.certificates_directory / config_.uptane.private_key_path;
 
   boost::filesystem::remove(public_key_path);
   boost::filesystem::remove(private_key_path);
 
-  Utils::writeFile(public_key_path.native(), public_key);
-  Utils::writeFile(private_key_path.native(), private_key);
+  Utils::writeFile(public_key_path.string(), public_key);
+  Utils::writeFile(private_key_path.string(), private_key);
 
   sync();
 }
 
-bool FSStorage::loadEcuKeys(bool is_primary, const std::string& hardware_id __attribute__((unused)),
-                            const std::string& ecu_id, std::string* public_key, std::string* private_key) {
-  boost::filesystem::path public_key_path;
-  boost::filesystem::path private_key_path;
-
-  if (is_primary) {
-    public_key_path = config_.uptane.public_key_path;
-    private_key_path = config_.uptane.private_key_path;
-  } else {
-    public_key_path = config_.tls.certificates_directory / (ecu_id + ".pub");
-    private_key_path = config_.tls.certificates_directory / (ecu_id + ".priv");
-  }
+bool FSStorage::loadPrimaryKeys(std::string* public_key, std::string* private_key) {
+  boost::filesystem::path public_key_path = config_.tls.certificates_directory / config_.uptane.public_key_path;
+  boost::filesystem::path private_key_path = config_.tls.certificates_directory / config_.uptane.private_key_path;
 
   if (!boost::filesystem::exists(public_key_path) || !boost::filesystem::exists(private_key_path)) return false;
 
-  if (public_key) *public_key = Utils::readFile(public_key_path.native());
-  if (private_key) *private_key = Utils::readFile(private_key_path.native());
+  if (public_key) *public_key = Utils::readFile(public_key_path.string());
+  if (private_key) *private_key = Utils::readFile(private_key_path.string());
   return true;
+}
+
+void FSStorage::clearPrimaryKeys() {
+  boost::filesystem::remove(config_.tls.certificates_directory / config_.uptane.public_key_path);
+  boost::filesystem::remove(config_.tls.certificates_directory / config_.uptane.private_key_path);
 }
 
 void FSStorage::storeTlsCredsCommon(const boost::filesystem::path& ca_path, const boost::filesystem::path& cert_path,
@@ -64,20 +51,12 @@ void FSStorage::storeTlsCredsCommon(const boost::filesystem::path& ca_path, cons
   boost::filesystem::remove(cert_path);
   boost::filesystem::remove(pkey_path);
 
-  Utils::writeFile(ca_path.native(), ca);
-  Utils::writeFile(cert_path.native(), cert);
-  Utils::writeFile(pkey_path.native(), pkey);
+  Utils::writeFile(ca_path.string(), ca);
+  Utils::writeFile(cert_path.string(), cert);
+  Utils::writeFile(pkey_path.string(), pkey);
 
   sync();
 }
-
-void FSStorage::storeBootstrapTlsCreds(const std::string& ca, const std::string& cert, const std::string& pkey) {
-  boost::filesystem::path ca_path = config_.tls.certificates_directory / "bootstrap_ca.pem";
-  boost::filesystem::path cert_path = config_.tls.certificates_directory / "bootstrap_cert.pem";
-  boost::filesystem::path pkey_path = config_.tls.certificates_directory / "bootstrap_pkey.pem";
-  storeTlsCredsCommon(ca_path, cert_path, pkey_path, ca, cert, pkey);
-}
-
 void FSStorage::storeTlsCreds(const std::string& ca, const std::string& cert, const std::string& pkey) {
   boost::filesystem::path ca_path = config_.tls.certificates_directory / config_.tls.ca_file;
   boost::filesystem::path cert_path = config_.tls.certificates_directory / config_.tls.client_certificate;
@@ -92,18 +71,11 @@ bool FSStorage::loadTlsCredsCommon(const boost::filesystem::path& ca_path, const
       !boost::filesystem::exists(pkey_path))
     return false;
 
-  if (ca) *ca = Utils::readFile(ca_path.native());
-  if (cert) *cert = Utils::readFile(cert_path.native());
-  if (pkey) *pkey = Utils::readFile(pkey_path.native());
+  if (ca) *ca = Utils::readFile(ca_path.string());
+  if (cert) *cert = Utils::readFile(cert_path.string());
+  if (pkey) *pkey = Utils::readFile(pkey_path.string());
 
   return true;
-}
-
-bool FSStorage::loadBootstrapTlsCreds(std::string* ca, std::string* cert, std::string* pkey) {
-  boost::filesystem::path ca_path = config_.tls.certificates_directory / "bootstrap_ca.pem";
-  boost::filesystem::path cert_path = config_.tls.certificates_directory / "bootstrap_cert.pem";
-  boost::filesystem::path pkey_path = config_.tls.certificates_directory / "bootstrap_pkey.pem";
-  return loadTlsCredsCommon(ca_path, cert_path, pkey_path, ca, cert, pkey);
 }
 
 bool FSStorage::loadTlsCreds(std::string* ca, std::string* cert, std::string* pkey) {
@@ -113,16 +85,22 @@ bool FSStorage::loadTlsCreds(std::string* ca, std::string* cert, std::string* pk
   return loadTlsCredsCommon(ca_path, cert_path, pkey_path, ca, cert, pkey);
 }
 
+void FSStorage::clearTlsCreds() {
+  boost::filesystem::remove(config_.tls.certificates_directory / config_.tls.ca_file);
+  boost::filesystem::remove(config_.tls.certificates_directory / config_.tls.client_certificate);
+  boost::filesystem::remove(config_.tls.certificates_directory / config_.tls.pkey_file);
+}
+
 void FSStorage::storeMetadata(const Uptane::MetaPack& metadata) {
   boost::filesystem::path image_path = config_.uptane.metadata_path / "repo";
   boost::filesystem::path director_path = config_.uptane.metadata_path / "director";
 
-  Utils::writeFile((director_path / "root.json").native(), metadata.director_root.toJson());
-  Utils::writeFile((director_path / "targets.json").native(), metadata.director_targets.toJson());
-  Utils::writeFile((image_path / "root.json").native(), metadata.image_root.toJson());
-  Utils::writeFile((image_path / "targets.json").native(), metadata.image_targets.toJson());
-  Utils::writeFile((image_path / "timestamp.json").native(), metadata.image_timestamp.toJson());
-  Utils::writeFile((image_path / "snapshot.json").native(), metadata.image_snapshot.toJson());
+  Utils::writeFile((director_path / "root.json").string(), metadata.director_root.toJson());
+  Utils::writeFile((director_path / "targets.json").string(), metadata.director_targets.toJson());
+  Utils::writeFile((image_path / "root.json").string(), metadata.image_root.toJson());
+  Utils::writeFile((image_path / "targets.json").string(), metadata.image_targets.toJson());
+  Utils::writeFile((image_path / "timestamp.json").string(), metadata.image_timestamp.toJson());
+  Utils::writeFile((image_path / "snapshot.json").string(), metadata.image_snapshot.toJson());
   sync();
 }
 
@@ -168,4 +146,90 @@ bool FSStorage::loadMetadata(Uptane::MetaPack* metadata) {
   metadata->image_snapshot = Uptane::Snapshot(json);
 
   return true;
+}
+
+void FSStorage::storeDeviceId(const std::string& device_id) {
+  Utils::writeFile((config_.tls.certificates_directory / "device_id").string(), device_id);
+}
+
+bool FSStorage::loadDeviceId(std::string* device_id) {
+  if (!boost::filesystem::exists((config_.tls.certificates_directory / "device_id").string())) return false;
+
+  if (device_id) *device_id = Utils::readFile((config_.tls.certificates_directory / "device_id").string());
+  return true;
+}
+
+void FSStorage::clearDeviceId() { boost::filesystem::remove(config_.tls.certificates_directory / "device_id"); }
+
+void FSStorage::storeEcuRegistered() {
+  Utils::writeFile((config_.tls.certificates_directory / "is_registered").string(), std::string("1"));
+}
+
+bool FSStorage::loadEcuRegistered() {
+  return boost::filesystem::exists((config_.tls.certificates_directory / "is_registered").string());
+}
+
+void FSStorage::clearEcuRegistered() {
+  boost::filesystem::remove(config_.tls.certificates_directory / "is_registered");
+}
+
+void FSStorage::storeEcuSerials(const std::vector<std::pair<std::string, std::string> >& serials) {
+  if (serials.size() >= 1) {
+    Utils::writeFile((config_.tls.certificates_directory / "primary_ecu_serial").string(), serials[0].first);
+    Utils::writeFile((config_.tls.certificates_directory / "primary_ecu_hardware_id").string(), serials[0].second);
+
+    boost::filesystem::remove_all((config_.tls.certificates_directory / "secondaries_list"));
+    std::vector<std::pair<std::string, std::string> >::const_iterator it;
+    std::ofstream file((config_.tls.certificates_directory / "secondaries_list").string().c_str());
+    for (it = serials.begin() + 1; it != serials.end(); it++)
+      // Assuming that there are no tabs and linebreaks in serials and hardware ids
+      file << it->first << "\t" << it->second << "\n";
+    file.close();
+  }
+}
+
+bool FSStorage::loadEcuSerials(std::vector<std::pair<std::string, std::string> >* serials) {
+  std::string buf;
+  std::string serial;
+  std::string hw_id;
+  if (!boost::filesystem::exists((config_.tls.certificates_directory / "primary_ecu_serial"))) return false;
+  serial = Utils::readFile((config_.tls.certificates_directory / "primary_ecu_serial").string());
+  // use default hardware ID for backwards compatibility
+  if (!boost::filesystem::exists((config_.tls.certificates_directory / "primary_ecu_hardware_id"))) {
+    char hostname[200];
+    if (gethostname(hostname, 200) < 0) {
+      return false;
+    }
+    hw_id = hostname;
+  } else {
+    hw_id = Utils::readFile((config_.tls.certificates_directory / "primary_ecu_hardware_id").string());
+  }
+  if (serials) serials->push_back(std::pair<std::string, std::string>(serial, hw_id));
+
+  // return true for backwards compatibility
+  if (!boost::filesystem::exists((config_.tls.certificates_directory / "secondaries_list"))) {
+    return true;
+  }
+  std::ifstream file((config_.tls.certificates_directory / "secondaries_list").string().c_str());
+  while (std::getline(file, buf)) {
+    size_t tab = buf.find('\t');
+    serial = buf.substr(0, tab);
+    try {
+      hw_id = buf.substr(tab + 1);
+    } catch (const std::out_of_range& e) {
+      // LOGGER_LOG(LVL_error, "Malformed secondaries_list");
+      if (serials) serials->clear();
+      file.close();
+      return false;
+    }
+    if (serials) serials->push_back(std::pair<std::string, std::string>(serial, hw_id));
+  }
+  file.close();
+  return true;
+}
+
+void FSStorage::clearEcuSerials() {
+  boost::filesystem::remove(config_.tls.certificates_directory / "primary_ecu_serial");
+  boost::filesystem::remove(config_.tls.certificates_directory / "primary_hardware_id");
+  boost::filesystem::remove(config_.tls.certificates_directory / "secondaries_list");
 }

--- a/src/fsstorage.h
+++ b/src/fsstorage.h
@@ -27,23 +27,12 @@ class FSStorage : public INvStorage {
   virtual void storeEcuRegistered();
   virtual bool loadEcuRegistered();
   virtual void clearEcuRegistered();
-  // virtual bool filePreallocate(bool from_director, const std::string &filename, size_t size);
-  // virtual bool fileFeed(bool from_director, const std::string &filename, const uint8_t* buf, size_t len);
-  // virtual bool fileCommit(bool from_director, const std::string &filename);
-  // virtual void fileAbort(bool from_director, const std::string &filename);
 
  private:
   Config config_;
   // descriptors of currently downloaded files
   std::map<std::string, FILE*> director_files;
   std::map<std::string, FILE*> image_files;
-
-  bool loadTlsCredsCommon(const boost::filesystem::path& ca_path, const boost::filesystem::path& cert_path,
-                          const boost::filesystem::path& pkey_path, std::string* ca, std::string* cert,
-                          std::string* pkey);
-  void storeTlsCredsCommon(const boost::filesystem::path& ca_path, const boost::filesystem::path& cert_path,
-                           const boost::filesystem::path& pkey_path, const std::string& ca, const std::string& cert,
-                           const std::string& pkey);
 };
 
 #endif  // FSSTORAGE_H_

--- a/src/fsstorage.h
+++ b/src/fsstorage.h
@@ -10,16 +10,23 @@ class FSStorage : public INvStorage {
  public:
   FSStorage(const Config& config);
   virtual ~FSStorage();
-  virtual void storeEcu(bool is_primary, const std::string& hardware_id, const std::string& ecu_id,
-                        const std::string& public_key, const std::string& private_key);
-  virtual bool loadEcuKeys(bool is_primary, const std::string& hardware_id, const std::string& ecu_id,
-                           std::string* public_key, std::string* private_key);
-  virtual void storeBootstrapTlsCreds(const std::string& ca, const std::string& cert, const std::string& pkey);
-  virtual bool loadBootstrapTlsCreds(std::string* ca, std::string* cert, std::string* pkey);
+  virtual void storePrimaryKeys(const std::string& public_key, const std::string& private_key);
+  virtual bool loadPrimaryKeys(std::string* public_key, std::string* private_key);
+  virtual void clearPrimaryKeys();
   virtual void storeTlsCreds(const std::string& ca, const std::string& cert, const std::string& pkey);
   virtual bool loadTlsCreds(std::string* ca, std::string* cert, std::string* pkey);
+  virtual void clearTlsCreds();
   virtual void storeMetadata(const Uptane::MetaPack& metadata);
   virtual bool loadMetadata(Uptane::MetaPack* metadata);
+  virtual void storeDeviceId(const std::string& device_id);
+  virtual bool loadDeviceId(std::string* device_id);
+  virtual void clearDeviceId();
+  virtual void storeEcuSerials(const std::vector<std::pair<std::string, std::string> >& serials);
+  virtual bool loadEcuSerials(std::vector<std::pair<std::string, std::string> >* serials);
+  virtual void clearEcuSerials();
+  virtual void storeEcuRegistered();
+  virtual bool loadEcuRegistered();
+  virtual void clearEcuRegistered();
   // virtual bool filePreallocate(bool from_director, const std::string &filename, size_t size);
   // virtual bool fileFeed(bool from_director, const std::string &filename, const uint8_t* buf, size_t len);
   // virtual bool fileCommit(bool from_director, const std::string &filename);

--- a/src/invstorage.h
+++ b/src/invstorage.h
@@ -7,16 +7,23 @@
 class INvStorage {
  public:
   virtual ~INvStorage() { ; }
-  virtual void storeEcu(bool is_primary, const std::string& hardware_id, const std::string& ecu_id,
-                        const std::string& public_key, const std::string& private_key) = 0;
-  virtual bool loadEcuKeys(bool is_primary, const std::string& hardware_id, const std::string& ecu_id,
-                           std::string* public_key, std::string* private_key) = 0;
-  virtual void storeBootstrapTlsCreds(const std::string& ca, const std::string& cert, const std::string& pkey) = 0;
-  virtual bool loadBootstrapTlsCreds(std::string* ca, std::string* cert, std::string* pkey) = 0;
+  virtual void storePrimaryKeys(const std::string& public_key, const std::string& private_key) = 0;
+  virtual bool loadPrimaryKeys(std::string* public_key, std::string* private_key) = 0;
+  virtual void clearPrimaryKeys() = 0;
   virtual void storeTlsCreds(const std::string& ca, const std::string& cert, const std::string& pkey) = 0;
   virtual bool loadTlsCreds(std::string* ca, std::string* cert, std::string* pkey) = 0;
+  virtual void clearTlsCreds() = 0;
   virtual void storeMetadata(const Uptane::MetaPack& metadata) = 0;
   virtual bool loadMetadata(Uptane::MetaPack* metadata) = 0;
+  virtual void storeDeviceId(const std::string& device_id) = 0;
+  virtual bool loadDeviceId(std::string* device_id) = 0;
+  virtual void clearDeviceId() = 0;
+  virtual void storeEcuSerials(const std::vector<std::pair<std::string, std::string> >& serials) = 0;
+  virtual bool loadEcuSerials(std::vector<std::pair<std::string, std::string> >* serials) = 0;
+  virtual void clearEcuSerials() = 0;
+  virtual void storeEcuRegistered() = 0;
+  virtual bool loadEcuRegistered() = 0;
+  virtual void clearEcuRegistered() = 0;
   // Incremental file API
   // virtual bool filePreallocate(bool from_director, const std::string &filename, size_t size) = 0;
   // virtual bool fileFeed(bool from_director, const std::string &filename, const uint8_t* buf, size_t len) = 0;

--- a/src/sotauptaneclient.cc
+++ b/src/sotauptaneclient.cc
@@ -55,9 +55,7 @@ Json::Value SotaUptaneClient::OstreeInstall(const OstreePackage &package) {
 
 void SotaUptaneClient::reportHWInfo() {
   Json::Value hw_info = Utils::getHardwareInfo();
-  if (!hw_info.empty()) {
-    uptane_repo.http.put(config.tls.server + "/core/system_info", Utils::getHardwareInfo());
-  }
+  if (!hw_info.empty()) uptane_repo.http.put(config.tls.server + "/core/system_info", hw_info);
 }
 
 void SotaUptaneClient::reportInstalledPackages() {

--- a/src/sotauptaneclient.cc
+++ b/src/sotauptaneclient.cc
@@ -67,7 +67,7 @@ void SotaUptaneClient::reportInstalledPackages() {
 
 void SotaUptaneClient::runForever(command::Channel *commands_channel) {
   LOGGER_LOG(LVL_debug, "Checking if device is provisioned...");
-  if (!uptane_repo.deviceRegister() || !uptane_repo.ecuRegister()) {
+  if (!uptane_repo.initialize()) {
     throw std::runtime_error("Fatal error of tls or ecu device registration");
   }
   LOGGER_LOG(LVL_debug, "... provisioned OK");

--- a/src/uptane/initialize.cc
+++ b/src/uptane/initialize.cc
@@ -1,0 +1,290 @@
+#include <string>
+
+#include "bootstrap.h"
+#include "logger.h"
+#include "uptane/uptanerepository.h"
+namespace Uptane {
+
+// Postcondition: device_id is in the storage
+bool Repository::initDeviceId(const UptaneConfig& uptane_config) {
+  // if device_id is already stored, just return
+  std::string device_id;
+  if (storage.loadDeviceId(&device_id)) return true;
+
+  // if device_id is specified in config, just use it, otherwise generate a  random one
+  device_id = uptane_config.device_id;
+  if (device_id.empty()) device_id = Utils::genPrettyName();
+
+  storage.storeDeviceId(device_id);
+  return true;
+}
+void Repository::resetDeviceId() { storage.clearDeviceId(); }
+
+// Postcondition [(serial, hw_id)] is in the storage
+bool Repository::initEcuSerials(UptaneConfig& uptane_config) {
+  if (storage.loadEcuSerials(NULL)) return true;
+
+  std::vector<std::pair<std::string, std::string> > ecu_serials;
+  std::string primary_ecu_serial_local = uptane_config.primary_ecu_serial;
+  if (primary_ecu_serial_local.empty()) primary_ecu_serial_local = Utils::randomUuid();
+
+  std::string primary_ecu_hardware_id = uptane_config.primary_ecu_hardware_id;
+  if (primary_ecu_hardware_id.empty()) {
+    char hostname[200];
+    if (gethostname(hostname, 200) < 0) return false;
+    primary_ecu_hardware_id = hostname;
+  }
+
+  ecu_serials.push_back(std::pair<std::string, std::string>(primary_ecu_serial_local, primary_ecu_hardware_id));
+
+  std::vector<Uptane::SecondaryConfig>::iterator it;
+  int index = 0;
+  for (it = uptane_config.secondaries.begin(); it != uptane_config.secondaries.end(); ++it) {
+    std::string secondary_ecu_serial = it->ecu_serial;
+    if (secondary_ecu_serial.empty())
+      secondary_ecu_serial = Utils::intToString(index++) + "-" + primary_ecu_serial_local;
+    std::string secondary_ecu_hardware_id = it->ecu_hardware_id;
+    if (secondary_ecu_hardware_id.empty()) {
+      secondary_ecu_hardware_id = primary_ecu_hardware_id;
+    }
+    ecu_serials.push_back(std::pair<std::string, std::string>(secondary_ecu_serial, secondary_ecu_hardware_id));
+    it->ecu_serial = secondary_ecu_serial;
+    it->ecu_hardware_id = secondary_ecu_hardware_id;
+  }
+
+  storage.storeEcuSerials(ecu_serials);
+  primary_ecu_serial = ecu_serials[0].first;
+  std::vector<Uptane::SecondaryConfig>::iterator conf_it;
+  for (conf_it = config.uptane.secondaries.begin(); conf_it != config.uptane.secondaries.end(); ++conf_it) {
+    // TODO: creating secondaries should be a responsibility of SotaUptaneClient, not Repository
+    //   It also kind of duplicates what is done in InitEcuSerials()
+    Secondary s(*conf_it, this);
+    secondaries.push_back(s);
+  }
+
+  return true;
+}
+
+void Repository::resetEcuSerials() {
+  storage.clearEcuSerials();
+  primary_ecu_serial = "";
+  secondaries.clear();
+}
+
+// Postcondition: (public, private) is in the storage. It should not be stored until secondaries are provisioned
+bool Repository::initEcuKeys() {
+  if (storage.loadPrimaryKeys(NULL, NULL)) return true;
+
+  std::string primary_public;
+  std::string primary_private;
+  if (!Crypto::generateRSAKeyPair(&primary_public, &primary_private)) return false;
+
+  std::vector<std::pair<std::string, std::string> > ecu_serials;
+  // InitEcuSerials should have been called by this point
+  if (!storage.loadEcuSerials(&ecu_serials) || ecu_serials.size() < 1) return false;
+
+  std::vector<std::pair<std::string, std::string> >::const_iterator it;
+  // skip first element, that is primary serial
+  for (it = ecu_serials.begin() + 1; it != ecu_serials.end(); it++) {
+    std::string secondary_public;
+    std::string secondary_keytype;
+    if (!transport.reqPublicKey(it->first, &secondary_keytype, &secondary_public)) {
+      std::string secondary_private;
+      if (!Crypto::generateRSAKeyPair(&secondary_public, &secondary_private)) {
+        LOGGER_LOG(LVL_error, "Could not generate rsa keys for secondary " << it->second << "@" << it->first);
+        return false;
+      }
+      transport.sendKeys(it->first, secondary_public, secondary_private);
+    }
+  }
+  storage.storePrimaryKeys(primary_public, primary_private);
+  primary_public_key = primary_public;
+  primary_private_key = primary_private;
+  return true;
+}
+
+void Repository::resetEcuKeys() {
+  storage.clearPrimaryKeys();
+  primary_public_key = "";
+  primary_private_key = "";
+}
+
+// Postcondition: TLS credentials are in the storage
+InitRetCode Repository::initTlsCreds(const ProvisionConfig& provision_config) {
+  std::string pkey;
+  std::string cert;
+  std::string ca;
+  if (storage.loadTlsCreds(&ca, &cert, &pkey)) {
+    LOGGER_LOG(LVL_trace, "Device already registered, proceeding");
+    // set provisioned credentials
+    http.setCerts(ca, cert, pkey);
+    return INIT_RET_OK;
+  }
+  // set bootstrap credentials
+  Bootstrap boot(provision_config.provision_path, provision_config.p12_password);
+  http.setCerts(boot.getCa(), boot.getCert(), boot.getPkey());
+
+  Json::Value data;
+  std::string device_id;
+  if (!storage.loadDeviceId(&device_id)) {
+    LOGGER_LOG(LVL_error, "device_id unknown during autoprovisioning process");
+    return INIT_RET_STORAGE_FAILURE;
+  }
+  data["deviceId"] = device_id;
+  data["ttl"] = provision_config.expiry_days;
+  HttpResponse response = http.post(provision_config.server + "/devices", data);
+  if (!response.isOk()) {
+    Json::Value resp_code = response.getJson()["code"];
+    if (resp_code.isString() && resp_code.asString() == "device_already_registered") {
+      LOGGER_LOG(LVL_error, "Device id" << device_id << "is occupied");
+      return INIT_RET_OCCUPIED;
+    } else {
+      LOGGER_LOG(LVL_error, "Autoprovisioning failed, response: " << response.body);
+      return INIT_RET_SERVER_FAILURE;
+    }
+  }
+
+  FILE* device_p12 = fmemopen(const_cast<char*>(response.body.c_str()), response.body.size(), "rb");
+  if (!Crypto::parseP12(device_p12, "", &pkey, &cert, &ca)) {
+    return INIT_RET_BAD_P12;
+  }
+  fclose(device_p12);
+  storage.storeTlsCreds(ca, cert, pkey);
+
+  // set provisioned credentials
+  http.setCerts(ca, cert, pkey);
+
+  // TODO: acknowledgement to the server
+  LOGGER_LOG(LVL_info, "Provisioned successfully on Device Gateway");
+  return INIT_RET_OK;
+}
+void Repository::resetTlsCreds() { storage.clearTlsCreds(); }
+
+// Postcondition: "ECUs registered" flag set in the storage
+InitRetCode Repository::initEcuRegister() {
+  if (storage.loadEcuRegistered()) return INIT_RET_OK;
+
+  std::string primary_public;
+  if (!storage.loadPrimaryKeys(&primary_public, NULL)) {
+    LOGGER_LOG(LVL_error, "Unable to read primary public key from the storage");
+    return INIT_RET_STORAGE_FAILURE;
+  }
+
+  std::vector<std::pair<std::string, std::string> > ecu_serials;
+  // InitEcuSerials should have been called by this point
+  if (!storage.loadEcuSerials(&ecu_serials) || ecu_serials.size() < 1) return INIT_RET_STORAGE_FAILURE;
+
+  Json::Value all_ecus;
+  all_ecus["primary_ecu_serial"] = ecu_serials[0].first;
+  all_ecus["ecus"] = Json::arrayValue;
+  {
+    Json::Value primary_ecu;
+    primary_ecu["hardware_identifier"] = ecu_serials[0].second;
+    primary_ecu["ecu_serial"] = ecu_serials[0].first;
+    primary_ecu["clientKey"]["keytype"] = "RSA";
+    primary_ecu["clientKey"]["keyval"]["public"] = primary_public;
+    all_ecus["ecus"].append(primary_ecu);
+  }
+
+  std::vector<std::pair<std::string, std::string> >::const_iterator it;
+  for (it = ecu_serials.begin() + 1; it != ecu_serials.end(); it++) {
+    std::string secondary_public;
+    std::string secondary_keytype;
+    if (!transport.reqPublicKey(it->first, &secondary_keytype, &secondary_public)) {
+      LOGGER_LOG(LVL_error, "Unable to read public key from secondary " << it->first);
+      return INIT_RET_SECONDARY_FAILURE;
+    }
+    Json::Value ecu;
+    ecu["hardware_identifier"] = it->second;
+    ecu["ecu_serial"] = it->first;
+    ecu["clientKey"]["keytype"] = secondary_keytype;
+    ecu["clientKey"]["keyval"]["public"] = secondary_public;
+    all_ecus["ecus"].append(ecu);
+  }
+
+  HttpResponse response = http.post(config.tls.server + "/director/ecus", all_ecus);
+  if (!response.isOk()) {
+    Json::Value resp_code = response.getJson()["code"];
+    if (resp_code.isString() &&
+        (resp_code.asString() == "ecu_already_registered" || resp_code.asString() == "device_already_registered")) {
+      LOGGER_LOG(LVL_error, "Some ECU is already registered");
+      return INIT_RET_OCCUPIED;
+    } else {
+      LOGGER_LOG(LVL_error, "Error registering device on Uptane, response: " << response.body);
+      return INIT_RET_SERVER_FAILURE;
+    }
+  }
+  // do not call storage.storeEcuRegistered(), it will be called from the top-level Init function after the
+  // acknowledgement
+  LOGGER_LOG(LVL_info, "ECUs have been successfully registered to the server");
+  return INIT_RET_OK;
+}
+
+// Postcondition: "ECUs registered" flag set in the storage
+bool Repository::initialize() {
+  if (storage.loadEcuRegistered()) return true;
+
+  // if device has aready been registered, just create new device and reprovision
+  //   it should be changed/fixed when the backend supports registration acknowledgement
+  for (int i = 0; i < MaxInitializationAttempts; i++) {
+    if (!initDeviceId(config.uptane)) {
+      LOGGER_LOG(LVL_error, "Device ID generation failed, abort initialization");
+      return false;
+    }
+    if (!initEcuSerials(config.uptane)) {
+      LOGGER_LOG(LVL_error, "ECU serial generation failed, abort initialization");
+      return false;
+    }
+    if (!initEcuKeys()) {
+      LOGGER_LOG(LVL_error, "ECU key generation failed, abort initialization");
+      return false;
+    }
+    InitRetCode ret_code = initTlsCreds(config.provision);
+    if (ret_code == INIT_RET_OCCUPIED) {
+      resetEcuKeys();
+      resetEcuSerials();
+      resetDeviceId();
+      LOGGER_LOG(LVL_info, "Device name is already registered, restart");
+      continue;
+    } else if (ret_code != INIT_RET_OK) {
+      LOGGER_LOG(LVL_error, "Autoprovisioning failed, abort initialization");
+      return false;
+    }
+
+    ret_code = initEcuRegister();
+    if (ret_code == INIT_RET_OCCUPIED) {
+      // TODO: proper way to process this case after acknowledgement is implemented on the server
+      //   is to download the list of registered ECUs and compare it to the list of ECUs present.
+      //   If they coincide, that means that the registration has already been done by this device,
+      //   but the registration process has been interrupted between sending the acknowledgement
+      //   and setting the flag in the storage. Otherwise we have a name collision and should re-run
+      //   initialization process.
+      //   Now we will just repeat initialization all the time.
+      resetTlsCreds();
+      resetEcuKeys();
+      resetEcuSerials();
+      resetDeviceId();
+      LOGGER_LOG(LVL_info, "ECU serial is already registered, restart");
+      continue;
+
+    } else if (ret_code != INIT_RET_OK) {
+      LOGGER_LOG(LVL_error, "ECU registration failed, abort initialization");
+      return false;
+    }
+
+    // TODO: acknowledge on server _before_ setting the flag
+    storage.storeEcuRegistered();
+    return true;
+  }
+  LOGGER_LOG(LVL_error, "Initialization failed after " << MaxInitializationAttempts << " attempts");
+  return false;
+}
+
+void Repository::initReset() {
+  storage.clearEcuRegistered();
+  resetTlsCreds();
+  resetEcuKeys();
+  resetEcuSerials();
+  resetDeviceId();
+}
+}

--- a/src/uptane/initialize.cc
+++ b/src/uptane/initialize.cc
@@ -29,11 +29,7 @@ bool Repository::initEcuSerials(UptaneConfig& uptane_config) {
   if (primary_ecu_serial_local.empty()) primary_ecu_serial_local = Utils::randomUuid();
 
   std::string primary_ecu_hardware_id = uptane_config.primary_ecu_hardware_id;
-  if (primary_ecu_hardware_id.empty()) {
-    char hostname[200];
-    if (gethostname(hostname, 200) < 0) return false;
-    primary_ecu_hardware_id = hostname;
-  }
+  if (primary_ecu_hardware_id.empty()) primary_ecu_hardware_id = Utils::getHostname();
 
   ecu_serials.push_back(std::pair<std::string, std::string>(primary_ecu_serial_local, primary_ecu_hardware_id));
 

--- a/src/uptane/secondary.h
+++ b/src/uptane/secondary.h
@@ -16,8 +16,9 @@ class Secondary {
   data::InstallOutcome install(const Uptane::Target &target);
   Json::Value genAndSendManifest(Json::Value custom = Json::Value(Json::nullValue));
   Json::Value newTargetsCallBack(const std::vector<Target> &targets);
-  void setPrivateKey(const std::string &pkey);
+  void setKeys(const std::string &public_key, const std::string &private_key);
   std::string getEcuSerial() { return config.ecu_serial; }
+  bool getPublicKey(std::string *key);
 
  private:
   SecondaryConfig config;

--- a/src/uptane/testbusprimary.cc
+++ b/src/uptane/testbusprimary.cc
@@ -21,17 +21,29 @@ Json::Value TestBusPrimary::sendTargets(const std::vector<Uptane::Target> &targe
   return manifests;
 }
 
-void TestBusPrimary::sendPrivateKey(const std::string &ecu_serial, const std::string &key) {
+void TestBusPrimary::sendKeys(const std::string &ecu_serial, const std::string &public_key,
+                              const std::string &private_key) {
   std::vector<Secondary>::iterator it;
   bool found = false;
   for (it = secondaries_->begin(); it != secondaries_->end(); ++it) {
     if (ecu_serial == it->getEcuSerial()) {
-      it->setPrivateKey(key);
+      it->setKeys(public_key, private_key);
       found = true;
     }
   }
   if (!found) {
     throw std::runtime_error("ecu_serial - " + ecu_serial + " not found");
   }
+}
+
+bool TestBusPrimary::reqPublicKey(const std::string &ecu_serial, std::string *keytype, std::string *key) {
+  std::vector<Secondary>::iterator it;
+  for (it = secondaries_->begin(); it != secondaries_->end(); ++it) {
+    if (ecu_serial == it->getEcuSerial()) {
+      *keytype = "RSA";
+      return it->getPublicKey(key);
+    }
+  }
+  throw std::runtime_error("ecu_serial - " + ecu_serial + " not found");
 }
 }

--- a/src/uptane/testbusprimary.h
+++ b/src/uptane/testbusprimary.h
@@ -12,7 +12,8 @@ class TestBusPrimary {
   TestBusPrimary(std::vector<Secondary> *secondaries);
   virtual Json::Value getManifests();
   virtual Json::Value sendTargets(const std::vector<Target> &targets);
-  virtual void sendPrivateKey(const std::string &ecu_serial, const std::string &key);
+  virtual void sendKeys(const std::string &ecu_serial, const std::string &public_key, const std::string &private_key);
+  virtual bool reqPublicKey(const std::string &ecu_serial, std::string *keytype, std::string *key);
 
  private:
   std::vector<Secondary> *secondaries_;

--- a/src/uptane/uptanerepository.cc
+++ b/src/uptane/uptanerepository.cc
@@ -27,22 +27,7 @@ Repository::Repository(const Config &config_in, INvStorage &storage_in)
       storage(storage_in),
       http(),
       manifests(Json::arrayValue),
-      transport(&secondaries) {
-  std::vector<std::pair<std::string, std::string> > ecu_serials;
-  if (storage.loadEcuSerials(&ecu_serials)) {
-    primary_ecu_serial = ecu_serials[0].first;
-    std::vector<Uptane::SecondaryConfig>::iterator it;
-    for (it = config.uptane.secondaries.begin(); it != config.uptane.secondaries.end(); ++it) {
-      // TODO: creating secondaries should be a responsibility of SotaUptaneClient, not Repository
-      //   It also kind of duplicates what is done in InitEcuSerials()
-      Secondary s(*it, this);
-      secondaries.push_back(s);
-    }
-  }
-
-  // The function can return false leaving the keys empty.
-  storage.loadPrimaryKeys(&primary_public_key, &primary_private_key);
-}
+      transport(&secondaries) {}
 
 void Repository::updateRoot(Version version) {
   director.updateRoot(version);

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -230,6 +230,14 @@ Json::Value Utils::getHardwareInfo() {
   }
 }
 
+std::string Utils::getHostname() {
+  char hostname[200];
+  if (gethostname(hostname, 200) < 0) {
+    return "";
+  }
+  return hostname;
+}
+
 std::string Utils::randomUuid() {
   boost::random::random_device urandom;
   boost::uuids::basic_random_generator<boost::random::random_device> uuid_gen(urandom);
@@ -237,7 +245,7 @@ std::string Utils::randomUuid() {
 }
 
 void Utils::copyDir(const boost::filesystem::path &from, const boost::filesystem::path &to) {
-  if (boost::filesystem::exists(to)) boost::filesystem::remove_all(to);
+  boost::filesystem::remove_all(to);
 
   boost::filesystem::create_directories(to);
   boost::filesystem::directory_iterator it(from);

--- a/src/utils.h
+++ b/src/utils.h
@@ -18,6 +18,7 @@ struct Utils {
   static void writeFile(const std::string &filename, const Json::Value &content);
   static void copyDir(const boost::filesystem::path &from, const boost::filesystem::path &to);
   static Json::Value getHardwareInfo();
+  static std::string getHostname();
   static std::string randomUuid();
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -122,6 +122,7 @@ if(BUILD_OSTREE)
                   ${PROJECT_SOURCE_DIR}/src/uptane/tuf.cc
                   ${PROJECT_SOURCE_DIR}/src/uptane/tufrepository.cc
                   ${PROJECT_SOURCE_DIR}/src/uptane/uptanerepository.cc
+                  ${PROJECT_SOURCE_DIR}/src/uptane/initialize.cc
                   ${PROJECT_SOURCE_DIR}/src/uptane/secondary.cc
                   ${PROJECT_SOURCE_DIR}/src/uptane/testbusprimary.cc
                   ${PROJECT_SOURCE_DIR}/src/uptane/testbussecondary.cc

--- a/tests/config_test.cc
+++ b/tests/config_test.cc
@@ -130,31 +130,6 @@ TEST(config, config_extract_credentials) {
 }
 
 /**
- * \verify{\tst{155}} Check that aktualizr generates random ecu_serial for
- * primary and all secondaries.
- */
-TEST(config, test_random_serial) {
-  boost::program_options::variables_map cmd;
-  boost::program_options::options_description description("some text");
-  description.add_options()("secondary-config", bpo::value<std::vector<std::string> >()->composing(),
-                            "set config for secondary");
-  const char *argv[] = {"aktualizr", "--secondary-config", "tests/test_data/secondary_serial.json"};
-  boost::program_options::store(boost::program_options::parse_command_line(3, argv, description), cmd);
-
-  boost::filesystem::remove_all(config_test_dir);
-  Config conf1("tests/config_tests.toml", cmd);
-  boost::filesystem::remove_all(config_test_dir);
-  Config conf2("tests/config_tests.toml", cmd);
-
-  EXPECT_NE(conf1.uptane.primary_ecu_serial, conf2.uptane.primary_ecu_serial);
-  EXPECT_EQ(conf1.uptane.secondaries.size(), 1);
-  EXPECT_EQ(conf2.uptane.secondaries.size(), 1);
-  EXPECT_NE(conf1.uptane.secondaries[0].ecu_serial, conf2.uptane.secondaries[0].ecu_serial);
-
-  boost::filesystem::remove_all(config_test_dir);
-}
-
-/**
  * \verify{\tst{156}} Check that aktualizr saves random ecu_serial for primary
  * and all secondaries.
  */
@@ -174,77 +149,6 @@ TEST(config, ecu_persist) {
   EXPECT_EQ(conf1.uptane.secondaries.size(), 1);
   EXPECT_EQ(conf2.uptane.secondaries.size(), 1);
   EXPECT_EQ(conf1.uptane.secondaries[0].ecu_serial, conf2.uptane.secondaries[0].ecu_serial);
-
-  boost::filesystem::remove_all(config_test_dir);
-}
-
-/**
- * \verify{\tst{146}} Check that aktualizr does not generate a pet name when
- * device ID is specified. This is currently provisional and not a finalized
- * requirement at this time.
- */
-TEST(config, config_pet_name_provided) {
-  std::string test_name = "test-name-123";
-  std::string device_path = config_test_dir + "/device_id";
-  boost::filesystem::remove(device_path);
-
-  /* Make sure provided device ID is read as expected. */
-  Config conf("tests/config_tests_device_id.toml");
-  EXPECT_EQ(conf.uptane.device_id, test_name);
-  EXPECT_TRUE(boost::filesystem::exists(device_path));
-  EXPECT_EQ(Utils::readFile(device_path), test_name);
-
-  /* Make sure name is unchanged after re-initializing config. */
-  conf.postUpdateValues();
-  EXPECT_EQ(conf.uptane.device_id, test_name);
-  EXPECT_TRUE(boost::filesystem::exists(device_path));
-  EXPECT_EQ(Utils::readFile(device_path), test_name);
-
-  boost::filesystem::remove_all(config_test_dir);
-}
-
-/**
- * \verify{\tst{145}} Check that aktualizr generates a pet name if no device ID
- * is specified.
- */
-TEST(config, config_pet_name_creation) {
-  std::string device_path = config_test_dir + "/device_id";
-  boost::filesystem::remove(device_path);
-
-  /* Make sure name is created. */
-  Config conf("tests/config_tests.toml");
-  std::string test_name1 = conf.uptane.device_id;
-  EXPECT_TRUE(boost::filesystem::exists(device_path));
-  std::string test_name2 = Utils::readFile(device_path);
-  EXPECT_EQ(test_name1, test_name2);
-
-  /* Make sure a new name is generated if the config does not specify a name and
-   * there is no device_id file. */
-  conf.uptane.device_id = "";
-  boost::filesystem::remove(device_path);
-  conf.postUpdateValues();
-  std::string test_name3 = conf.uptane.device_id;
-  EXPECT_NE(test_name1, test_name3);
-  EXPECT_TRUE(boost::filesystem::exists(device_path));
-  std::string test_name4 = Utils::readFile(device_path);
-  EXPECT_EQ(test_name3, test_name4);
-
-  /* If the device_id is cleared in the config, but the file is still present,
-   * re-initializing the config should still read the device_id from file. */
-  conf.uptane.device_id = "";
-  conf.postUpdateValues();
-  EXPECT_EQ(conf.uptane.device_id, test_name3);
-  EXPECT_TRUE(boost::filesystem::exists(device_path));
-  EXPECT_EQ(Utils::readFile(device_path), test_name3);
-
-  /* If the device_id file is removed, but the field is still present in the
-   * config, re-initializing the config should still read the device_id from
-   * config. */
-  boost::filesystem::remove(device_path);
-  conf.postUpdateValues();
-  EXPECT_EQ(conf.uptane.device_id, test_name3);
-  EXPECT_TRUE(boost::filesystem::exists(device_path));
-  EXPECT_EQ(Utils::readFile(device_path), test_name3);
 
   boost::filesystem::remove_all(config_test_dir);
 }

--- a/tests/config_tests_device_id.toml
+++ b/tests/config_tests_device_id.toml
@@ -24,3 +24,7 @@ client_config = "my/rvi_conf.json"
 
 [uptane]
 device_id = "test-name-123"
+
+[provision]
+provision_path = "tests/test_data/cred.zip"
+p12_password = ""

--- a/tests/crypto_test.cc
+++ b/tests/crypto_test.cc
@@ -70,6 +70,14 @@ TEST(crypto, verify_ed25519) {
   EXPECT_FALSE(signe_is_ok);
 }
 
+TEST(crypto, bad_keytype) {
+  try {
+    PublicKey pkey("somekey", "nosuchtype");
+    FAIL();
+  } catch (std::runtime_error ex) {
+  }
+}
+
 TEST(crypto, parsep12) {
   std::string pkey;
   std::string cert;

--- a/tests/crypto_test.cc
+++ b/tests/crypto_test.cc
@@ -29,7 +29,8 @@ TEST(crypto, sha512_is_correct) {
 TEST(crypto, sign_verify_rsa) {
   std::string text = "This is text for sign";
   PublicKey pkey(Utils::readFile("tests/test_data/public.key"), "rsa");
-  std::string signature = Utils::toBase64(Crypto::RSAPSSSign("tests/test_data/priv.key", text));
+  std::string private_key = Utils::readFile("tests/test_data/priv.key");
+  std::string signature = Utils::toBase64(Crypto::RSAPSSSign(private_key, text));
   bool signe_is_ok = Crypto::VerifySignature(pkey, signature, text);
   EXPECT_TRUE(signe_is_ok);
 }

--- a/tests/uptane_test.cc
+++ b/tests/uptane_test.cc
@@ -398,7 +398,6 @@ TEST(uptane, pet_name_provided) {
   Utils::copyDir("tests/test_data", uptane_test_dir);
   std::string test_name = "test-name-123";
   std::string device_path = uptane_test_dir + "/device_id";
-  boost::filesystem::remove(device_path);
 
   /* Make sure provided device ID is read as expected. */
   Config conf("tests/config_tests_device_id.toml");
@@ -431,7 +430,6 @@ TEST(uptane, pet_name_provided) {
 TEST(uptane, pet_name_creation) {
   Utils::copyDir("tests/test_data", uptane_test_dir);
   std::string device_path = uptane_test_dir + "/device_id";
-  boost::filesystem::remove(device_path);
 
   // Make sure name is created.
   Config conf("tests/config_tests.toml");
@@ -511,13 +509,6 @@ TEST(SotaUptaneClientTest, initialize_fail) {
   conf.uptane.private_key_path = "private.key";
   conf.uptane.public_key_path = "public.key";
 
-  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.client_certificate);
-  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.ca_file);
-  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.pkey_file);
-  boost::filesystem::remove(conf.tls.certificates_directory / "bootstrap_ca.pem");
-  boost::filesystem::remove(conf.tls.certificates_directory / "bootstrap_cert.pem");
-  boost::filesystem::remove(conf.tls.certificates_directory / "bootstrap_pkey.pem");
-
   FSStorage storage(conf);
   Uptane::Repository uptane(conf, storage);
 
@@ -579,12 +570,6 @@ TEST(SotaUptaneClientTest, RunForeverNoUpdates) {
   conf.uptane.private_key_path = "private.key";
   conf.uptane.public_key_path = "public.key";
 
-  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.client_certificate);
-  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.ca_file);
-  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.pkey_file);
-  boost::filesystem::remove(metadata_path + "/director/timestamp.json");
-  boost::filesystem::remove(metadata_path + "/repo/timestamp.json");
-
   conf.tls.server = tls_server;
   event::Channel events_channel;
   command::Channel commands_channel;
@@ -642,12 +627,6 @@ TEST(SotaUptaneClientTest, RunForeverHasUpdates) {
   ecu_config.ecu_public_key = "sec1.pub";
   conf.uptane.secondaries.push_back(ecu_config);
 
-  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.client_certificate);
-  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.ca_file);
-  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.pkey_file);
-  boost::filesystem::remove(metadata_path + "/director/timestamp.json");
-  boost::filesystem::remove(metadata_path + "/repo/timestamp.json");
-
   conf.tls.server = tls_server;
   event::Channel events_channel;
   command::Channel commands_channel;
@@ -684,9 +663,6 @@ TEST(SotaUptaneClientTest, RunForeverInstall) {
   conf.tls.certificates_directory = uptane_test_dir;
   conf.uptane.repo_server = tls_server + "/repo";
 
-  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.client_certificate);
-  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.ca_file);
-  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.pkey_file);
   boost::filesystem::remove(test_manifest);
 
   conf.tls.server = tls_server;

--- a/tests/uptane_test.cc
+++ b/tests/uptane_test.cc
@@ -209,8 +209,8 @@ TEST(uptane, sign) {
   config.uptane.director_server = tls_server + "/director";
   config.tls.certificates_directory = uptane_test_dir;
   config.uptane.repo_server = tls_server + "/repo";
-  config.uptane.private_key_path = (config.tls.certificates_directory / "priv.key").string();
-  config.uptane.public_key_path = (config.tls.certificates_directory / "public.key").string();
+  config.uptane.private_key_path = "priv.key";
+  config.uptane.public_key_path = "public.key";
 
   FSStorage storage(config);
   Uptane::Repository uptane_repo(config, storage);
@@ -218,7 +218,11 @@ TEST(uptane, sign) {
   Json::Value tosign_json;
   tosign_json["mykey"] = "value";
 
-  Json::Value signed_json = Crypto::signTuf(config.uptane.private_key_path, config.uptane.public_key_path, tosign_json);
+  std::string private_key =
+      Utils::readFile((config.tls.certificates_directory / config.uptane.private_key_path).string());
+  std::string public_key =
+      Utils::readFile((config.tls.certificates_directory / config.uptane.public_key_path).string());
+  Json::Value signed_json = Crypto::signTuf(private_key, public_key, tosign_json);
   EXPECT_EQ(signed_json["signed"]["mykey"].asString(), "value");
   EXPECT_EQ(signed_json["signatures"][0]["keyid"].asString(),
             "6a809c62b4f6c2ae11abfb260a6a9a57d205fc2887ab9c83bd6be0790293e187");
@@ -231,8 +235,19 @@ TEST(uptane, sign) {
  * \verify{\tst{153}} Check that aktualizr creates provisioning files if they
  * don't exist already.
  */
-TEST(SotaUptaneClientTest, device_registered) {
+TEST(SotaUptaneClientTest, initialize) {
   Config conf("tests/config_tests_prov.toml");
+  Utils::copyDir("tests/test_data", uptane_test_dir);
+  conf.uptane.metadata_path = "tests/";
+  conf.uptane.repo_server = tls_server + "/director";
+  conf.tls.certificates_directory = uptane_test_dir + "/certs";
+
+  conf.uptane.repo_server = tls_server + "/repo";
+  conf.tls.server = tls_server;
+
+  conf.uptane.primary_ecu_serial = "testecuserial";
+  conf.uptane.private_key_path = "private.key";
+  conf.uptane.public_key_path = "public.key";
 
   boost::filesystem::remove_all(uptane_test_dir);
   EXPECT_FALSE(boost::filesystem::exists(conf.tls.certificates_directory / conf.tls.client_certificate));
@@ -251,11 +266,14 @@ TEST(SotaUptaneClientTest, device_registered) {
   EXPECT_FALSE(boost::filesystem::exists(conf.tls.certificates_directory / conf.tls.pkey_file));
 
   Uptane::Repository uptane(conf, storage);
-  result = uptane.deviceRegister();
+  result = uptane.initialize();
   EXPECT_TRUE(result);
   EXPECT_TRUE(boost::filesystem::exists(conf.tls.certificates_directory / conf.tls.client_certificate));
   EXPECT_TRUE(boost::filesystem::exists(conf.tls.certificates_directory / conf.tls.ca_file));
   EXPECT_TRUE(boost::filesystem::exists(conf.tls.certificates_directory / conf.tls.pkey_file));
+  Json::Value ecu_data = Utils::parseJSONFile(uptane_test_dir + "/post.json");
+  EXPECT_EQ(ecu_data["ecus"].size(), 1);
+  EXPECT_EQ(ecu_data["primary_ecu_serial"].asString(), conf.uptane.primary_ecu_serial);
 
   boost::filesystem::remove_all(uptane_test_dir);
 }
@@ -264,8 +282,13 @@ TEST(SotaUptaneClientTest, device_registered) {
  * \verify{\tst{154}} Check that aktualizr does NOT change provisioning files if
  * they DO exist already.
  */
-TEST(SotaUptaneClientTest, device_register_twice) {
+TEST(SotaUptaneClientTest, initialize_twice) {
   Config conf("tests/config_tests_prov.toml");
+  Utils::copyDir("tests/test_data", uptane_test_dir);
+  conf.tls.certificates_directory = uptane_test_dir + "/certs";
+  conf.uptane.primary_ecu_serial = "testecuserial";
+  conf.uptane.private_key_path = "private.key";
+  conf.uptane.public_key_path = "public.key";
 
   boost::filesystem::remove_all(uptane_test_dir);
   EXPECT_FALSE(boost::filesystem::exists(conf.tls.certificates_directory / conf.tls.client_certificate));
@@ -284,7 +307,7 @@ TEST(SotaUptaneClientTest, device_register_twice) {
   EXPECT_FALSE(boost::filesystem::exists(conf.tls.certificates_directory / conf.tls.pkey_file));
 
   Uptane::Repository uptane(conf, storage);
-  result = uptane.deviceRegister();
+  result = uptane.initialize();
   EXPECT_TRUE(result);
   EXPECT_TRUE(boost::filesystem::exists(conf.tls.certificates_directory / conf.tls.client_certificate));
   EXPECT_TRUE(boost::filesystem::exists(conf.tls.certificates_directory / conf.tls.ca_file));
@@ -293,7 +316,7 @@ TEST(SotaUptaneClientTest, device_register_twice) {
   result = storage.loadTlsCreds(&ca1, &cert1, &pkey1);
   EXPECT_TRUE(result);
 
-  result = uptane.deviceRegister();
+  result = uptane.initialize();
   EXPECT_TRUE(result);
   EXPECT_TRUE(boost::filesystem::exists(conf.tls.certificates_directory / conf.tls.client_certificate));
   EXPECT_TRUE(boost::filesystem::exists(conf.tls.certificates_directory / conf.tls.ca_file));
@@ -312,35 +335,213 @@ TEST(SotaUptaneClientTest, device_register_twice) {
   boost::filesystem::remove_all(uptane_test_dir);
 }
 
-TEST(SotaUptaneClientTest, device_registered_fail) {
+/**
+ * \verify{\tst{155}} Check that aktualizr generates random ecu_serial for
+ * primary and all secondaries.
+ */
+TEST(uptane, random_serial) {
+  Utils::copyDir("tests/test_data", uptane_test_dir);
+  Config conf_1("tests/config_tests_prov.toml");
+  conf_1.tls.certificates_directory = uptane_test_dir + "/certs_1";
+  boost::filesystem::remove_all(uptane_test_dir + "/certs_1");
+  Config conf_2("tests/config_tests_prov.toml");
+  conf_2.tls.certificates_directory = uptane_test_dir + "/certs_2";
+  boost::filesystem::remove_all(uptane_test_dir + "/certs_2");
+
+  conf_1.uptane.primary_ecu_serial = "l";
+  conf_1.uptane.private_key_path = "private.key";
+  conf_1.uptane.public_key_path = "public.key";
+
+  conf_2.uptane.primary_ecu_serial = "";
+  conf_2.uptane.private_key_path = "private.key";
+  conf_2.uptane.public_key_path = "public.key";
+
+  // add secondaries
+  Uptane::SecondaryConfig ecu_config;
+  ecu_config.full_client_dir = uptane_test_dir;
+  ecu_config.ecu_serial = "";
+  ecu_config.ecu_hardware_id = "";
+  ecu_config.ecu_private_key = "sec.priv";
+  ecu_config.ecu_public_key = "sec.pub";
+  ecu_config.firmware_path = "/tmp/firmware.txt";
+  conf_1.uptane.secondaries.push_back(ecu_config);
+  conf_2.uptane.secondaries.push_back(ecu_config);
+
+  FSStorage storage_1(conf_1);
+  FSStorage storage_2(conf_2);
+
+  Uptane::Repository uptane_1(conf_1, storage_1);
+  EXPECT_TRUE(uptane_1.initialize());
+
+  Uptane::Repository uptane_2(conf_2, storage_2);
+  EXPECT_TRUE(uptane_2.initialize());
+
+  std::vector<std::pair<std::string, std::string> > ecu_serials_1;
+  std::vector<std::pair<std::string, std::string> > ecu_serials_2;
+
+  EXPECT_TRUE(storage_1.loadEcuSerials(&ecu_serials_1));
+  EXPECT_TRUE(storage_2.loadEcuSerials(&ecu_serials_2));
+  EXPECT_EQ(ecu_serials_1.size(), 2);
+  EXPECT_EQ(ecu_serials_2.size(), 2);
+  EXPECT_NE(ecu_serials_1[0].first, ecu_serials_2[0].first);
+  EXPECT_NE(ecu_serials_1[1].first, ecu_serials_2[1].first);
+
+  boost::filesystem::remove_all(uptane_test_dir);
+}
+
+/**
+ * \verify{\tst{146}} Check that aktualizr does not generate a pet name when
+ * device ID is specified. This is currently provisional and not a finalized
+ * requirement at this time.
+ */
+TEST(uptane, pet_name_provided) {
+  Utils::copyDir("tests/test_data", uptane_test_dir);
+  std::string test_name = "test-name-123";
+  std::string device_path = uptane_test_dir + "/device_id";
+  boost::filesystem::remove(device_path);
+
+  /* Make sure provided device ID is read as expected. */
+  Config conf("tests/config_tests_device_id.toml");
+  conf.tls.certificates_directory = uptane_test_dir;
+  conf.uptane.primary_ecu_serial = "testecuserial";
+  conf.uptane.private_key_path = "private.key";
+  conf.uptane.public_key_path = "public.key";
+
+  FSStorage storage(conf);
+  Uptane::Repository uptane(conf, storage);
+  EXPECT_TRUE(uptane.initialize());
+
+  EXPECT_EQ(conf.uptane.device_id, test_name);
+  EXPECT_TRUE(boost::filesystem::exists(device_path));
+  EXPECT_EQ(Utils::readFile(device_path), test_name);
+
+  /* Make sure name is unchanged after re-initializing config. */
+  conf.postUpdateValues();
+  EXPECT_EQ(conf.uptane.device_id, test_name);
+  EXPECT_TRUE(boost::filesystem::exists(device_path));
+  EXPECT_EQ(Utils::readFile(device_path), test_name);
+
+  boost::filesystem::remove_all(uptane_test_dir);
+}
+
+/**
+ * \verify{\tst{145}} Check that aktualizr generates a pet name if no device ID
+ * is specified.
+ */
+TEST(uptane, pet_name_creation) {
+  Utils::copyDir("tests/test_data", uptane_test_dir);
+  std::string device_path = uptane_test_dir + "/device_id";
+  boost::filesystem::remove(device_path);
+
+  // Make sure name is created.
+  Config conf("tests/config_tests.toml");
+  conf.tls.certificates_directory = uptane_test_dir;
+  conf.uptane.primary_ecu_serial = "testecuserial";
+  conf.uptane.private_key_path = "private.key";
+  conf.uptane.public_key_path = "public.key";
+  conf.provision.provision_path = uptane_test_dir + "/cred.zip";
+
+  std::string test_name1, test_name2;
+  {
+    FSStorage storage(conf);
+    Uptane::Repository uptane(conf, storage);
+    EXPECT_TRUE(uptane.initialize());
+
+    EXPECT_TRUE(boost::filesystem::exists(device_path));
+    test_name1 = Utils::readFile(device_path);
+    EXPECT_NE(test_name1, "");
+  }
+
+  // Make sure a new name is generated if the config does not specify a name and
+  // there is no device_id file.
+  {
+    Utils::copyDir("tests/test_data", uptane_test_dir);
+    boost::filesystem::remove(device_path);
+    conf.uptane.device_id = "";
+
+    FSStorage storage(conf);
+    Uptane::Repository uptane(conf, storage);
+    EXPECT_TRUE(uptane.initialize());
+
+    EXPECT_TRUE(boost::filesystem::exists(device_path));
+    test_name2 = Utils::readFile(device_path);
+    EXPECT_NE(test_name2, test_name1);
+  }
+  // If the device_id is cleared in the config, but the file is still present,
+  // re-initializing the config should still read the device_id from file.
+  {
+    conf.uptane.device_id = "";
+    FSStorage storage(conf);
+    Uptane::Repository uptane(conf, storage);
+    EXPECT_TRUE(uptane.initialize());
+
+    EXPECT_TRUE(boost::filesystem::exists(device_path));
+    EXPECT_EQ(Utils::readFile(device_path), test_name2);
+  }
+
+  // If the device_id file is removed, but the field is still present in the
+  // config, re-initializing the config should still read the device_id from
+  // config.
+  {
+    Utils::copyDir("tests/test_data", uptane_test_dir);
+    conf.uptane.device_id = test_name2;
+
+    FSStorage storage(conf);
+    Uptane::Repository uptane(conf, storage);
+    EXPECT_TRUE(uptane.initialize());
+
+    EXPECT_TRUE(boost::filesystem::exists(device_path));
+    EXPECT_EQ(Utils::readFile(device_path), test_name2);
+  }
+
+  boost::filesystem::remove_all(uptane_test_dir);
+}
+
+TEST(SotaUptaneClientTest, initialize_fail) {
   Config conf("tests/config_tests_prov.toml");
+  Utils::copyDir("tests/test_data", uptane_test_dir);
+  conf.uptane.metadata_path = "tests/";
+  conf.uptane.repo_server = tls_server + "/director";
+  conf.tls.certificates_directory = uptane_test_dir + "/certs";
+
+  conf.uptane.repo_server = tls_server + "/repo";
+  conf.tls.server = tls_server;
+
+  conf.uptane.primary_ecu_serial = "testecuserial";
+  conf.uptane.private_key_path = "private.key";
+  conf.uptane.public_key_path = "public.key";
 
   boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.client_certificate);
   boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.ca_file);
+  boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.pkey_file);
+  boost::filesystem::remove(conf.tls.certificates_directory / "bootstrap_ca.pem");
+  boost::filesystem::remove(conf.tls.certificates_directory / "bootstrap_cert.pem");
+  boost::filesystem::remove(conf.tls.certificates_directory / "bootstrap_pkey.pem");
 
   FSStorage storage(conf);
   Uptane::Repository uptane(conf, storage);
 
   provisioningResponse = ProvisionFailure;
-  bool result = uptane.deviceRegister();
+  bool result = uptane.initialize();
   provisioningResponse = ProvisionOK;
   EXPECT_FALSE(result);
-
   boost::filesystem::remove_all(uptane_test_dir);
 }
 
-TEST(SotaUptaneClientTest, device_registered_putmanifest) {
+TEST(SotaUptaneClientTest, putmanifest) {
   Config config;
   Utils::copyDir("tests/test_data", uptane_test_dir);
   config.uptane.metadata_path = uptane_test_dir;
   config.uptane.repo_server = tls_server + "/director";
   config.tls.certificates_directory = uptane_test_dir;
+  config.provision.provision_path = uptane_test_dir + "/cred.zip";
   config.uptane.repo_server = tls_server + "/repo";
   config.uptane.primary_ecu_serial = "testecuserial";
-  config.uptane.private_key_path = (config.tls.certificates_directory / "private.key").string();
+  config.uptane.private_key_path = "private.key";
+  config.uptane.public_key_path = "public.key";
 
   Uptane::SecondaryConfig ecu_config;
-  ecu_config.full_client_dir = boost::filesystem::path("mybasedir");
+  ecu_config.full_client_dir = uptane_test_dir;
   ecu_config.ecu_serial = "secondary_ecu_serial";
   ecu_config.ecu_hardware_id = "secondary_hardware";
   ecu_config.ecu_private_key = "sec.priv";
@@ -350,6 +551,7 @@ TEST(SotaUptaneClientTest, device_registered_putmanifest) {
 
   FSStorage storage(config);
   Uptane::Repository uptane(config, storage);
+  uptane.initialize();
 
   boost::filesystem::remove(test_manifest);
 
@@ -366,27 +568,6 @@ TEST(SotaUptaneClientTest, device_registered_putmanifest) {
   boost::filesystem::remove_all(uptane_test_dir);
 }
 
-TEST(SotaUptaneClientTest, device_ecu_register) {
-  Config config;
-  Utils::copyDir("tests/test_data", uptane_test_dir);
-  config.uptane.metadata_path = "tests";
-  config.uptane.repo_server = tls_server + "/director";
-  config.tls.certificates_directory = uptane_test_dir + "/certs";
-
-  config.uptane.repo_server = tls_server + "/repo";
-  config.tls.server = tls_server;
-
-  config.uptane.primary_ecu_serial = "testecuserial";
-  config.uptane.private_key_path = (config.tls.certificates_directory / "private.key").string();
-
-  FSStorage storage(config);
-  Uptane::Repository uptane(config, storage);
-  uptane.ecuRegister();
-  Json::Value ecu_data = Utils::parseJSONFile(uptane_test_dir + "/post.json");
-  EXPECT_EQ(ecu_data["ecus"].size(), 1);
-  EXPECT_EQ(ecu_data["primary_ecu_serial"].asString(), config.uptane.primary_ecu_serial);
-}
-
 TEST(SotaUptaneClientTest, RunForeverNoUpdates) {
   Config conf("tests/config_tests_prov.toml");
   Utils::copyDir("tests/test_data", uptane_test_dir);
@@ -395,7 +576,8 @@ TEST(SotaUptaneClientTest, RunForeverNoUpdates) {
   conf.tls.certificates_directory = uptane_test_dir;
   conf.uptane.repo_server = tls_server + "/repo";
   conf.uptane.primary_ecu_serial = "CA:FE:A6:D2:84:9D";
-  conf.uptane.private_key_path = (conf.tls.certificates_directory / "private.key").string();
+  conf.uptane.private_key_path = "private.key";
+  conf.uptane.public_key_path = "public.key";
 
   boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.client_certificate);
   boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.ca_file);
@@ -445,15 +627,19 @@ TEST(SotaUptaneClientTest, RunForeverHasUpdates) {
   conf.tls.certificates_directory = uptane_test_dir;
   conf.uptane.repo_server = tls_server + "/repo";
   conf.uptane.primary_ecu_serial = "CA:FE:A6:D2:84:9D";
-  conf.uptane.private_key_path = (conf.tls.certificates_directory / "private.key").string();
+  conf.uptane.private_key_path = "private.key";
+  conf.uptane.public_key_path = "public.key";
 
   Uptane::SecondaryConfig ecu_config;
-  ecu_config.full_client_dir = boost::filesystem::path("mybasedir");
+  ecu_config.full_client_dir = uptane_test_dir;
   ecu_config.ecu_serial = "secondary_ecu_serial";
   ecu_config.ecu_hardware_id = "secondary_hardware";
   ecu_config.ecu_private_key = "sec.priv";
   ecu_config.ecu_public_key = "sec.pub";
   ecu_config.firmware_path = uptane_test_dir + "/firmware.txt";
+  ecu_config.full_client_dir = uptane_test_dir;
+  ecu_config.ecu_private_key = "sec1.priv";
+  ecu_config.ecu_public_key = "sec1.pub";
   conf.uptane.secondaries.push_back(ecu_config);
 
   boost::filesystem::remove(conf.tls.certificates_directory / conf.tls.client_certificate);
@@ -492,7 +678,8 @@ TEST(SotaUptaneClientTest, RunForeverInstall) {
   Config conf("tests/config_tests_prov.toml");
   Utils::copyDir("tests/test_data", uptane_test_dir);
   conf.uptane.primary_ecu_serial = "testecuserial";
-  conf.uptane.private_key_path = (conf.tls.certificates_directory / "private.key").string();
+  conf.uptane.private_key_path = "private.key";
+  conf.uptane.public_key_path = "public.key";
   conf.uptane.director_server = tls_server + "/director";
   conf.tls.certificates_directory = uptane_test_dir;
   conf.uptane.repo_server = tls_server + "/repo";
@@ -540,15 +727,16 @@ TEST(SotaUptaneClientTest, UptaneSecondaryAdd) {
   config.uptane.metadata_path = "tests";
   config.uptane.repo_server = tls_server + "/director";
   config.tls.certificates_directory = uptane_test_dir;
+  config.provision.provision_path = uptane_test_dir + "/cred.zip";
   config.uptane.repo_server = tls_server + "/repo";
   config.tls.server = tls_server;
 
   config.uptane.primary_ecu_serial = "testecuserial";
-  config.uptane.private_key_path = (config.tls.certificates_directory / "private.key").string();
-  config.uptane.public_key_path = (config.tls.certificates_directory / "public.key").string();
+  config.uptane.private_key_path = "private.key";
+  config.uptane.public_key_path = "public.key";
 
   Uptane::SecondaryConfig ecu_config;
-  ecu_config.full_client_dir = boost::filesystem::path("mybasedir");
+  ecu_config.full_client_dir = uptane_test_dir;
   ecu_config.ecu_serial = "secondary_ecu_serial";
   ecu_config.ecu_hardware_id = "secondary_hardware";
   ecu_config.ecu_private_key = "sec.priv";
@@ -558,8 +746,7 @@ TEST(SotaUptaneClientTest, UptaneSecondaryAdd) {
 
   FSStorage storage(config);
   Uptane::Repository uptane(config, storage);
-
-  uptane.ecuRegister();
+  uptane.initialize();
   Json::Value ecu_data = Utils::parseJSONFile(uptane_test_dir + "/post.json");
   EXPECT_EQ(ecu_data["ecus"].size(), 2);
   EXPECT_EQ(ecu_data["primary_ecu_serial"].asString(), config.uptane.primary_ecu_serial);

--- a/tests/utils_test.cc
+++ b/tests/utils_test.cc
@@ -37,6 +37,8 @@ TEST(Utils, PrettyNameOk) {
   EXPECT_FALSE(PrettyNameOk("foo-bar-123&"));
 }
 
+TEST(Utils, getHostname) { EXPECT_NE(Utils::getHostname(), ""); }
+
 /**
  * \verify{\tst{144}} Check that aktualizr can generate a pet name
  */


### PR DESCRIPTION
Secondaries have become even a bit more messy, but they need a major refactoring. That's probably the next thing we should do.
Changes:
- deviceRegister() and ecuRegister() are merged into a single method called initialize()
- serial number and device ID generation (for both primaries and secondaries) is now a part of initialization
- Added clearXXX() functions to the storage to support repeated initialization.
- The only Crypto function still working with files is parseP12. It can be changed later for consistency (or when we decide to store bootstrap credentials in some database as well), but no urgent need yet.