### PR TITLE
Bugfix/fix build ostree

### DIFF
--- a/src/fsstorage.cc
+++ b/src/fsstorage.cc
@@ -78,6 +78,7 @@ void FSStorage::clearTlsCreds() {
   boost::filesystem::remove(config_.tls.certificates_directory / config_.tls.pkey_file);
 }
 
+#ifdef BUILD_OSTREE
 void FSStorage::storeMetadata(const Uptane::MetaPack& metadata) {
   boost::filesystem::path image_path = config_.uptane.metadata_path / "repo";
   boost::filesystem::path director_path = config_.uptane.metadata_path / "director";
@@ -134,6 +135,7 @@ bool FSStorage::loadMetadata(Uptane::MetaPack* metadata) {
 
   return true;
 }
+#endif  // BUILD_OSTREE
 
 void FSStorage::storeDeviceId(const std::string& device_id) {
   Utils::writeFile((config_.tls.certificates_directory / "device_id").string(), device_id);

--- a/src/fsstorage.h
+++ b/src/fsstorage.h
@@ -16,8 +16,10 @@ class FSStorage : public INvStorage {
   virtual void storeTlsCreds(const std::string& ca, const std::string& cert, const std::string& pkey);
   virtual bool loadTlsCreds(std::string* ca, std::string* cert, std::string* pkey);
   virtual void clearTlsCreds();
+#ifdef BUILD_OSTREE
   virtual void storeMetadata(const Uptane::MetaPack& metadata);
   virtual bool loadMetadata(Uptane::MetaPack* metadata);
+#endif  // BUILD_OSTREE
   virtual void storeDeviceId(const std::string& device_id);
   virtual bool loadDeviceId(std::string* device_id);
   virtual void clearDeviceId();

--- a/src/invstorage.h
+++ b/src/invstorage.h
@@ -13,8 +13,10 @@ class INvStorage {
   virtual void storeTlsCreds(const std::string& ca, const std::string& cert, const std::string& pkey) = 0;
   virtual bool loadTlsCreds(std::string* ca, std::string* cert, std::string* pkey) = 0;
   virtual void clearTlsCreds() = 0;
+#ifdef BUILD_OSTREE
   virtual void storeMetadata(const Uptane::MetaPack& metadata) = 0;
   virtual bool loadMetadata(Uptane::MetaPack* metadata) = 0;
+#endif  // BUILD_OSTREE
   virtual void storeDeviceId(const std::string& device_id) = 0;
   virtual bool loadDeviceId(std::string* device_id) = 0;
   virtual void clearDeviceId() = 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -203,16 +203,16 @@ set_tests_properties(test-no-config-check-message
 
 # Try building with various cmake options
 add_test(NAME test_build_all_off
-        COMMAND ${PROJECT_SOURCE_DIR}/tests/build_with_options ${PROJECT_SOURCE_DIR} test_build_all_off "-DBUILD_GENIVI=OFF -DBUILD_TESTS=OFF")
+        COMMAND ${PROJECT_SOURCE_DIR}/tests/build_with_options.sh ${PROJECT_SOURCE_DIR} test_build_all_off "-DBUILD_GENIVI=OFF -DBUILD_OSTREE=OFF")
 
 add_test(NAME test_build_all_on
-        COMMAND ${PROJECT_SOURCE_DIR}/tests/build_with_options ${PROJECT_SOURCE_DIR} test_build_all_on "-DBUILD_WITH_CODE_COVERAGE=ON -DBUILD_GENIVI=ON -DBUILD_OSTREE=ON")
+        COMMAND ${PROJECT_SOURCE_DIR}/tests/build_with_options.sh ${PROJECT_SOURCE_DIR} test_build_all_on "-DBUILD_WITH_CODE_COVERAGE=ON -DBUILD_GENIVI=ON -DBUILD_OSTREE=ON")
 
 add_test(NAME test_build_debug
-        COMMAND ${PROJECT_SOURCE_DIR}/tests/build_with_options ${PROJECT_SOURCE_DIR} test_build_debug "-DCMAKE_BUILD_TYPE=Debug")
+        COMMAND ${PROJECT_SOURCE_DIR}/tests/build_with_options.sh ${PROJECT_SOURCE_DIR} test_build_debug "-DCMAKE_BUILD_TYPE=Debug")
 
 add_test(NAME test_build_release
-        COMMAND ${PROJECT_SOURCE_DIR}/tests/build_with_options ${PROJECT_SOURCE_DIR} test_build_release "-DCMAKE_BUILD_TYPE=Release")
+        COMMAND ${PROJECT_SOURCE_DIR}/tests/build_with_options.sh ${PROJECT_SOURCE_DIR} test_build_release "-DCMAKE_BUILD_TYPE=Release")
 
 add_dependencies(qa check-full)
 

--- a/tests/build_with_options
+++ b/tests/build_with_options
@@ -1,5 +1,0 @@
-echo $PWD
-mkdir "$2"
-cd "$2"
-cmake $3 $1
-make -j5 aktualizr

--- a/tests/build_with_options.sh
+++ b/tests/build_with_options.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo $PWD
+# Protect against mistakes by not just blindly deleting the second input
+# argument.
+rm -Rf "${2}_prev"
+mv $2 "${2}_prev"
+mkdir -p "$2"
+cd "$2"
+cmake $3 $1
+make -j5 aktualizr

--- a/tests/fsstorage_test.cc
+++ b/tests/fsstorage_test.cc
@@ -54,6 +54,7 @@ TEST(fsstorage, load_store_tls) {
   boost::filesystem::remove_all(fsstorage_test_dir);
 }
 
+#ifdef BUILD_OSTREE
 TEST(fsstorage, load_store_metadata) {
   Config config;
   config.tls.certificates_directory = fsstorage_test_dir;
@@ -125,6 +126,7 @@ TEST(fsstorage, load_store_metadata) {
 
   boost::filesystem::remove_all(fsstorage_test_dir);
 }
+#endif  // BUILD_OSTREE
 
 TEST(fsstorage, load_store_deviceid) {
   Config config;


### PR DESCRIPTION
Three issues:
1. Building tests with BUILD_OSTREE=OFF was failing. Building aktualizr succeeded due to linker magic.
2. The CMake build tests only build aktualizr, so they wouldn't catch the problem. For now, I've left that unchanged, because building the tests a total of five times for each 'make qa' takes forever and is maybe heavy-handed.
3. The CMake build tests did not clean up after themselves, which left them vulnerable to linking inconsistencies.