### PR TITLE
Return error to director on malformed refname

### DIFF
--- a/src/ostree.h
+++ b/src/ostree.h
@@ -18,8 +18,8 @@ struct Ostree {
 
 class OstreePackage {
  public:
-  OstreePackage(const std::string &ecu_serial_in, const std::string &ref_name_in, const std::string &desc_in,
-                const std::string &treehub_in);
+  OstreePackage(const std::string &ecu_serial_in, const std::string &ref_name_in, const std::string &branch_name_in,
+                const std::string &refhash_in, const std::string &desc_in, const std::string &treehub_in);
   std::string ecu_serial;
   std::string ref_name;
   std::string branch_name;
@@ -30,7 +30,6 @@ class OstreePackage {
 
   Json::Value toEcuVersion(const Json::Value &custom) const;
   static OstreePackage getEcu(const std::string &ecu_serial, const std::string &ostree_sysroot);
-  static OstreePackage fromJson(const Json::Value &json);
 };
 
 struct OstreeBranch {

--- a/src/sotauptaneclient.h
+++ b/src/sotauptaneclient.h
@@ -16,7 +16,7 @@ class SotaUptaneClient {
   SotaUptaneClient(const Config &config_in, event::Channel *events_channel_in, Uptane::Repository &repo);
 
   Json::Value sign(const Json::Value &in_data);
-  Json::Value OstreeInstall(const OstreePackage &package);
+  Json::Value OstreeInstallAndManifest(const Uptane::Target &package);
   void run(command::Channel *commands_channel);
   void runForever(command::Channel *commands_channel);
 
@@ -24,6 +24,7 @@ class SotaUptaneClient {
   void reportHWInfo();
   void reportInstalledPackages();
   bool isInstalled(const Uptane::Target &target);
+  data::InstallOutcome OstreeInstall(const Uptane::Target &package);
   OstreePackage uptaneToOstree(const Uptane::Target &target);
   std::vector<Uptane::Target> findForEcu(const std::vector<Uptane::Target> &targets, std::string ecu_id);
   Config config;

--- a/tests/fake_ostree.cc
+++ b/tests/fake_ostree.cc
@@ -1,22 +1,19 @@
 #include "ostree.h"
 
 OstreePackage::OstreePackage(const std::string &ecu_serial_in, const std::string &ref_name_in,
+                             const std::string &branch_name_in, const std::string &refhash_in,
                              const std::string &desc_in, const std::string &treehub_in)
-    : ecu_serial(ecu_serial_in), ref_name(ref_name_in), description(desc_in), pull_uri(treehub_in) {
-  std::size_t pos = ref_name.find_last_of("-");
-  branch_name = ref_name.substr(0, pos);
-  refhash = ref_name.substr(pos + 1, std::string::npos);
-}
+    : ecu_serial(ecu_serial_in),
+      ref_name(ref_name_in),
+      branch_name(branch_name_in),
+      refhash(refhash_in),
+      description(desc_in),
+      pull_uri(treehub_in) {}
 
 data::InstallOutcome OstreePackage::install(const data::PackageManagerCredentials &cred, OstreeConfig config) const {
   (void)cred;
   (void)config;
   return data::InstallOutcome(data::OK, "Good");
-}
-
-OstreePackage OstreePackage::fromJson(const Json::Value &json) {
-  return OstreePackage(json["ecu_serial"].asString(), json["ref_name"].asString(), json["description"].asString(),
-                       json["pull_uri"].asString());
 }
 
 Json::Value OstreePackage::toEcuVersion(const Json::Value &custom) const {
@@ -42,7 +39,7 @@ Json::Value OstreePackage::toEcuVersion(const Json::Value &custom) const {
 
 OstreePackage OstreePackage::getEcu(const std::string &ecu_serial,
                                     const std::string &ostree_sysroot __attribute__((unused))) {
-  return OstreePackage(ecu_serial, "frgfdg-hash", "dsfsdf", "sfsdfs");
+  return OstreePackage(ecu_serial, "frgfdg-hash", "fr", "hash", "dsfsdf", "sfsdfs");
 }
 
 Json::Value Ostree::getInstalledPackages(const std::string &file_path) {

--- a/tests/ostree_test.cc
+++ b/tests/ostree_test.cc
@@ -9,22 +9,7 @@
 #include "ostree.h"
 #include "utils.h"
 TEST(ostree, constructor) {
-  OstreePackage op("ecu_serial", "branch-name-hash", "description", "pull_uri");
-  EXPECT_EQ(op.ecu_serial, "ecu_serial");
-  EXPECT_EQ(op.ref_name, "branch-name-hash");
-  EXPECT_EQ(op.branch_name, "branch-name");
-  EXPECT_EQ(op.refhash, "hash");
-  EXPECT_EQ(op.description, "description");
-  EXPECT_EQ(op.pull_uri, "pull_uri");
-}
-
-TEST(ostree, fromjson) {
-  Json::Value json;
-  json["ecu_serial"] = "ecu_serial";
-  json["ref_name"] = "branch-name-hash";
-  json["description"] = "description";
-  json["pull_uri"] = "pull_uri";
-  OstreePackage op = OstreePackage::fromJson(json);
+  OstreePackage op("ecu_serial", "branch-name-hash", "branch-name", "hash", "description", "pull_uri");
   EXPECT_EQ(op.ecu_serial, "ecu_serial");
   EXPECT_EQ(op.ref_name, "branch-name-hash");
   EXPECT_EQ(op.branch_name, "branch-name");
@@ -34,7 +19,7 @@ TEST(ostree, fromjson) {
 }
 
 TEST(ostree, toEcuVersion) {
-  OstreePackage op("ecu_serial", "branch-name-hash", "description", "pull_uri");
+  OstreePackage op("ecu_serial", "branch-name-hash", "branch-name", "hash", "description", "pull_uri");
   Json::Value custom;
   custom["key"] = "value";
   Json::Value ecuver = op.toEcuVersion(custom);


### PR DESCRIPTION
This PR _might_ fix [the problem with garbage package names](https://advancedtelematic.atlassian.net/browse/PRO-3825). I can't say if it really solves it because login to CI garage is currently broken, but at least it doesn't break existing functionality and makes code slightly cleaner: crashing with an exception on wrong Uptane metadata was not a good idea (yes, it was my code).