### PR TITLE
Create getPrimaryEcuSerial to avoid accessing private member.

### DIFF
--- a/src/sotauptaneclient.h
+++ b/src/sotauptaneclient.h
@@ -15,7 +15,6 @@ class SotaUptaneClient {
 
   SotaUptaneClient(const Config &config_in, event::Channel *events_channel_in, Uptane::Repository &repo);
 
-  void putManifest(SotaUptaneClient::ServiceType service, const std::string &manifest);
   Json::Value sign(const Json::Value &in_data);
   Json::Value OstreeInstall(const OstreePackage &package);
   void run(command::Channel *commands_channel);

--- a/src/uptane/uptanerepository.h
+++ b/src/uptane/uptanerepository.h
@@ -33,6 +33,7 @@ class Repository {
   // void addSecondary(const std::string &ecu_serial, const std::string &hardware_identifier);
   Json::Value updateSecondaries(const std::vector<Uptane::Target> &secondary_targets);
   std::pair<int, std::vector<Uptane::Target> > getTargets();
+  std::string getPrimaryEcuSerial() { return primary_ecu_serial; };
 
   // implemented in uptane/initialize.cc
   bool initialize();


### PR DESCRIPTION
This is a cleaner/simpler/better version of refactor/getPrimaryEcuVersion that doesn't change the ostree boundaries but still works for Vladimir's code.

Also, one step closer to removing 'friend class ::SotaUptaneClient' in uptanerepository.h.