### PR TITLE
Extract device_id from the certificate

### DIFF
--- a/src/uptane/uptanerepository.h
+++ b/src/uptane/uptanerepository.h
@@ -65,7 +65,7 @@ class Repository {
   bool getMeta();
 
   // implemented in uptane/initialize.cc
-  bool initDeviceId(const UptaneConfig &uptane_config);
+  bool initDeviceId(const ProvisionConfig &provision_config, const UptaneConfig &uptane_config);
   void resetDeviceId();
   bool initEcuSerials(UptaneConfig &uptane_config);
   void resetEcuSerials();

--- a/tests/uptane_test.cc
+++ b/tests/uptane_test.cc
@@ -910,6 +910,8 @@ TEST(SotaUptaneClientTest, provision_on_server) {
  */
 TEST(SotaUptaneClientTest, implicit_failure) {
   Config config;
+  config.uptane.device_id = "device_id";
+  config.postUpdateValues();
   FSStorage storage(config);
   HttpFake http(uptane_test_dir);
   Uptane::Repository uptane(config, storage, http);
@@ -926,6 +928,8 @@ TEST(SotaUptaneClientTest, implicit_incomplete) {
   config.tls.ca_file = "ca.pem";
   config.tls.client_certificate = "client.pem";
   config.tls.pkey_file = "pkey.pem";
+  config.uptane.device_id = "device_id";
+  config.postUpdateValues();
   FSStorage storage(config);
   HttpFake http(uptane_test_dir);
   Uptane::Repository uptane(config, storage, http);


### PR DESCRIPTION
As @christianhuggerATS pointed out, it's a pretty useless piece of code, we don't use device_id in the aktualizr. It might be convenient to have device_id accessible during the debugging though. If it needs to be merged is questionable.