### PR TITLE
Add 1 to device_id length to accommodate trailing null.

### DIFF
--- a/src/uptane/initialize.cc
+++ b/src/uptane/initialize.cc
@@ -38,8 +38,8 @@ bool Repository::initDeviceId(const ProvisionConfig& provision_config, const Upt
         X509_free(x);
         return false;
       }
-      boost::scoped_array<char> buf(new char[len]);
-      X509_NAME_get_text_by_NID(X509_get_subject_name(x), NID_commonName, buf.get(), len);
+      boost::scoped_array<char> buf(new char[len + 1]);
+      X509_NAME_get_text_by_NID(X509_get_subject_name(x), NID_commonName, buf.get(), len + 1);
       device_id = std::string(buf.get());
       X509_free(x);
       std::cout << "Implicit provisioning: set device_id to " << device_id << std::endl;


### PR DESCRIPTION
Fixing a bug caught by @rdanitz 