### PR TITLE
Fixes to make sota-tools compatible with gcc v4.x (requirement from AGL/jsmoeller) and the respective test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - DOCKERFILE=Dockerfile.nop11 CACHE=latest SCRIPT=src/scripts/test.sh
   - DOCKERFILE=Dockerfile.deb-stable CACHE=latest-deb-stable SCRIPT=src/scripts/test.sh DARGS="-eBUILD_ONLY=1 -eBUILD_DEB=1"
   - DOCKERFILE=Dockerfile.deb-unstable CACHE=latest-deb-unstable SCRIPT=src/scripts/test.sh DARGS="-eBUILD_ONLY=1"
+  - DOCKERFILE=Dockerfile.gcc4 CACHE=latest SCRIPT=src/scripts/test.sh DARGS="-eBUILD_ONLY=1 -eNO_FORMAT_CHECK=1"
 services:
   - docker
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   - DOCKERFILE=Dockerfile.nop11 CACHE=latest SCRIPT=src/scripts/test.sh
   - DOCKERFILE=Dockerfile.deb-stable CACHE=latest-deb-stable SCRIPT=src/scripts/test.sh DARGS="-eBUILD_ONLY=1 -eBUILD_DEB=1"
   - DOCKERFILE=Dockerfile.deb-unstable CACHE=latest-deb-unstable SCRIPT=src/scripts/test.sh DARGS="-eBUILD_ONLY=1"
-  - DOCKERFILE=Dockerfile.gcc4 CACHE=latest SCRIPT=src/scripts/test.sh DARGS="-eBUILD_ONLY=1 -eNO_FORMAT_CHECK=1"
+  - DOCKERFILE=Dockerfile.gcc4 CACHE=latest SCRIPT=src/scripts/test.sh DARGS="-eBUILD_ONLY=1"
 services:
   - docker
 script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake-modules)
 # find all required libraries
 set(Boost_USE_STATIC_LIBS ON)
 find_package(PkgConfig REQUIRED)
-find_package(Boost COMPONENTS system filesystem thread program_options log_setup log regex chrono random REQUIRED)
+find_package(Boost 1.57.0 COMPONENTS system filesystem thread program_options log_setup log regex chrono random REQUIRED)
 find_package(CURL REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(Threads REQUIRED)

--- a/Dockerfile.gcc4
+++ b/Dockerfile.gcc4
@@ -1,0 +1,22 @@
+FROM ubuntu:xenial
+LABEL Description="Aktualizr testing dockerfile"
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update
+RUN apt-get -y install debian-archive-keyring
+RUN echo "deb http://httpredir.debian.org/debian jessie-backports main contrib non-free" > /etc/apt/sources.list.d/jessie-backports.list
+
+# It is important to run these in the same RUN command, because otherwise
+# Docker layer caching breaks us
+RUN apt-get update && apt-get -y install wget liblzma-dev bison e2fslibs-dev libgpgme11-dev libglib2.0-dev gcc-4.9 g++-4.9 make cmake git psmisc dbus python3-dbus python3-gi python3-openssl libdbus-1-dev libjansson-dev libgtest-dev libssl-dev autoconf automake pkg-config libtool libexpat1-dev libboost-program-options-dev libboost-test-dev libboost-random-dev libboost-regex-dev libboost-dev libboost-system-dev libboost-date-time-dev libboost-thread-dev libboost-log-dev libjsoncpp-dev curl libcurl4-openssl-dev lcov clang clang-format-3.8
+RUN apt-get update && apt-get -y install ostree libostree-dev libsodium-dev libarchive-dev python3-venv python3-dev valgrind libp11-dev softhsm2 opensc libengine-pkcs11-openssl
+RUN rm /usr/bin/gcc /usr/bin/gcc-ar /usr/bin/gcc-nm /usr/bin/gcc-ranlib /usr/bin/g++ && \
+    ln -s gcc-4.9 /usr/bin/gcc && \
+    ln -s gcc-ar-4.9 /usr/bin/gcc-ar && \
+    ln -s gcc-nm-4.9 /usr/bin/gcc-nm && \
+    ln -s gcc-ranlib-4.9 /usr/bin/gcc-ranlib && \
+    ln -s g++-nm-4.9 /usr/bin/g++
+
+WORKDIR aktualizr
+ADD . src

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,7 +4,10 @@ set -e
 mkdir -p build-test
 cd build-test
 cmake -DBUILD_GENIVI=ON -DBUILD_OSTREE=ON -DBUILD_SOTA_TOOLS=ON ../src
-make check-format
+if [ -z $NO_FORMAT_CHECK ]; then
+  make check-format
+fi
+
 make -j8
 if [ -n "$BUILD_ONLY" ]; then
   if [ -n "$BUILD_DEB" ]; then

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,9 +4,8 @@ set -e
 mkdir -p build-test
 cd build-test
 cmake -DBUILD_GENIVI=ON -DBUILD_OSTREE=ON -DBUILD_SOTA_TOOLS=ON ../src
-if [ -z $NO_FORMAT_CHECK ]; then
-  make check-format
-fi
+
+make check-format
 
 make -j8
 if [ -n "$BUILD_ONLY" ]; then

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -19,6 +19,11 @@
 #include "config.h"
 #include "utils.h"
 
+// some older versions of openssl have BIO_new_mem_buf defined with fisrt parameter of type (void*)
+//   which is not true and breaks our build
+#undef BIO_new_mem_buf
+BIO *BIO_new_mem_buf(const void *, int);
+
 struct PublicKey {
   enum Type { RSA = 0, ED25519 };
   PublicKey() {}

--- a/src/sota_tools/authenticate.cc
+++ b/src/sota_tools/authenticate.cc
@@ -1,7 +1,7 @@
 #include <archive.h>
 #include <archive_entry.h>
-#include <boost/move/unique_ptr.hpp>
 #include <boost/move/make_unique.hpp>
+#include <boost/move/unique_ptr.hpp>
 #include <boost/optional.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>

--- a/src/sota_tools/ostree_ref.cc
+++ b/src/sota_tools/ostree_ref.cc
@@ -13,7 +13,7 @@ using std::string;
 using std::stringstream;
 using std::ifstream;
 
-OSTreeRef::OSTreeRef(const OSTreeRepo &repo, const string ref_name) : ref_name_(ref_name) {
+OSTreeRef::OSTreeRef(const OSTreeRepo &repo, const string& ref_name) : ref_name_(ref_name) {
   if (boost::filesystem::is_regular_file(repo.root() + "/refs/heads/" + ref_name)) {
     std::ifstream f(repo.root() + "/refs/heads/" + ref_name, std::ios::in | std::ios::binary);
 
@@ -32,7 +32,7 @@ OSTreeRef::OSTreeRef(const OSTreeRepo &repo, const string ref_name) : ref_name_(
   }
 }
 
-OSTreeRef::OSTreeRef(const TreehubServer &serve_repo, const string ref_name) : is_valid(true), ref_name_(ref_name) {
+OSTreeRef::OSTreeRef(const TreehubServer &serve_repo, const string& ref_name) : is_valid(true), ref_name_(ref_name) {
   CURL *curl_handle = curl_easy_init();
   serve_repo.InjectIntoCurl(Url(), curl_handle);
   curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, &OSTreeRef::curl_handle_write);

--- a/src/sota_tools/ostree_ref.cc
+++ b/src/sota_tools/ostree_ref.cc
@@ -13,7 +13,7 @@ using std::string;
 using std::stringstream;
 using std::ifstream;
 
-OSTreeRef::OSTreeRef(const OSTreeRepo &repo, const string& ref_name) : ref_name_(ref_name) {
+OSTreeRef::OSTreeRef(const OSTreeRepo &repo, const string &ref_name) : ref_name_(ref_name) {
   if (boost::filesystem::is_regular_file(repo.root() + "/refs/heads/" + ref_name)) {
     std::ifstream f(repo.root() + "/refs/heads/" + ref_name, std::ios::in | std::ios::binary);
 
@@ -32,7 +32,7 @@ OSTreeRef::OSTreeRef(const OSTreeRepo &repo, const string& ref_name) : ref_name_
   }
 }
 
-OSTreeRef::OSTreeRef(const TreehubServer &serve_repo, const string& ref_name) : is_valid(true), ref_name_(ref_name) {
+OSTreeRef::OSTreeRef(const TreehubServer &serve_repo, const string &ref_name) : is_valid(true), ref_name_(ref_name) {
   CURL *curl_handle = curl_easy_init();
   serve_repo.InjectIntoCurl(Url(), curl_handle);
   curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, &OSTreeRef::curl_handle_write);

--- a/src/sota_tools/ostree_ref.h
+++ b/src/sota_tools/ostree_ref.h
@@ -12,8 +12,9 @@
 
 class OSTreeRef {
  public:
-  OSTreeRef(const OSTreeRepo& root, const std::string ref_name);
-  OSTreeRef(const TreehubServer& serve_repo, const std::string ref_name);
+  OSTreeRef(const OSTreeRepo& root, const std::string& ref_name);
+  OSTreeRef(const TreehubServer& serve_repo, const std::string& ref_name);
+  OSTreeRef(OSTreeRef&& rhs) : ref_content_(rhs.ref_content_), ref_name_(rhs.ref_name_) {}
 
   void PushRef(const TreehubServer& push_target, CURL* curl_easy_handle);
 

--- a/src/sotauptaneclient.cc
+++ b/src/sotauptaneclient.cc
@@ -79,7 +79,7 @@ Json::Value SotaUptaneClient::OstreeInstallAndManifest(const Uptane::Target &tar
   } else {
     data::OperationResult result = data::OperationResult::fromOutcome(target.filename(), OstreeInstall(target));
     operation_result["operation_result"] = result.toJson();
-    if (result.result_code == data::UpdateResultCode::OK) {
+    if (result.result_code == data::OK) {
       uptane_repo.saveInstalledVersion(target);
     }
   }

--- a/src/uptane/tuf.cc
+++ b/src/uptane/tuf.cc
@@ -137,7 +137,7 @@ bool Target::MatchWith(const Hash &hash) const {
 std::string Target::sha256Hash() const {
   std::vector<Uptane::Hash>::const_iterator it;
   for (it = hashes_.begin(); it != hashes_.end(); it++) {
-    if (it->type() == Hash::Type::kSha256) {
+    if (it->type() == Hash::kSha256) {
       return boost::algorithm::to_lower_copy(it->HashString());
     }
   }


### PR DESCRIPTION
Causes for incompatibilities

1. std::stringstream is not moveable in gcc v4.x
2. Enums are not namespaces (I've also encountered this error on newer versions of GCC).