### PR TITLE
curl_easy_getinfo(CURLINFO_RESPONSE_CODE, ...) expexts long argument,  fix variable types accordingly

### DIFF
--- a/src/httpclient.h
+++ b/src/httpclient.h
@@ -32,7 +32,7 @@ class HttpClient : public HttpInterface {
   virtual HttpResponse download(const std::string &url, curl_write_callback callback, void *userp);
   virtual void setCerts(const std::string &ca, CryptoSource ca_source, const std::string &cert,
                         CryptoSource cert_source, const std::string &pkey, CryptoSource pkey_source);
-  unsigned int http_code;
+  long http_code;
 
  private:
   /**

--- a/src/sota_tools/oauth2.cc
+++ b/src/sota_tools/oauth2.cc
@@ -43,7 +43,7 @@ AuthenticationResult OAuth2::Authenticate() {
   curl_easy_perform(curl_handle);
 
   AuthenticationResult res;
-  int rescode;
+  long rescode;
   curl_easy_getinfo(curl_handle, CURLINFO_RESPONSE_CODE, &rescode);
   if (rescode == 200) {
     ptree pt;


### PR DESCRIPTION
Of course as a variadic function it won't tell you anything, it will just make your code segfault in random places.