### PR TITLE
Refactor virtual secondaries to implement SecondaryInterface

### DIFF
--- a/src/uptane/legacysecondary.cc
+++ b/src/uptane/legacysecondary.cc
@@ -12,32 +12,6 @@ LegacySecondary::LegacySecondary(const LegacySecondaryConfig &sconfig_in, Uptane
   boost::filesystem::create_directories(sconfig.firmware_path.parent_path());
 }
 
-Json::Value verifyMeta(const TimeMeta &time_meta, const Root &root_meta, const Targets &targets_meta) {
-  Json::Value result;
-  // No verification is currently performed
-  result["valid"] = true;
-
-  Utils::writeFile(sconfig.previous_time_path.string(), Utils::readFile(sconfig.time_path.string()));
-  Utils::writeFile(sconfig.time_path.string(), new_time);
-
-  result["wait_for_target"] = false;
-  wait_for_target = false;
-
-  std::vector<Uptane::Target>::const_iterator it;
-  for (it = targets_meta.targets.begin(); it != targets_meta.targets.end(); ++it) {
-    if (it->IsForLegacySecondary(sconfig.ecu_serial)) {
-      result["wait_for_target"] = true;
-      wait_for_target = true;
-      expected_target_name = it->filename();
-      expected_target_hashes = it->hashes();
-      expected_target_length = it->length();
-      break;
-    }
-  }
-
-  return result;
-}
-
 bool writeImage(const uint8_t *blob, size_t size) {
   if (!wait_for_target) return false;
 

--- a/src/uptane/legacysecondary.h
+++ b/src/uptane/legacysecondary.h
@@ -18,7 +18,6 @@ class LegacySecondary : public SecondaryInterface {
   LegacySecondary(const SecondaryConfig &sconfig_in, Uptane::Repository *primary) : SecondaryInterface(sconfig_in);
 
   void setKeys(const std::string &public_key, const std::string &private_key);
-  Json::Value verifyMeta(const TimeMeta &time_meta, const Root &root_meta, const Targets &targets_meta);
   bool writeImage(const uint8_t *blob, size_t size);
   Json::Value genAndSendManifest(Json::Value custom = Json::Value(Json::nullValue));
 

--- a/src/uptane/secondaryconfig.h
+++ b/src/uptane/secondaryconfig.h
@@ -23,13 +23,12 @@ class SecondaryConfig {
   std::string ecu_serial;
   std::string ecu_hardware_id;
   bool partial_verifying;
-  std::string ecu_private_key_;
-  std::string ecu_public_key_;
+  std::string ecu_private_key;
+  std::string ecu_public_key;
 
   boost::filesystem::path full_client_dir;     // kVirtual, kLegacy
   boost::filesystem::path firmware_path;       // kVirtual
-  boost::filesystem::path time_path;           // kVirtual
-  boost::filesystem::path previous_time_path;  // kVirtual
+  boost::filesystem::path metadata_path;           // kVirtual
   boost::filesystem::path target_name_path;    // kVirtual
 };
 }

--- a/src/uptane/secondaryinterface.h
+++ b/src/uptane/secondaryinterface.h
@@ -23,12 +23,12 @@ class SecondaryInterface {
   virtual ~SecondaryInterface() {}
   virtual std::string getSerial() { return sconfig.ecu_serial; }
   virtual std::string getHwId() { return sconfig.ecu_hardware_id; }
-  virtual std::string getPublicKey() { return sconfig.ecu_public_key(); }
+  virtual std::string getPublicKey() = 0;
 
   virtual Json::Value getManifest() = 0;
-  virtual Json::Value putMetadata(const TimeMeta& time_meta, const MetaPack& meta_pack) = 0;
-  virtual int getRootVersion(const bool director) = 0;
-  virtual void putRoot(Uptane::Root) = 0;
+  virtual bool putMetadata(const MetaPack& meta_pack) = 0;
+  virtual int getRootVersion(bool director) = 0;
+  virtual bool putRoot(Uptane::Root root, bool director) = 0;
 
   virtual bool sendFirmware(const uint8_t* blob, size_t size) = 0;
 

--- a/src/uptane/secondarymanager.cc
+++ b/src/uptane/secondarymanager.cc
@@ -13,15 +13,15 @@ Json::Value SecondaryManager::getManifest(const std::string& ecu_serial) {
     return secondaries_[ecu_serial].genAndSendManifest();
 }
 
-Json::Value SecondaryManager::sendMetaPartial(const TimeMeta& time_meta, const Root& root_meta,
+Json::Value SecondaryManager::sendMetaPartial(const Root& root_meta,
                                               const Targets& targets_meta) {
   if (secondaries_.find(ecu_serial) == secondaries.end())
     throw std::runtime_error("ecu_serial - " + ecu_serial + " not found");
   else
-    return secondaries_[ecu_serial].verifyMeta(time_meta, root_meta, targets_meta);
+    return secondaries_[ecu_serial].verifyMeta(root_meta, targets_meta);
 }
 
-Json::Value SecondaryManager::sendMetaFull(const std::string& ecu_serial, const TimeMeta& time_meta,
+Json::Value SecondaryManager::sendMetaFull(const std::string& ecu_serial,
                                            const struct MetaPack* meta_pack) {
   throw std::runtime_error("SecondaryManager only supports partial verification");
 }

--- a/src/uptane/secondarymanager.h
+++ b/src/uptane/secondarymanager.h
@@ -17,8 +17,8 @@ class SecondaryManager {
  public:
   SecondaryManager(std::vector<SecondaryInterface*>& secondaries);
   virtual Json::Value getManifest(const std::string& ecu_serial);
-  virtual Json::Value sendMetaPartial(const TimeMeta& time_meta, const Root& root_meta, const Targets& targets_meta);
-  virtual Json::Value sendMetaFull(const TimeMeta& time_meta, const struct MetaPack& meta_pack);
+  virtual Json::Value sendMetaPartial(const Root& root_meta, const Targets& targets_meta);
+  virtual Json::Value sendMetaFull(const struct MetaPack& meta_pack);
   virtual bool sendFirmware(const uint8_t* blob, size_t size);
   virtual void getPublicKey(const std::string& ecu_serial, std::string* keytype, std::string* key);
   virtual void setKeys(const std::string& ecu_serial, const std::string& keytype, const std::string& public_key,

--- a/src/uptane/tuf.h
+++ b/src/uptane/tuf.h
@@ -113,6 +113,7 @@ class Target {
  public:
   Target(const std::string &name, const Json::Value &content);
 
+  // TODO: ECU HW ID
   std::string ecu_identifier() const { return ecu_identifier_; }
   std::string filename() const { return filename_; }
   std::string format() const { return type_; }
@@ -225,8 +226,6 @@ class TimestampMeta {
   Json::Value toJson() const;
   bool operator==(const TimestampMeta &rhs) const { return version == rhs.version && expiry == rhs.expiry; }
 };
-
-struct TimeMeta {};
 
 class Snapshot {
  public:

--- a/src/uptane/uptanerepository.cc
+++ b/src/uptane/uptanerepository.cc
@@ -149,10 +149,9 @@ Json::Value Repository::updateSecondaries(const std::vector<Uptane::Target> &sec
       if (!storage.loadMeta(&meta)) {
         throw std::runtime_error("No valid metadata, but trying to upload firmware");
       }
-      TimeMeta time_meta;
       Json::Value resp;
       if (it->partial_verifying) {
-        resp = it->transport->sendMetaPartial(time_meta, meta.director_root, meta.director_targets);
+        resp = it->transport->sendMetaPartial(meta.director_root, meta.director_targets);
       } else {
       }
     }

--- a/src/uptane/virtualsecondary.cc
+++ b/src/uptane/virtualsecondary.cc
@@ -7,42 +7,80 @@
 #include "logger.h"
 
 namespace Uptane {
-VirtualSecondary::VirtualSecondary(const VirtualSecondaryConfig &sconfig_in, Uptane::Repository *primary)
+VirtualSecondary::VirtualSecondary(const VirtualSecondaryConfig &sconfig_in)
     : sconfig(sconfig_in), transport(primary), wait_image(false) {
   boost::filesystem::create_directories(sconfig.firmware_path.parent_path());
+  boost::filesystem::create_directories(sconfig.metadata_path);
+
+  loadMetadata (meta_pack);
+  if(!loadKeys(&public_key, &private_key)) {
+    if (!Crypto::generateRSAKeyPair(&public_key, &private_key)) {
+      LOGGER_LOG(LVL_error, "Could not generate rsa keys for secondary " << sconfig.ecu_serial << "@" << sconfig.ecu_hardware_id);
+      throw std::runtime_error("Unable to initialize libsodium");
+    }
+    storeKeys(public_key, private_key);
+  }
 }
 
-Json::Value verifyMeta(const TimeMeta &time_meta, const Root &root_meta, const Targets &targets_meta) {
-  Json::Value result;
-  // No verification is currently performed
-  result["valid"] = true;
+bool VirtualSecondary::putMetadata(const MetaPack& meta_pack) {
+  // No verification is currently performed, we can add verification in future for testing purposes
+  detected_attack = "";
+  current_meta = meta_pack;
+  storeMetadata(current_meta);
 
-  Utils::writeFile(sconfig.previous_time_path.string(), Utils::readFile(sconfig.time_path.string()));
-  Utils::writeFile(sconfig.time_path.string(), new_time);
+  expected_target_name = "";
+  expected_target_hashes = "";
+  expected_target_length = "";
 
-  result["wait_for_target"] = false;
-  wait_for_target = false;
+  bool target_found = false;
 
   std::vector<Uptane::Target>::const_iterator it;
-  for (it = targets_meta.targets.begin(); it != targets_meta.targets.end(); ++it) {
-    if (it->IsForVirtualSecondary(sconfig.ecu_serial)) {
-      result["wait_for_target"] = true;
-      wait_for_target = true;
+  for(it = meta_pack.director_targets.targets.begin(); it != meta_pack.director_targets.targets.end(); ++it) {
+    // TODO: what about hardware ID? Also missing in Uptane::Target
+    if(it->ecu_identifier() == sconfig.ecu_serial) {
+      if (target_found) {
+        detected_attack = "Duplicate entry for this ECU";
+        break;
+      }
       expected_target_name = it->filename();
       expected_target_hashes = it->hashes();
       expected_target_length = it->length();
-      break;
+      target_found = true;
     }
   }
 
-  return result;
+  if (!taret_found)
+    detected_attack = "No update for this ECU";
+
+  return true;
 }
 
-bool writeImage(const uint8_t *blob, size_t size) {
-  if (!wait_for_target) return false;
+int VirtualSecondary::getRootVersion(bool director) {
+  if(director)
+    return current_meta.director_root.version();
+  else
+    return current_meta.image_root.version();
+}
 
-  wait_for_target = false;
-  if (size > expected_targets_length) {
+void VirtualSecondary::putRoot(Uptane::Root root, bool director) {
+  Uptane::Root& prev_root = (director) ? current_meta.director_root : current_meta.image_root;
+
+  // No verification is currently performed, we can add verification in future for testing purposes
+  if(root.version() == prev_root.version() + 1)
+    prev_root = root;
+  else
+    detected_attack = "Tried to update root version " + prev_root.version() + " with version " + root.version();
+
+   storeMetadata(current_meta);
+
+  return true;
+}
+
+bool VirtualSecondary::sendFirmware(const uint8_t *blob, size_t size) {
+  if (!expected_target_name) return true;
+  if (!detected_attack.empty()) return true;
+
+  if (size > expected_target_length) {
     detected_attack = "overflow";
     return true;
   }
@@ -66,37 +104,43 @@ bool writeImage(const uint8_t *blob, size_t size) {
   return true;
 }
 
-Json::Value VirtualSecondary::genAndSendManifest(Json::Value custom) {
+Json::Value VirtualSecondary::getManifest() {
   Json::Value manifest;
 
   // package manager will generate this part in future
   Json::Value installed_image;
   installed_image["filepath"] = Utils::readFile(sconfig.target_name_path.string());
-  std::string content = Utils::readFile(
-      sconfig.firmware_path.string());  // FIXME this is bad idea to read all image to memory, we need to
-                                        // implement progressive hash function
+
+  std::string content = Utils::readFile(sconfig.firmware_path.string());
   installed_image["fileinfo"]["hashes"]["sha256"] =
       boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(content)));
   installed_image["fileinfo"]["length"] = static_cast<Json::Int64>(content.size());
-  //////////////////
 
-  if (custom != Json::nullValue) {
-    manifest["custom"] = custom;
-  }
   manifest["attacks_detected"] = detected_attack;
   manifest["installed_image"] = installed_image;
   manifest["ecu_serial"] = sconfig.ecu_serial;
   manifest["previous_timeserver_time"] = Utils::readFile(sconfig.previous_time_path.string());
   manifest["timeserver_time"] = Utils::readFile(sconfig.time_path.string());
 
-  std::string public_key = Utils::readFile((sconfig.full_client_dir / sconfig.ecu_public_key).string());
-  std::string private_key = Utils::readFile((sconfig.full_client_dir / sconfig.ecu_private_key).string());
   Json::Value signed_ecu_version = Crypto::signTuf(private_key, public_key, manifest);
   return signed_ecu_version;
 }
 
-void VirtualSecondary::setKeys(const std::string &public_key, const std::string &private_key) {
+void VirtualSecondary::storeKeys(const std::string &public_key, const std::string &private_key) {
   Utils::writeFile((sconfig.full_client_dir / sconfig.ecu_private_key).string(), private_key);
   Utils::writeFile((sconfig.full_client_dir / sconfig.ecu_public_key).string(), public_key);
 }
+
+bool VirtualSecondary::loadKeys(std::string *public_key, std::string *private_key) {
+  std::string public_key_path = (sconfig.full_client_dir / sconfig.ecu_public_key);
+  std::string private_key_path = (sconfig.full_client_dir / sconfig.ecu_private_key);
+
+  if (!boost::filesystem::exists(public_key_path) || !boost::filesystem::exists(private_key_path)) {
+    return false;
+  }
+
+  *private_key = Utils::readFile(private_key_path.string());
+  *public_key = Utils::readFile(public_key_path.string());
+}
+
 }

--- a/src/uptane/virtualsecondary.h
+++ b/src/uptane/virtualsecondary.h
@@ -15,19 +15,38 @@
 namespace Uptane {
 class VirtualSecondary : public SecondaryInterface {
  public:
-  VirtualSecondary(const SecondaryConfig &sconfig_in, Uptane::Repository *primary) : SecondaryInterface(sconfig_in);
+  VirtualSecondary(const SecondaryConfig &sconfig_in) : SecondaryInterface(sconfig_in);
 
-  void setKeys(const std::string &public_key, const std::string &private_key);
-  Json::Value verifyMeta(const TimeMeta &time_meta, const Root &root_meta, const Targets &targets_meta);
-  bool writeImage(const uint8_t *blob, size_t size);
-  Json::Value genAndSendManifest(Json::Value custom = Json::Value(Json::nullValue));
+  //void setKeys(const std::string &public_key, const std::string &private_key);
+  //bool writeImage(const uint8_t *blob, size_t size);
+  //Json::Value genAndSendManifest(Json::Value custom = Json::Value(Json::nullValue));
+
+  virtual std::string getPublicKey() { return public_key; }
+  virtual Json::Value getManifest();
+  virtual bool putMetadata(const MetaPack& meta_pack);
+  virtual int getRootVersion(bool director);
+  virtual bool putRoot(Uptane::Root root, bool director);
+
+  virtual bool sendFirmware(const uint8_t* blob, size_t size) = 0;
+
+
 
  private:
+  std::string public_key;
+  std::string private_key;
+
   std::string detected_attack;
-  bool wait_for_target;
   std::string expected_target_name;
   std::vector<Hash> expected_target_hashes;
   int64_t expected_target_length;
+
+  MetaPack current_meta;
+
+  void VirtualSecondary::storeKeys(const std::string &public_key, const std::string &private_key);
+  bool VirtualSecondary::loadKeys(std::string *public_key, std::string *private_key);
+
+  void VirtualSecondary::storeMetadata(const MetaPack& meta_pack);
+  bool VirtualSecondary::loadMetadata(MetaPack* meta_pack);
 };
 }
 


### PR DESCRIPTION
1. TimeMeta is deleted. It requires backend support and will be probably added in a different sprint.
2. ECU serial/hw_id generation is deleted. For testing it should be present in secondary config files, in future it can be reimplemented properly if needed.
3. Minor changes to SecondaryInterface.