### PR TITLE
Don't set is_registered if the device really isn't

### DIFF
--- a/src/fsstorage.cc
+++ b/src/fsstorage.cc
@@ -12,22 +12,8 @@ FSStorage::FSStorage(const Config& config) : config_(config) {
   boost::filesystem::create_directories(config_.tls.certificates_directory);
   boost::filesystem::create_directories(config_.uptane.metadata_path / "repo");
   boost::filesystem::create_directories(config_.uptane.metadata_path / "director");
-
-  // migrate from old aktualizr behavior if we already provisioned
-  boost::filesystem::path public_key_path = config_.tls.certificates_directory / config_.uptane.public_key_path;
-  boost::filesystem::path private_key_path = config_.tls.certificates_directory / config_.uptane.private_key_path;
-  boost::filesystem::path ca_path(config_.tls.ca_file());
-  boost::filesystem::path cert_path(config_.tls.client_certificate());
-  boost::filesystem::path pkey_path(config_.tls.pkey_file());
-  boost::filesystem::path device_id = config_.tls.certificates_directory / "device_id";
-  boost::filesystem::path primary_ecu_serial = config_.tls.certificates_directory / "primary_ecu_serial";
-  if (boost::filesystem::exists(public_key_path) && boost::filesystem::exists(private_key_path) &&
-      boost::filesystem::exists(ca_path) && boost::filesystem::exists(cert_path) &&
-      boost::filesystem::exists(pkey_path) && boost::filesystem::exists(device_id) &&
-      boost::filesystem::exists(primary_ecu_serial)) {
-    Utils::writeFile((config_.tls.certificates_directory / "is_registered").string(), std::string("1"));
-  }
 }
+
 FSStorage::~FSStorage() {
   // TODO: clear director_files, image_files
 }

--- a/tests/uptane_test.cc
+++ b/tests/uptane_test.cc
@@ -975,10 +975,13 @@ TEST(SotaUptaneClientTest, implicit_provision) {
   boost::filesystem::remove_all(uptane_test_dir);
 }
 
+/*
+Test removed until requirements are clarified
+
 TEST(SotaUptaneClientTest, CheckOldProvision) {
   boost::filesystem::path work_dir = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
   boost::filesystem::create_directories(work_dir);
-  system((std::string("cp -rf tests/test_data/oldprovdir/* ") + work_dir.string()).c_str());
+  system((std::string("cp -rf tests/test_data/oldprovdir/\* ") + work_dir.string()).c_str());
   Config config;
   config.tls.server = "nonexistent_server";
   config.tls.certificates_directory = work_dir;
@@ -988,7 +991,7 @@ TEST(SotaUptaneClientTest, CheckOldProvision) {
   Uptane::Repository uptane(config, storage, http);
   EXPECT_TRUE(uptane.initialize());  // It will fail in case of provisioning because of wrong server url
   boost::filesystem::remove_all(work_dir);
-}
+}*/
 
 #ifdef TEST_PKCS11_MODULE_PATH
 TEST(SotaUptaneClientTest, pkcs11_provision) {


### PR DESCRIPTION
'is_registered' is meant to indicate that ECUs are registered on the
backend, so no (other) local file can indicate the same. Current
behavior breaks certain scenarios where all these files are already
present at the time where aktualizr is called first time and also
decreases initialization robustness against interruptions. This commit
is basically reverting 4a9fb2b1b5d5d067b1bcd4675ce79433cd193039, so
migration from very old versions of aktualizr might be broken.