### PR TITLE
MakeLists.txt: Build aktuakizr_info if -DBUILD_OSTREE=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,9 @@ if(BUILD_SOTA_TOOLS)
     add_subdirectory("src/sota_tools")
 endif(BUILD_SOTA_TOOLS)
 
-add_subdirectory("src/aktualizr_info")
+if(BUILD_OSTREE)
+    add_subdirectory("src/aktualizr_info")
+endif(BUILD_OSTREE)
 
 include(CTest)
 add_subdirectory("tests" EXCLUDE_FROM_ALL)


### PR DESCRIPTION
Build executable aktuakizr_info only if BUILD_OSTREE
is enabled. Otherwise building of aktuakizr_info
will fail due to  error: "‘class FSStorage’ has
no member named ‘loadMetadata’".

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>