### PR TITLE
Enforce C++98/03 where it matters.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake-modules)
 # find all required libraries
 set(Boost_USE_STATIC_LIBS ON)
 find_package(PkgConfig REQUIRED)
-find_package(Boost 1.57.0 COMPONENTS system filesystem thread program_options log_setup log regex chrono random REQUIRED)
+find_package(Boost 1.57.0 COMPONENTS system filesystem thread program_options log_setup log chrono random REQUIRED)
 find_package(CURL REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(Threads REQUIRED)
@@ -148,12 +148,16 @@ include_directories(${LIBDBUS_INCLUDE_DIRS})
 include_directories(${sodium_INCLUDE_DIR})
 
 if(BUILD_GENIVI)
-    set(CMAKE_CXX_STANDARD 11)
     add_subdirectory("third_party/rvi_lib")
+    set_property(TARGET rvi PROPERTY CXX_STANDARD 11)
 endif(BUILD_GENIVI)
 
 # Setup warnings. Do this after rvi_lib is added so that it isn't affected.
 if (CMAKE_COMPILER_IS_GNUCXX)
+    # Still enforce C++98/03 for client-side code.
+    set(CMAKE_CXX_STANDARD 98)
+    # Do not use GNU or other extensions.
+    set(CMAKE_CXX_EXTENSIONS OFF)
     add_definitions(-fstack-protector-all)
     # Enable maximum set of warnings. -Wno-sign-compare is required because of
     # problems in gtest. -Wswitch-default and -Wconversion would be nice as

--- a/src/external_secondaries/CMakeLists.txt
+++ b/src/external_secondaries/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(myecuinterface ${MAIN_ECU_INTERFACE_SRC} dummy.cc)
 target_link_libraries(myecuinterface ${Boost_LIBRARIES})
 
 add_executable(aktualizr-validate-secondary-interface validate_secondary_interface_test.cc)
+set_property(TARGET aktualizr-validate-secondary-interface PROPERTY CXX_STANDARD 11)
 target_link_libraries(aktualizr-validate-secondary-interface ${Boost_LIBRARIES} gtest)
 
 aktualizr_source_file_checks(${MAIN_ECU_INTERFACE_SRC} ${ECU_INTERFACE_HEADERS} dummy.cc)

--- a/src/external_secondaries/validate_secondary_interface_test.cc
+++ b/src/external_secondaries/validate_secondary_interface_test.cc
@@ -1,7 +1,7 @@
-#include <boost/regex.hpp>
+#include <regex>
+#include <gtest/gtest.h>
 #include <boost/program_options.hpp>
 #include <boost/shared_ptr.hpp>
-#include <gtest/gtest.h>
 
 namespace bpo = boost::program_options;
 
@@ -11,7 +11,7 @@ std::string target;
 std::string exec(const std::string &cmd) {
   std::array<char, 128> buffer;
   std::string result;
-  boost::shared_ptr<FILE> pipe(popen(cmd.c_str(), "r"), pclose);
+  std::shared_ptr<FILE> pipe(popen(cmd.c_str(), "r"), pclose);
   if (!pipe) throw std::runtime_error("popen() failed!");
   while (!feof(pipe.get())) {
     if (fgets(buffer.data(), 128, pipe.get()) != nullptr) result += buffer.data();
@@ -35,12 +35,12 @@ TEST(ECUInterface, check_loglevel) {
 }
 
 bool isECUListValid(const std::string &output){
-  boost::smatch ecu_match;
-  boost::regex ecu_regex("\\w+(?: \\w+)?\\n?");
+  std::smatch ecu_match;
+  std::regex ecu_regex("\\w+(?: \\w+)?\\n?");
 
   unsigned int matched_symbols = 0;
   std::string::const_iterator search_start(output.cbegin());
-  while(boost::regex_search(search_start, output.cend(), ecu_match, ecu_regex)) {
+  while(std::regex_search(search_start, output.cend(), ecu_match, ecu_regex)) {
     matched_symbols += ecu_match.length();
     search_start += ecu_match.position() + ecu_match.length();
   }
@@ -59,11 +59,11 @@ TEST(ECUInterface, check_list_ecus_loglevel) {
 
 TEST(ECUInterface, install_good) {
 
-  boost::smatch ecu_match;
-  boost::regex ecu_regex("(\\w+) ?(\\w+)?\\n?");
+  std::smatch ecu_match;
+  std::regex ecu_regex("(\\w+) ?(\\w+)?\\n?");
   std::string output = exec(target + " list-ecus");
 
-  EXPECT_TRUE(boost::regex_search(output, ecu_match, ecu_regex));
+  EXPECT_TRUE(std::regex_search(output, ecu_match, ecu_regex));
   std::string cmd = target + " install-software  --firmware "+ firmware +" --hardware-identifier " + ecu_match[1].str();
 
   if (ecu_match.size() == 3){

--- a/src/sota_tools/CMakeLists.txt
+++ b/src/sota_tools/CMakeLists.txt
@@ -14,6 +14,7 @@ set (SOTA_TOOLS_LIB_SRC
 )
 
 add_library(sota_tools_static_lib STATIC ${SOTA_TOOLS_LIB_SRC})
+set_property(TARGET sota_tools_static_lib PROPERTY CXX_STANDARD 11)
 
 ##### garage-push targets
 
@@ -22,6 +23,7 @@ set (GARAGE_PUSH_SRCS
 )
 
 add_executable(garage-push ${GARAGE_PUSH_SRCS})
+set_property(TARGET garage-push PROPERTY CXX_STANDARD 11)
 
 # Export compile_commands.json for clang-check
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -48,6 +50,7 @@ set (GARAGE_CHECK_SRCS
 )
 
 add_executable(garage-check ${GARAGE_CHECK_SRCS})
+set_property(TARGET garage-check PROPERTY CXX_STANDARD 11)
 
 target_link_libraries(garage-check sota_tools_static_lib aktualizr_static_lib
   ${Boost_LIBRARIES}
@@ -69,6 +72,7 @@ set (GARAGE_DEPLOY_SRCS
 )
 
 add_executable(garage-deploy ${GARAGE_DEPLOY_SRCS})
+set_property(TARGET garage-deploy PROPERTY CXX_STANDARD 11)
 target_link_libraries(garage-deploy sota_tools_static_lib aktualizr_static_lib
   ${Boost_LIBRARIES}
   ${CMAKE_THREAD_LIBS_INIT}

--- a/src/sota_tools/Dockerfile
+++ b/src/sota_tools/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get update -q && apt-get -qy install \
   libboost-log-dev \
   libboost-program-options-dev \
   libboost-random-dev \
-  libboost-regex-dev \
   libboost-system-dev \
   libcurl4-gnutls-dev \
   libglib2.0-dev \


### PR DESCRIPTION
* Do not tolerate GNU or other extensions.
* Build sota_tools with C++11.
* Revert 8aee6ac8e9dbef2e2dd290f4e74c2872c502177e and instead build aktualizr-validate-secondary-interface with C++11.
* Do not link with boost regex since we don't use it.