### PR TITLE
Move updateSecondaries function to SotaUptaneClient

### DIFF
--- a/src/sotauptaneclient.h
+++ b/src/sotauptaneclient.h
@@ -16,7 +16,7 @@
 class SotaUptaneClient {
  public:
   SotaUptaneClient(const Config &config_in, event::Channel *events_channel_in, Uptane::Repository &repo);
-  void OstreeInstallAndManifest(const Uptane::Target &package);
+  void OstreeInstallSetResult(const Uptane::Target &package);
   void runForever(command::Channel *commands_channel);
 
   Json::Value AssembleManifest();

--- a/src/sotauptaneclient.h
+++ b/src/sotauptaneclient.h
@@ -16,7 +16,7 @@
 class SotaUptaneClient {
  public:
   SotaUptaneClient(const Config &config_in, event::Channel *events_channel_in, Uptane::Repository &repo);
-  Json::Value OstreeInstallAndManifest(const Uptane::Target &package);
+  void OstreeInstallAndManifest(const Uptane::Target &package);
   void runForever(command::Channel *commands_channel);
 
   Json::Value AssembleManifest();
@@ -29,6 +29,7 @@ class SotaUptaneClient {
   void reportInstalledPackages();
   void run(command::Channel *commands_channel);
   OstreePackage uptaneToOstree(const Uptane::Target &target);
+  void updateSecondaries(std::vector<Uptane::Target> targets);
 
   Config config;
   event::Channel *events_channel;
@@ -36,4 +37,5 @@ class SotaUptaneClient {
   // ecu_serial -> secondary*
   std::map<std::string, boost::shared_ptr<Uptane::SecondaryInterface> > secondaries;
   int last_targets_version;
+  Json::Value operation_result;
 };

--- a/src/uptane/managedsecondary.cc
+++ b/src/uptane/managedsecondary.cc
@@ -79,32 +79,31 @@ bool ManagedSecondary::putRoot(Uptane::Root root, const bool director) {
   return true;
 }
 
-bool ManagedSecondary::sendFirmware(const uint8_t *blob, size_t size) {
+bool ManagedSecondary::sendFirmware(const std::string &data) {
   if (expected_target_name.empty()) return true;
   if (!detected_attack.empty()) return true;
 
-  if (size > expected_target_length) {
+  if (data.size() > expected_target_length) {
     detected_attack = "overflow";
     return true;
   }
-  // TODO: this cast shouldn't be necessary, right?
-  std::string content = std::string((const char *)blob, size);
+
   std::vector<Hash>::const_iterator it;
   for (it = expected_target_hashes.begin(); it != expected_target_hashes.end(); it++) {
     if (it->TypeString() == "sha256") {
-      if (boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(content))) != it->HashString()) {
+      if (boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(data))) != it->HashString()) {
         detected_attack = "wrong_hash";
         return true;
       }
     } else if (it->TypeString() == "sha512") {
-      if (boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha512digest(content))) != it->HashString()) {
+      if (boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha512digest(data))) != it->HashString()) {
         detected_attack = "wrong_hash";
         return true;
       }
     }
   }
   detected_attack = "";
-  return storeFirmware(expected_target_name, content);
+  return storeFirmware(expected_target_name, data);
 }
 
 Json::Value ManagedSecondary::getManifest() {

--- a/src/uptane/managedsecondary.h
+++ b/src/uptane/managedsecondary.h
@@ -26,7 +26,7 @@ class ManagedSecondary : public SecondaryInterface {
   virtual int getRootVersion(const bool director);
   virtual bool putRoot(Uptane::Root root, const bool director);
 
-  virtual bool sendFirmware(const uint8_t* blob, size_t size);
+  virtual bool sendFirmware(const std::string& data);
   virtual Json::Value getManifest();
 
  private:

--- a/src/uptane/secondaryinterface.h
+++ b/src/uptane/secondaryinterface.h
@@ -30,7 +30,7 @@ class SecondaryInterface {
   virtual int getRootVersion(bool director) = 0;
   virtual bool putRoot(Uptane::Root root, bool director) = 0;
 
-  virtual bool sendFirmware(const uint8_t* blob, size_t size) = 0;
+  virtual bool sendFirmware(const std::string& data) = 0;
 
  protected:
   SecondaryConfig sconfig;

--- a/src/uptane/uptanerepository.cc
+++ b/src/uptane/uptanerepository.cc
@@ -50,7 +50,7 @@ bool Repository::putManifest(const Json::Value &version_manifests) {
   return response.isOk();
 }
 
-Json::Value Repository::getCurrentVersionManifests(const Json::Value &primary_version_manifest) {
+Json::Value Repository::signVersionManifest(const Json::Value &primary_version_manifest) {
   ENGINE *crypto_engine = NULL;
 #ifdef BUILD_P11
   if (key_source == kPkcs11) crypto_engine = p11.getEngine();

--- a/src/uptane/uptanerepository.cc
+++ b/src/uptane/uptanerepository.cc
@@ -119,33 +119,6 @@ std::pair<int, std::vector<Uptane::Target> > Repository::getTargets() {
   return std::pair<uint32_t, std::vector<Uptane::Target> >(version, director_targets);
 }
 
-Json::Value Repository::updateSecondaries(const std::vector<Uptane::Target> &secondary_targets) {
-  // TODO: may be quite resource consuming, consider storing map ecu_serial -> SecondaryConfig as a member instead
-  // map from ecu_serial -> SecondaryInterface now exists in sotauptaneclient.
-  std::map<std::string, const Uptane::Target *> targets_by_serial;
-  std::vector<Uptane::Target>::const_iterator t_it;
-  for (t_it = secondary_targets.begin(); t_it != secondary_targets.end(); t_it++) {
-    targets_by_serial[t_it->ecu_identifier()] = &*t_it;
-  }
-  std::vector<SecondaryConfig>::const_iterator sec_it;
-  for (sec_it = config.uptane.secondary_configs.begin(); sec_it != config.uptane.secondary_configs.end(); sec_it++) {
-    if (targets_by_serial.find(sec_it->ecu_serial) != targets_by_serial.end()) {
-      // TODO: when metadata verification is separated from image loading (see comments in sotauptaneclient.cc) it
-      // should be rewritten
-      Uptane::MetaPack meta;
-      if (!storage.loadMetadata(&meta)) {
-        throw std::runtime_error("No valid metadata, but trying to upload firmware");
-      }
-      Json::Value resp;
-      // if (it->partial_verifying) {
-      // resp = it->transport->sendMetaPartial(meta.director_root, meta.director_targets);
-      //} else {
-      //}
-    }
-  }
-  return Json::Value();  // transport.sendTargets(secondary_targets);
-}
-
 void Repository::saveInstalledVersion(const Target &target) {
   std::string versions_str;
   storage.loadInstalledVersions(&versions_str);

--- a/src/uptane/uptanerepository.h
+++ b/src/uptane/uptanerepository.h
@@ -34,7 +34,7 @@ class Repository {
  public:
   Repository(const Config &config, INvStorage &storage, HttpInterface &http_client);
   bool putManifest(const Json::Value &version_manifests);
-  Json::Value getCurrentVersionManifests(const Json::Value &version_manifests);
+  Json::Value signVersionManifest(const Json::Value &version_manifests);
   void addSecondary(const std::string &ecu_serial, const std::string &hardware_identifier,
                     const std::string &public_key) {
     secondary_info[ecu_serial] = std::make_pair(hardware_identifier, public_key);

--- a/src/uptane/uptanerepository.h
+++ b/src/uptane/uptanerepository.h
@@ -39,7 +39,6 @@ class Repository {
                     const std::string &public_key) {
     secondary_info[ecu_serial] = std::make_pair(hardware_identifier, public_key);
   }
-  Json::Value updateSecondaries(const std::vector<Uptane::Target> &secondary_targets);
   std::pair<int, std::vector<Uptane::Target> > getTargets();
   std::string getPrimaryEcuSerial() const { return primary_ecu_serial; };
   std::string getPrimaryHardwareId() const { return primary_hardware_id_; };
@@ -53,6 +52,8 @@ class Repository {
   // TODO: only used by tests, rewrite test and delete this method
   void updateRoot(Version version = Version());
   // TODO: Receive and update time nonces.
+
+  bool currentMeta(Uptane::MetaPack *meta) { return storage.loadMetadata(meta); }
 
  private:
   Config config;

--- a/tests/uptane_ci_test.cc
+++ b/tests/uptane_ci_test.cc
@@ -32,7 +32,7 @@ TEST(SotaUptaneClientTest, OneCycleUpdate) {
   Json::Value unsigned_ecu_version =
       OstreePackage(refname, hash, "").toEcuVersion(repo.getPrimaryEcuSerial(), Json::nullValue);
 
-  EXPECT_TRUE(repo.putManifest(repo.getCurrentVersionManifests(unsigned_ecu_version)));
+  EXPECT_TRUE(repo.putManifest(repo.signVersionManifest(unsigned_ecu_version)));
 
   // should not throw any exceptions
   repo.getTargets();


### PR DESCRIPTION
The client now appends operation_result to every manifest, backend's reaction should be tested. If it's OK with it, the second call to putManifest() can be removed.