### PR TITLE
Do not use branch name when pulling OSTree commits

### DIFF
--- a/src/ostree.cc
+++ b/src/ostree.cc
@@ -92,10 +92,8 @@ OstreePackage::OstreePackage(const std::string &ref_name_in, const std::string &
                              const std::string &treehub_in)
     : ref_name(ref_name_in), refhash(refhash_in), pull_uri(treehub_in) {}
 
-data::InstallOutcome OstreePackage::install(const data::PackageManagerCredentials &cred, OstreeConfig config,
-                                            const std::string &refspec) const {
+data::InstallOutcome OstreePackage::install(const data::PackageManagerCredentials &cred, OstreeConfig config) const {
   const char remote[] = "aktualizr-remote";
-  const char *const refs[] = {refspec.c_str()};
   const char *const commit_ids[] = {refhash.c_str()};
   const char *opt_osname = NULL;
   OstreeRepo *repo = NULL;
@@ -122,9 +120,7 @@ data::InstallOutcome OstreePackage::install(const data::PackageManagerCredential
   g_variant_builder_init(&builder, G_VARIANT_TYPE("a{sv}"));
   g_variant_builder_add(&builder, "{s@v}", "flags", g_variant_new_variant(g_variant_new_int32(0)));
 
-  g_variant_builder_add(&builder, "{s@v}", "refs", g_variant_new_variant(g_variant_new_strv(refs, 1)));
-  g_variant_builder_add(&builder, "{s@v}", "override-commit-ids",
-                        g_variant_new_variant(g_variant_new_strv(commit_ids, 1)));
+  g_variant_builder_add(&builder, "{s@v}", "refs", g_variant_new_variant(g_variant_new_strv(commit_ids, 1)));
 
   options = g_variant_ref_sink(g_variant_builder_end(&builder));
 
@@ -135,7 +131,7 @@ data::InstallOutcome OstreePackage::install(const data::PackageManagerCredential
     return install_outcome;
   }
 
-  GKeyFile *origin = ostree_sysroot_origin_new_from_refspec(sysroot.get(), refs[0]);
+  GKeyFile *origin = ostree_sysroot_origin_new_from_refspec(sysroot.get(), commit_ids[0]);
   if (!ostree_repo_resolve_rev(repo, refhash.c_str(), FALSE, &revision, &error)) {
     LOGGER_LOG(LVL_error, error->message);
     data::InstallOutcome install_outcome(data::INSTALL_FAILED, error->message);

--- a/src/ostree.h
+++ b/src/ostree.h
@@ -22,8 +22,7 @@ class OstreePackage {
   std::string ref_name;
   std::string refhash;
   std::string pull_uri;
-  data::InstallOutcome install(const data::PackageManagerCredentials &cred, OstreeConfig config,
-                               const std::string &refspec) const;
+  data::InstallOutcome install(const data::PackageManagerCredentials &cred, OstreeConfig config) const;
 
   Json::Value toEcuVersion(const std::string &ecu_serial, const Json::Value &custom) const;
   static std::string getCurrent(const std::string &ostree_sysroot);

--- a/src/sotauptaneclient.cc
+++ b/src/sotauptaneclient.cc
@@ -114,7 +114,7 @@ data::InstallOutcome SotaUptaneClient::OstreeInstall(const Uptane::Target &targe
     cred.pkey_file = tmp_pkey_file.Path().native();
     cred.cert_file = tmp_cert_file.Path().native();
 #endif
-    return package.install(cred, config.ostree, uptane_repo.getPrimaryHardwareId());
+    return package.install(cred, config.ostree);
   } catch (std::exception &ex) {
     return data::InstallOutcome(data::INSTALL_FAILED, ex.what());
   }

--- a/tests/fake_ostree.cc
+++ b/tests/fake_ostree.cc
@@ -4,11 +4,9 @@ OstreePackage::OstreePackage(const std::string &ref_name_in, const std::string &
                              const std::string &treehub_in)
     : ref_name(ref_name_in), refhash(refhash_in), pull_uri(treehub_in) {}
 
-data::InstallOutcome OstreePackage::install(const data::PackageManagerCredentials &cred, OstreeConfig config,
-                                            const std::string &refspec) const {
+data::InstallOutcome OstreePackage::install(const data::PackageManagerCredentials &cred, OstreeConfig config) const {
   (void)cred;
   (void)config;
-  (void)refspec;
   return data::InstallOutcome(data::OK, "Good");
 }
 


### PR DESCRIPTION
Maintaining consistency of branch names on remote server and on the device is an error-prone process and the branch name is not really required.