### PR TITLE
Tolerate (ignore) whitespace in api-version output.

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -424,6 +424,7 @@ void Config::initLegacySecondaries(const std::string& legacy_interface) {
 
   std::stringstream ss(output);
   std::string buffer;
+  unsigned int index = 0;
   while (std::getline(ss, buffer, '\n')) {
     Uptane::SecondaryConfig sconfig;
     sconfig.secondary_type = Uptane::kLegacy;
@@ -448,7 +449,7 @@ void Config::initLegacySecondaries(const std::string& legacy_interface) {
     sconfig.ecu_private_key = "sec.private";
     sconfig.ecu_public_key = "sec.public";
 
-    sconfig.full_client_dir = storage.path / sconfig.ecu_serial;
+    sconfig.full_client_dir = storage.path / (sconfig.ecu_hardware_id + "-" + Utils::intToString(++index));
     sconfig.firmware_path = sconfig.full_client_dir / "firmware.bin";
     sconfig.metadata_path = sconfig.full_client_dir / "metadata";
     sconfig.target_name_path = sconfig.full_client_dir / "target_name";
@@ -459,7 +460,7 @@ void Config::initLegacySecondaries(const std::string& legacy_interface) {
 }
 
 // This writes out every configuration option, including those set with default
-// and blank values. This may be useful to replicating an exact configuration
+// and blank values. This may be useful for replicating an exact configuration
 // environment. However, if we were to want to simplify the output file, we
 // could skip blank strings or compare values against a freshly built instance
 // to detect and skip default values.

--- a/src/config.cc
+++ b/src/config.cc
@@ -401,7 +401,7 @@ bool Config::checkLegacyVersion(const std::string& legacy_interface) {
   if (rs != 0) {
     LOGGER_LOG(LVL_error, "Legacy external flasher api-version command failed: " << output);
   } else {
-    boost::trim_if(output, boost::is_any_of(", \n\r\t"));
+    boost::trim_if(output, boost::is_any_of(" \n\r\t"));
     if (output != "1") {
       LOGGER_LOG(LVL_error, "Unexpected legacy external flasher API version: " << output);
     } else {
@@ -429,7 +429,7 @@ void Config::initLegacySecondaries(const std::string& legacy_interface) {
     Uptane::SecondaryConfig sconfig;
     sconfig.secondary_type = Uptane::kLegacy;
     std::vector<std::string> ecu_info;
-    boost::split(ecu_info, buffer, boost::is_any_of(", \n\r\t"), boost::token_compress_on);
+    boost::split(ecu_info, buffer, boost::is_any_of(" \n\r\t"), boost::token_compress_on);
     if (ecu_info.size() == 0) {
       // Could print a warning but why bother.
       continue;

--- a/src/config.h
+++ b/src/config.h
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <iostream>
 #include <string>
+#include <vector>
 
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
@@ -225,6 +226,7 @@ class Config {
   void updateFromPropertyTree(const boost::property_tree::ptree& pt);
   void updateFromToml(const std::string& filename);
   void updateFromCommandLine(const boost::program_options::variables_map& cmd);
+  void readSecondaryConfigs(const std::vector<std::string>& sconfigs);
   bool checkLegacyVersion(const std::string& legacy_interface);
   void initLegacySecondaries(const std::string& legacy_interface);
 };

--- a/src/config.h
+++ b/src/config.h
@@ -225,6 +225,8 @@ class Config {
   void updateFromPropertyTree(const boost::property_tree::ptree& pt);
   void updateFromToml(const std::string& filename);
   void updateFromCommandLine(const boost::program_options::variables_map& cmd);
+  bool checkLegacyVersion(const std::string& legacy_interface);
+  void initLegacySecondaries(const std::string& legacy_interface);
 };
 
 #endif  // CONFIG_H_

--- a/src/uptane/legacysecondary.cc
+++ b/src/uptane/legacysecondary.cc
@@ -23,8 +23,8 @@ bool LegacySecondary::storeFirmware(const std::string& target_name, const std::s
   std::stringstream command;
   std::string output;
   command << sconfig.flasher.string() << " install-software --hardware-identifier " << sconfig.ecu_hardware_id
-          << " --ecu-identifier " << sconfig.ecu_serial << " --firmware " << sconfig.firmware_path.string()
-          << " --loglevel " << loggerGetSeverity();
+          << " --ecu-identifier " << getSerial() << " --firmware " << sconfig.firmware_path.string() << " --loglevel "
+          << loggerGetSeverity();
   int rs = Utils::shell(command.str(), &output);
 
   if (rs != 0) {


### PR DESCRIPTION
Just in case someone ever included it.

This is also just a bit of a refactor to clean up that section of the code.