### PR TITLE
Do not try to unpack boostrap credentials when no-root is specified

### DIFF
--- a/config/sota_implicit_prov.toml
+++ b/config/sota_implicit_prov.toml
@@ -7,6 +7,3 @@ tls_pkey_path = "pkey.pem"
 uptane_metadata_path = "metadata"
 uptane_private_key_path = "ecukey.der"
 uptane_public_key_path = "ecukey.pub"
-
-[import]
-tls_cacert_path = "/usr/lib/sota/root.crt"

--- a/src/implicit_writer/main.cc
+++ b/src/implicit_writer/main.cc
@@ -86,10 +86,10 @@ int main(int argc, char *argv[]) {
   std::cout << "Reading config file: " << config_in_path << "\n";
   Config config(config_in_path);
 
-  Bootstrap boot(credentials_path, "");
-  boost::filesystem::path ca_path(prefix);
-  ca_path /= config.import.tls_cacert_path;
   if (!no_root) {
+    Bootstrap boot(credentials_path, "");
+    boost::filesystem::path ca_path(prefix);
+    ca_path /= config.import.tls_cacert_path;
     std::cout << "Writing root CA: " << ca_path << "\n";
     Utils::writeFile(ca_path.string(), boot.getCa());
   }

--- a/src/implicit_writer/main.cc
+++ b/src/implicit_writer/main.cc
@@ -89,6 +89,7 @@ int main(int argc, char *argv[]) {
   if (!no_root) {
     Bootstrap boot(credentials_path, "");
     boost::filesystem::path ca_path(prefix);
+    config.import.tls_cacert_path = "/usr/lib/sota/root.crt";
     ca_path /= config.import.tls_cacert_path;
     std::cout << "Writing root CA: " << ca_path << "\n";
     Utils::writeFile(ca_path.string(), boot.getCa());


### PR DESCRIPTION
Required to support _real_ implicit provisioning