### PR TITLE
Bugfix/pro 4531/persistent legacies

### DIFF
--- a/src/aktualizr.h
+++ b/src/aktualizr.h
@@ -5,12 +5,12 @@
 
 class Aktualizr : public boost::noncopyable {
  public:
-  Aktualizr(const Config &config);
+  Aktualizr(const Config& config);
 
   int run();
 
  private:
-  Config config_;
+  const Config& config_;
 };
 
 #endif  // AKTUALIZR_H_

--- a/src/config.cc
+++ b/src/config.cc
@@ -425,7 +425,6 @@ void Config::initLegacySecondaries(const std::string& legacy_interface) {
 
   std::stringstream ss(output);
   std::string buffer;
-  unsigned int index = 0;
   while (std::getline(ss, buffer, '\n')) {
     Uptane::SecondaryConfig sconfig;
     sconfig.secondary_type = Uptane::kLegacy;
@@ -436,12 +435,15 @@ void Config::initLegacySecondaries(const std::string& legacy_interface) {
       continue;
     } else if (ecu_info.size() == 1) {
       sconfig.ecu_hardware_id = ecu_info[0];
-      sconfig.ecu_serial = "";  // Initialized in ManagedSecondary constructor.
+      // Use getSerial, which will get the public_key_id, initialized in ManagedSecondary constructor.
+      sconfig.ecu_serial = "";
+      sconfig.full_client_dir = storage.path / sconfig.ecu_hardware_id;
       LOGGER_LOG(LVL_info, "Legacy ECU configured with hardware ID " << sconfig.ecu_hardware_id);
     } else if (ecu_info.size() >= 2) {
       // For now, silently ignore anything after the second token.
       sconfig.ecu_hardware_id = ecu_info[0];
       sconfig.ecu_serial = ecu_info[1];
+      sconfig.full_client_dir = storage.path / (sconfig.ecu_hardware_id + "-" + sconfig.ecu_serial);
       LOGGER_LOG(LVL_info, "Legacy ECU configured with hardware ID " << sconfig.ecu_hardware_id << " and serial "
                                                                      << sconfig.ecu_serial);
     }
@@ -450,7 +452,6 @@ void Config::initLegacySecondaries(const std::string& legacy_interface) {
     sconfig.ecu_private_key = "sec.private";
     sconfig.ecu_public_key = "sec.public";
 
-    sconfig.full_client_dir = storage.path / (sconfig.ecu_hardware_id + "-" + Utils::intToString(++index));
     sconfig.firmware_path = sconfig.full_client_dir / "firmware.bin";
     sconfig.metadata_path = sconfig.full_client_dir / "metadata";
     sconfig.target_name_path = sconfig.full_client_dir / "target_name";

--- a/src/dbusgateway/dbusgateway.h
+++ b/src/dbusgateway/dbusgateway.h
@@ -24,7 +24,7 @@ class DbusGateway : public Gateway {
   boost::thread thread;
   boost::atomic<bool> stop;
   data::OperationResult getOperationResult(DBusMessageIter *);
-  Config config;
+  const Config &config;
   command::Channel *command_channel;
   DBusError err;
   DBusConnection *conn;

--- a/src/dbusgateway/swlm.h
+++ b/src/dbusgateway/swlm.h
@@ -12,7 +12,7 @@ class SoftwareLoadingManagerProxy {
   void downloadComplete(const std::string &update_image, const std::string &signature);
 
  private:
-  Config config;
+  const Config &config;
   DBusError err;
   DBusConnection *conn;
 };

--- a/src/eventsinterpreter.h
+++ b/src/eventsinterpreter.h
@@ -16,7 +16,7 @@ class EventsInterpreter {
   void run();
 
  private:
-  Config config;
+  const Config &config;
   boost::thread thread;
   event::Channel *events_channel;
   command::Channel *commands_channel;

--- a/src/external_secondaries/example_interface.cc
+++ b/src/external_secondaries/example_interface.cc
@@ -5,7 +5,7 @@
 #include "ecuinterface.h"
 #include "utils.h"
 
-const std::string filename = "/tmp/example_serial";
+const std::string filename = "/var/sota/example_serial";
 std::string serial;
 
 ECUInterface::ECUInterface(const unsigned int loglevel) : loglevel_(loglevel) {

--- a/src/fsstorage.cc
+++ b/src/fsstorage.cc
@@ -223,9 +223,10 @@ void FSStorage::storeEcuSerials(const std::vector<std::pair<std::string, std::st
     boost::filesystem::remove_all((config_.path / "secondaries_list"));
     std::vector<std::pair<std::string, std::string> >::const_iterator it;
     std::ofstream file((config_.path / "secondaries_list").string().c_str());
-    for (it = serials.begin() + 1; it != serials.end(); it++)
+    for (it = serials.begin() + 1; it != serials.end(); it++) {
       // Assuming that there are no tabs and linebreaks in serials and hardware ids
       file << it->first << "\t" << it->second << "\n";
+    }
     file.close();
   }
 }
@@ -234,15 +235,20 @@ bool FSStorage::loadEcuSerials(std::vector<std::pair<std::string, std::string> >
   std::string buf;
   std::string serial;
   std::string hw_id;
-  if (!boost::filesystem::exists((config_.path / "primary_ecu_serial"))) return false;
+  if (!boost::filesystem::exists((config_.path / "primary_ecu_serial"))) {
+    return false;
+  }
   serial = Utils::readFile((config_.path / "primary_ecu_serial").string());
   // use default hardware ID for backwards compatibility
-  if (!boost::filesystem::exists((config_.path / "primary_ecu_hardware_id")))
+  if (!boost::filesystem::exists((config_.path / "primary_ecu_hardware_id"))) {
     hw_id = Utils::getHostname();
-  else
+  } else {
     hw_id = Utils::readFile((config_.path / "primary_ecu_hardware_id").string());
+  }
 
-  if (serials) serials->push_back(std::pair<std::string, std::string>(serial, hw_id));
+  if (serials) {
+    serials->push_back(std::pair<std::string, std::string>(serial, hw_id));
+  }
 
   // return true for backwards compatibility
   if (!boost::filesystem::exists((config_.path / "secondaries_list"))) {
@@ -255,11 +261,15 @@ bool FSStorage::loadEcuSerials(std::vector<std::pair<std::string, std::string> >
     try {
       hw_id = buf.substr(tab + 1);
     } catch (const std::out_of_range& e) {
-      if (serials) serials->clear();
+      if (serials) {
+        serials->clear();
+      }
       file.close();
       return false;
     }
-    if (serials) serials->push_back(std::pair<std::string, std::string>(serial, hw_id));
+    if (serials) {
+      serials->push_back(std::pair<std::string, std::string>(serial, hw_id));
+    }
   }
   file.close();
   return true;
@@ -276,7 +286,9 @@ void FSStorage::storeInstalledVersions(const std::string& content) {
 }
 
 bool FSStorage::loadInstalledVersions(std::string* content) {
-  if (!boost::filesystem::exists(config_.path / "installed_versions")) return false;
+  if (!boost::filesystem::exists(config_.path / "installed_versions")) {
+    return false;
+  }
   *content = Utils::readFile((config_.path / "installed_versions").string());
   return true;
 }

--- a/src/fsstorage.h
+++ b/src/fsstorage.h
@@ -43,7 +43,7 @@ class FSStorage : public INvStorage {
   virtual bool loadInstalledVersions(std::string* content);
 
  private:
-  StorageConfig config_;
+  const StorageConfig& config_;
   // descriptors of currently downloaded files
   std::map<std::string, FILE*> director_files;
   std::map<std::string, FILE*> image_files;

--- a/src/socketgateway.cc
+++ b/src/socketgateway.cc
@@ -129,7 +129,7 @@ void SocketGateway::broadcast_event(const boost::shared_ptr<event::BaseEvent> &e
 }
 
 void SocketGateway::processEvent(const boost::shared_ptr<event::BaseEvent> &event) {
-  std::vector<std::string>::iterator find_iter =
+  std::vector<std::string>::const_iterator find_iter =
       std::find(config.network.socket_events.begin(), config.network.socket_events.end(), event->variant);
   if (find_iter != config.network.socket_events.end()) {
     broadcast_event(event);

--- a/src/socketgateway.h
+++ b/src/socketgateway.h
@@ -16,7 +16,7 @@ class SocketGateway : public Gateway, boost::noncopyable {
   virtual void processEvent(const boost::shared_ptr<event::BaseEvent> &event);
 
  private:
-  Config config;
+  const Config &config;
   command::Channel *commands_channel;
   std::vector<int> event_connections;
   std::vector<int> command_connections;

--- a/src/sotarviclient.h
+++ b/src/sotarviclient.h
@@ -38,13 +38,13 @@ public:
 private:
     TRviHandle rvi;
     std::map<std::string, std::vector<int> > chunks_map;
-    Config config;
+    const Config &config;
     int connection;
     event::Channel * events_channel;
     Json::Value services;
     bool stop;
     boost::thread thread;
-    
+
 
 };
 

--- a/src/sotauptaneclient.cc
+++ b/src/sotauptaneclient.cc
@@ -15,19 +15,7 @@
 
 SotaUptaneClient::SotaUptaneClient(const Config &config_in, event::Channel *events_channel_in, Uptane::Repository &repo)
     : config(config_in), events_channel(events_channel_in), uptane_repo(repo), last_targets_version(-1) {
-  std::vector<Uptane::SecondaryConfig>::iterator it;
-  for (it = config.uptane.secondary_configs.begin(); it != config.uptane.secondary_configs.end(); ++it) {
-    boost::shared_ptr<Uptane::SecondaryInterface> sec = Uptane::SecondaryFactory::makeSecondary(*it);
-    std::string sec_serial = sec->getSerial();
-    std::map<std::string, boost::shared_ptr<Uptane::SecondaryInterface> >::const_iterator map_it =
-        secondaries.find(sec_serial);
-    if (map_it != secondaries.end()) {
-      LOGGER_LOG(LVL_error, "Multiple secondaries found with the same serial: " << sec_serial);
-      continue;
-    }
-    secondaries[sec_serial] = sec;
-    uptane_repo.addSecondary(sec_serial, sec->getHwId(), sec->getPublicKey());
-  }
+  initSecondaries();
 }
 
 void SotaUptaneClient::run(command::Channel *commands_channel) {
@@ -171,6 +159,7 @@ void SotaUptaneClient::runForever(command::Channel *commands_channel) {
   if (!uptane_repo.initialize()) {
     throw std::runtime_error("Fatal error of tls or ecu device registration");
   }
+  verifySecondaries();
   LOGGER_LOG(LVL_debug, "... provisioned OK");
   reportHwInfo();
   reportInstalledPackages();
@@ -234,6 +223,73 @@ void SotaUptaneClient::runForever(command::Channel *commands_channel) {
       LOGGER_LOG(LVL_error, e.what());
     } catch (const std::exception &ex) {
       LOGGER_LOG(LVL_error, "Unknown exception was thrown: " << ex.what());
+    }
+  }
+}
+
+void SotaUptaneClient::initSecondaries() {
+  std::vector<Uptane::SecondaryConfig>::iterator it;
+  for (it = config.uptane.secondary_configs.begin(); it != config.uptane.secondary_configs.end(); ++it) {
+    boost::shared_ptr<Uptane::SecondaryInterface> sec = Uptane::SecondaryFactory::makeSecondary(*it);
+    std::string sec_serial = sec->getSerial();
+    std::map<std::string, boost::shared_ptr<Uptane::SecondaryInterface> >::const_iterator map_it =
+        secondaries.find(sec_serial);
+    if (map_it != secondaries.end()) {
+      LOGGER_LOG(LVL_error, "Multiple secondaries found with the same serial: " << sec_serial);
+      continue;
+    }
+    secondaries[sec_serial] = sec;
+    uptane_repo.addSecondary(sec_serial, sec->getHwId(), sec->getPublicKey());
+  }
+}
+
+struct SerialCompare {
+  std::string target;
+  bool operator()(std::pair<std::string, std::string> &in) { return (in.first == target); }
+};
+
+// Check stored secondaries list against secondaries known to aktualizr via
+// commandline input and legacy interface.
+void SotaUptaneClient::verifySecondaries() {
+  std::vector<std::pair<std::string, std::string> > serials;
+  if (!uptane_repo.storage.loadEcuSerials(&serials) || serials.empty()) {
+    LOGGER_LOG(LVL_error, "No ECU serials found in storage!");
+    return;
+  }
+
+  std::vector<bool> found(serials.size(), false);
+  SerialCompare primary_comp;
+
+  primary_comp.target = uptane_repo.getPrimaryEcuSerial();
+  // Should be a const_iterator but we need C++11 for cbegin.
+  std::vector<std::pair<std::string, std::string> >::iterator store_it;
+  store_it = std::find_if(serials.begin(), serials.end(), primary_comp);
+  if (store_it == serials.end()) {
+    LOGGER_LOG(LVL_error, "Primary ECU serial " << uptane_repo.getPrimaryEcuSerial() << " not found in storage!");
+  } else {
+    found[std::distance(serials.begin(), store_it)] = true;
+  }
+
+  std::map<std::string, boost::shared_ptr<Uptane::SecondaryInterface> >::const_iterator it;
+  for (it = secondaries.begin(); it != secondaries.end(); ++it) {
+    primary_comp.target = it->second->getSerial();
+    store_it = std::find_if(serials.begin(), serials.end(), primary_comp);
+    if (store_it == serials.end()) {
+      LOGGER_LOG(LVL_error, "Secondary ECU serial " << it->second->getSerial() << " (hardware ID "
+                                                    << it->second->getHwId() << ") not found in storage!");
+    } else if (found[std::distance(serials.begin(), store_it)] == true) {
+      LOGGER_LOG(LVL_error, "Secondary ECU serial " << it->second->getSerial() << " (hardware ID "
+                                                    << it->second->getHwId() << ") has a duplicate entry in storage!");
+    } else {
+      found[std::distance(serials.begin(), store_it)] = true;
+    }
+  }
+
+  std::vector<bool>::iterator found_it;
+  for (found_it = found.begin(); found_it != found.end(); ++found_it) {
+    if (!*found_it) {
+      LOGGER_LOG(LVL_warning, "ECU serial " << serials[std::distance(found.begin(), found_it)].first
+                                            << " in storage was not reported to aktualizr!");
     }
   }
 }

--- a/src/sotauptaneclient.cc
+++ b/src/sotauptaneclient.cc
@@ -228,7 +228,7 @@ void SotaUptaneClient::runForever(command::Channel *commands_channel) {
 }
 
 void SotaUptaneClient::initSecondaries() {
-  std::vector<Uptane::SecondaryConfig>::iterator it;
+  std::vector<Uptane::SecondaryConfig>::const_iterator it;
   for (it = config.uptane.secondary_configs.begin(); it != config.uptane.secondary_configs.end(); ++it) {
     boost::shared_ptr<Uptane::SecondaryInterface> sec = Uptane::SecondaryFactory::makeSecondary(*it);
     std::string sec_serial = sec->getSerial();

--- a/src/sotauptaneclient.cc
+++ b/src/sotauptaneclient.cc
@@ -243,11 +243,6 @@ void SotaUptaneClient::initSecondaries() {
   }
 }
 
-struct SerialCompare {
-  std::string target;
-  bool operator()(std::pair<std::string, std::string> &in) { return (in.first == target); }
-};
-
 // Check stored secondaries list against secondaries known to aktualizr via
 // commandline input and legacy interface.
 void SotaUptaneClient::verifySecondaries() {
@@ -258,9 +253,7 @@ void SotaUptaneClient::verifySecondaries() {
   }
 
   std::vector<bool> found(serials.size(), false);
-  SerialCompare primary_comp;
-
-  primary_comp.target = uptane_repo.getPrimaryEcuSerial();
+  SerialCompare primary_comp(uptane_repo.getPrimaryEcuSerial());
   // Should be a const_iterator but we need C++11 for cbegin.
   std::vector<std::pair<std::string, std::string> >::iterator store_it;
   store_it = std::find_if(serials.begin(), serials.end(), primary_comp);
@@ -272,8 +265,8 @@ void SotaUptaneClient::verifySecondaries() {
 
   std::map<std::string, boost::shared_ptr<Uptane::SecondaryInterface> >::const_iterator it;
   for (it = secondaries.begin(); it != secondaries.end(); ++it) {
-    primary_comp.target = it->second->getSerial();
-    store_it = std::find_if(serials.begin(), serials.end(), primary_comp);
+    SerialCompare secondary_comp(it->second->getSerial());
+    store_it = std::find_if(serials.begin(), serials.end(), secondary_comp);
     if (store_it == serials.end()) {
       LOGGER_LOG(LVL_error, "Secondary ECU serial " << it->second->getSerial() << " (hardware ID "
                                                     << it->second->getHwId() << ") not found in storage!");

--- a/src/sotauptaneclient.h
+++ b/src/sotauptaneclient.h
@@ -42,3 +42,12 @@ class SotaUptaneClient {
   int last_targets_version;
   Json::Value operation_result;
 };
+
+class SerialCompare {
+ public:
+  SerialCompare(const std::string &target_in) : target(target_in) {}
+  bool operator()(std::pair<std::string, std::string> &in) { return (in.first == target); }
+
+ private:
+  std::string target;
+};

--- a/src/sotauptaneclient.h
+++ b/src/sotauptaneclient.h
@@ -32,6 +32,8 @@ class SotaUptaneClient {
   void reportInstalledPackages();
   void run(command::Channel *commands_channel);
   OstreePackage uptaneToOstree(const Uptane::Target &target);
+  void initSecondaries();
+  void verifySecondaries();
   void updateSecondaries(std::vector<Uptane::Target> targets);
 
   Config config;

--- a/src/sotauptaneclient.h
+++ b/src/sotauptaneclient.h
@@ -36,7 +36,7 @@ class SotaUptaneClient {
   void verifySecondaries();
   void updateSecondaries(std::vector<Uptane::Target> targets);
 
-  Config config;
+  const Config &config;
   event::Channel *events_channel;
   Uptane::Repository &uptane_repo;
   int last_targets_version;

--- a/src/sqlstorage.h
+++ b/src/sqlstorage.h
@@ -71,7 +71,7 @@ class SQLStorage : public INvStorage {
   bool dbInit();
 
  private:
-  StorageConfig config_;
+  const StorageConfig& config_;
   // request info
   SQLReqId request;
   std::map<std::string, std::string> req_params;

--- a/src/uptane/secondaryinterface.h
+++ b/src/uptane/secondaryinterface.h
@@ -32,7 +32,7 @@ class SecondaryInterface {
 
   virtual bool sendFirmware(const std::string& data) = 0;
 
-  SecondaryConfig sconfig;
+  const SecondaryConfig& sconfig;
 };
 }
 

--- a/src/uptane/tufrepository.h
+++ b/src/uptane/tufrepository.h
@@ -57,7 +57,7 @@ class TufRepository {
  private:
   std::string name_;
   boost::filesystem::path path_;
-  Config config_;
+  const Config& config_;
   INvStorage& storage_;
   HttpInterface& http_;
   std::string base_url_;

--- a/src/uptane/uptanerepository.h
+++ b/src/uptane/uptanerepository.h
@@ -54,7 +54,7 @@ class Repository {
   bool currentMeta(Uptane::MetaPack *meta) { return storage.loadMetadata(meta); }
 
  private:
-  Config config;
+  const Config &config;
   TufRepository director;
   TufRepository image;
   INvStorage &storage;

--- a/src/uptane/uptanerepository.h
+++ b/src/uptane/uptanerepository.h
@@ -41,8 +41,6 @@ class Repository {
   }
   std::pair<int, std::vector<Uptane::Target> > getTargets();
   std::string getPrimaryEcuSerial() const { return primary_ecu_serial; };
-  std::string getPrimaryHardwareId() const { return primary_hardware_id_; };
-  std::string getInstalledRefName() const;
   void saveInstalledVersion(const Target &target);
   std::string findInstalledVersion(const std::string &hash);
 
@@ -88,7 +86,7 @@ class Repository {
   bool initDeviceId(const ProvisionConfig &provision_config, const UptaneConfig &uptane_config,
                     const TlsConfig &tls_config);
   void resetDeviceId();
-  bool initEcuSerials(UptaneConfig &uptane_config);
+  bool initEcuSerials(const UptaneConfig &uptane_config);
   void resetEcuSerials();
   bool initPrimaryEcuKeys(const UptaneConfig &uptane_config);
   bool initSecondaryEcuKeys();
@@ -98,7 +96,7 @@ class Repository {
   void resetTlsCreds();
   InitRetCode initEcuRegister(const UptaneConfig &uptane_config);
   bool loadSetTlsCreds(const TlsConfig &tls_config);
-  void setEcuSerialsMembers(const std::vector<std::pair<std::string, std::string> > &ecu_serials);
+  void setEcuSerialMembers(const std::pair<std::string, std::string> &ecu_serials);
   void setEcuKeysMembers(const std::string &primary_public, const std::string &primary_private,
                          const std::string &primary_public_id, CryptoSource source);
 };


### PR DESCRIPTION
Also make all configs const references.

Currently if we detect variations in the list of secondary (or primary) serials, it just throws error messages.