### PR TITLE
Bump gargage-sign version

### DIFF
--- a/src/sota_tools/CMakeLists.txt
+++ b/src/sota_tools/CMakeLists.txt
@@ -101,8 +101,8 @@ add_dependencies(build_tests garage-deploy)
 install(TARGETS garage-deploy RUNTIME DESTINATION bin COMPONENT garage_deploy)
 
 include(ExternalProject)
-ExternalProject_Add(garage-sign DEPENDS garage-deploy URL https://ats-tuf-cli-releases.s3-eu-central-1.amazonaws.com/cli-0.2.0-57-g3f86c67.tgz
-URL_HASH SHA256=f653d24172ed245a6256b2f341a9b77bddf624cd6bbda574c1a85430e3155394
+ExternalProject_Add(garage-sign DEPENDS garage-deploy URL https://ats-tuf-cli-releases.s3-eu-central-1.amazonaws.com/cli-0.2.0-59-gbb29ed5.tgz
+URL_HASH SHA256=3175e4ca7eb3fb72d99e468a6f6827499b3d9da3fccdc1dcf36c2cbd90aa8f0e
 CONFIGURE_COMMAND echo "Skipping configure"
 BUILD_COMMAND echo "Skipping build"
 INSTALL_COMMAND echo "Skipping install")


### PR DESCRIPTION
Supports "no_auth" in treehub.json