### PR TITLE
Remove the dreaded "friend class ::SotaUptaneClient".

### DIFF
--- a/src/aktualizr.cc
+++ b/src/aktualizr.cc
@@ -73,7 +73,7 @@ int Aktualizr::run() {
     storage->importData(config_.import);
     HttpClient http;
     Uptane::Repository repo(config_, storage, http);
-    SotaUptaneClient uptane_client(config_, &events_channel, repo);
+    SotaUptaneClient uptane_client(config_, &events_channel, repo, storage, http);
     uptane_client.runForever(&commands_channel);
 #else
     LOGGER_LOG(LVL_error, "OSTree support is disabled, but currently required for UPTANE");

--- a/src/sotauptaneclient.cc
+++ b/src/sotauptaneclient.cc
@@ -13,7 +13,7 @@
 #include "utils.h"
 
 SotaUptaneClient::SotaUptaneClient(const Config &config_in, event::Channel *events_channel_in, Uptane::Repository &repo,
-                                   const boost::shared_ptr<INvStorage> &storage_in, HttpInterface &http_client)
+                                   const boost::shared_ptr<INvStorage> storage_in, HttpInterface &http_client)
     : config(config_in),
       events_channel(events_channel_in),
       uptane_repo(repo),

--- a/src/sotauptaneclient.cc
+++ b/src/sotauptaneclient.cc
@@ -6,15 +6,20 @@
 #include "json/json.h"
 
 #include "crypto.h"
-#include "httpclient.h"
 #include "logger.h"
 #include "uptane/exceptions.h"
 #include "uptane/secondaryconfig.h"
 #include "uptane/secondaryfactory.h"
 #include "utils.h"
 
-SotaUptaneClient::SotaUptaneClient(const Config &config_in, event::Channel *events_channel_in, Uptane::Repository &repo)
-    : config(config_in), events_channel(events_channel_in), uptane_repo(repo), last_targets_version(-1) {
+SotaUptaneClient::SotaUptaneClient(const Config &config_in, event::Channel *events_channel_in, Uptane::Repository &repo,
+                                   const boost::shared_ptr<INvStorage> &storage_in, HttpInterface &http_client)
+    : config(config_in),
+      events_channel(events_channel_in),
+      uptane_repo(repo),
+      storage(storage_in),
+      http(http_client),
+      last_targets_version(-1) {
   initSecondaries();
 }
 
@@ -65,7 +70,7 @@ data::InstallOutcome SotaUptaneClient::OstreeInstall(const Uptane::Target &targe
     TemporaryFile tmp_cert_file("ostree-cert");
 
     std::string ca;
-    if (!uptane_repo.storage->loadTlsCa(&ca)) return data::InstallOutcome(data::INSTALL_FAILED, "CA file is absent");
+    if (!storage->loadTlsCa(&ca)) return data::InstallOutcome(data::INSTALL_FAILED, "CA file is absent");
 
     tmp_ca_file.PutContents(ca);
 
@@ -75,8 +80,7 @@ data::InstallOutcome SotaUptaneClient::OstreeInstall(const Uptane::Target &targe
       cred.pkey_file = uptane_repo.pkcs11_tls_keyname;
     else {
       std::string pkey;
-      if (!uptane_repo.storage->loadTlsPkey(&pkey))
-        return data::InstallOutcome(data::INSTALL_FAILED, "TLS primary key is absent");
+      if (!storage->loadTlsPkey(&pkey)) return data::InstallOutcome(data::INSTALL_FAILED, "TLS primary key is absent");
       tmp_pkey_file.PutContents(pkey);
       cred.pkey_file = tmp_pkey_file.Path().native();
     }
@@ -85,18 +89,15 @@ data::InstallOutcome SotaUptaneClient::OstreeInstall(const Uptane::Target &targe
       cred.cert_file = uptane_repo.pkcs11_tls_certname;
     else {
       std::string cert;
-      if (!uptane_repo.storage->loadTlsCert(&cert))
-        return data::InstallOutcome(data::INSTALL_FAILED, "TLS certificate is absent");
+      if (!storage->loadTlsCert(&cert)) return data::InstallOutcome(data::INSTALL_FAILED, "TLS certificate is absent");
       tmp_cert_file.PutContents(cert);
       cred.cert_file = tmp_cert_file.Path().native();
     }
 #else
     std::string pkey;
     std::string cert;
-    if (!uptane_repo.storage->loadTlsCert(&cert))
-      return data::InstallOutcome(data::INSTALL_FAILED, "TLS certificate is absent");
-    if (!uptane_repo.storage->loadTlsPkey(&pkey))
-      return data::InstallOutcome(data::INSTALL_FAILED, "TLS primary key is absent");
+    if (!storage->loadTlsCert(&cert)) return data::InstallOutcome(data::INSTALL_FAILED, "TLS certificate is absent");
+    if (!storage->loadTlsPkey(&pkey)) return data::InstallOutcome(data::INSTALL_FAILED, "TLS primary key is absent");
     tmp_pkey_file.PutContents(pkey);
     tmp_cert_file.PutContents(cert);
     cred.pkey_file = tmp_pkey_file.Path().native();
@@ -126,12 +127,13 @@ void SotaUptaneClient::OstreeInstallSetResult(const Uptane::Target &target) {
 
 void SotaUptaneClient::reportHwInfo() {
   Json::Value hw_info = Utils::getHardwareInfo();
-  if (!hw_info.empty()) uptane_repo.http.put(config.tls.server + "/core/system_info", hw_info);
+  if (!hw_info.empty()) {
+    http.put(config.tls.server + "/core/system_info", hw_info);
+  }
 }
 
 void SotaUptaneClient::reportInstalledPackages() {
-  uptane_repo.http.put(config.tls.server + "/core/installed",
-                       Ostree::getInstalledPackages(config.ostree.packages_file));
+  http.put(config.tls.server + "/core/installed", Ostree::getInstalledPackages(config.ostree.packages_file));
 }
 
 Json::Value SotaUptaneClient::AssembleManifest() {
@@ -247,7 +249,7 @@ void SotaUptaneClient::initSecondaries() {
 // commandline input and legacy interface.
 void SotaUptaneClient::verifySecondaries() {
   std::vector<std::pair<std::string, std::string> > serials;
-  if (!uptane_repo.storage->loadEcuSerials(&serials) || serials.empty()) {
+  if (!storage->loadEcuSerials(&serials) || serials.empty()) {
     LOGGER_LOG(LVL_error, "No ECU serials found in storage!");
     return;
   }
@@ -303,7 +305,7 @@ void SotaUptaneClient::updateSecondaries(std::vector<Uptane::Target> targets) {
     std::map<std::string, boost::shared_ptr<Uptane::SecondaryInterface> >::iterator sec =
         secondaries.find(it->ecu_identifier());
     if (sec != secondaries.end()) {
-      std::string firmware_path = uptane_repo.image.getTargetPath(*it);
+      std::string firmware_path = uptane_repo.getTargetPath(*it);
       if (!boost::filesystem::exists(firmware_path)) continue;
 
       if (!sec->second->putMetadata(meta)) {

--- a/src/sotauptaneclient.h
+++ b/src/sotauptaneclient.h
@@ -8,6 +8,7 @@
 #include "config.h"
 #include "events.h"
 #include "httpclient.h"
+#include "invstorage.h"
 #include "ostree.h"
 #include "uptane/secondaryinterface.h"
 #include "uptane/tufrepository.h"
@@ -15,7 +16,8 @@
 
 class SotaUptaneClient {
  public:
-  SotaUptaneClient(const Config &config_in, event::Channel *events_channel_in, Uptane::Repository &repo);
+  SotaUptaneClient(const Config &config_in, event::Channel *events_channel_in, Uptane::Repository &repo,
+                   const boost::shared_ptr<INvStorage> &storage_in, HttpInterface &http_client);
   void OstreeInstallSetResult(const Uptane::Target &package);
   void runForever(command::Channel *commands_channel);
 
@@ -39,6 +41,8 @@ class SotaUptaneClient {
   const Config &config;
   event::Channel *events_channel;
   Uptane::Repository &uptane_repo;
+  const boost::shared_ptr<INvStorage> &storage;
+  HttpInterface &http;
   int last_targets_version;
   Json::Value operation_result;
 };

--- a/src/sotauptaneclient.h
+++ b/src/sotauptaneclient.h
@@ -17,7 +17,7 @@
 class SotaUptaneClient {
  public:
   SotaUptaneClient(const Config &config_in, event::Channel *events_channel_in, Uptane::Repository &repo,
-                   const boost::shared_ptr<INvStorage> &storage_in, HttpInterface &http_client);
+                   const boost::shared_ptr<INvStorage> storage_in, HttpInterface &http_client);
   void OstreeInstallSetResult(const Uptane::Target &package);
   void runForever(command::Channel *commands_channel);
 
@@ -41,7 +41,7 @@ class SotaUptaneClient {
   const Config &config;
   event::Channel *events_channel;
   Uptane::Repository &uptane_repo;
-  const boost::shared_ptr<INvStorage> &storage;
+  const boost::shared_ptr<INvStorage> storage;
   HttpInterface &http;
   int last_targets_version;
   Json::Value operation_result;

--- a/src/uptane/uptanerepository.cc
+++ b/src/uptane/uptanerepository.cc
@@ -19,7 +19,7 @@
 
 namespace Uptane {
 
-Repository::Repository(const Config &config_in, boost::shared_ptr<INvStorage> &storage_in, HttpInterface &http_client)
+Repository::Repository(const Config &config_in, boost::shared_ptr<INvStorage> storage_in, HttpInterface &http_client)
     : config(config_in),
       director("director", config.uptane.director_server, config, storage_in, http_client),
       image("repo", config.uptane.repo_server, config, storage_in, http_client),

--- a/src/uptane/uptanerepository.cc
+++ b/src/uptane/uptanerepository.cc
@@ -1,5 +1,7 @@
 #include "uptane/uptanerepository.h"
 
+#include <stdio.h>
+
 #include <openssl/bio.h>
 #include <openssl/pem.h>
 #include <openssl/x509.h>
@@ -7,8 +9,6 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/make_shared.hpp>
-
-#include <stdio.h>
 
 #include "bootstrap.h"
 #include "crypto.h"
@@ -131,4 +131,6 @@ std::string Repository::findInstalledVersion(const std::string &hash) {
   storage->loadInstalledVersions(&versions);
   return versions[boost::algorithm::to_lower_copy(hash)];
 }
+
+std::string Repository::getTargetPath(const Target &target) { return image.getTargetPath(target); }
 }

--- a/src/uptane/uptanerepository.h
+++ b/src/uptane/uptanerepository.h
@@ -1,22 +1,20 @@
 #ifndef UPTANE_REPOSITORY_H_
 #define UPTANE_REPOSITORY_H_
 
-#include <json/json.h>
 #include <vector>
-#include "config.h"
-#include "invstorage.h"
-#include "uptane/secondaryinterface.h"
-#include "uptane/tufrepository.h"
+#include "json/json.h"
 
+#include "config.h"
 #include "crypto.h"
 #include "httpinterface.h"
+#include "invstorage.h"
 #include "logger.h"
+#include "uptane/secondaryinterface.h"
+#include "uptane/tufrepository.h"
 
 #ifdef BUILD_P11
 #include "p11engine.h"
 #endif
-
-class SotaUptaneClient;
 
 namespace Uptane {
 
@@ -29,7 +27,9 @@ enum InitRetCode {
   INIT_RET_BAD_P12,
   INIT_RET_PKCS11_FAILURE
 };
+
 const int MaxInitializationAttempts = 3;
+
 class Repository {
  public:
   Repository(const Config &config, boost::shared_ptr<INvStorage> &storage, HttpInterface &http_client);
@@ -43,6 +43,7 @@ class Repository {
   std::string getPrimaryEcuSerial() const { return primary_ecu_serial; };
   void saveInstalledVersion(const Target &target);
   std::string findInstalledVersion(const std::string &hash);
+  std::string getTargetPath(const Target &target);
 
   // implemented in uptane/initialize.cc
   bool initialize();
@@ -52,6 +53,9 @@ class Repository {
   // TODO: Receive and update time nonces.
 
   bool currentMeta(Uptane::MetaPack *meta) { return storage->loadMetadata(meta); }
+
+  std::string pkcs11_tls_keyname;
+  std::string pkcs11_tls_certname;
 
  private:
   const Config &config;
@@ -72,13 +76,9 @@ class Repository {
   std::string primary_private_key_uri;
   std::string primary_public_key_id;
 
-  std::string pkcs11_tls_keyname;
-  std::string pkcs11_tls_certname;
-
   // ECU serial => (ECU hardware ID, ECU public_key)
   std::map<std::string, std::pair<std::string, std::string> > secondary_info;
 
-  friend class ::SotaUptaneClient;
   bool verifyMeta(const Uptane::MetaPack &meta);
   bool getMeta();
 

--- a/src/uptane/uptanerepository.h
+++ b/src/uptane/uptanerepository.h
@@ -32,7 +32,7 @@ const int MaxInitializationAttempts = 3;
 
 class Repository {
  public:
-  Repository(const Config &config, boost::shared_ptr<INvStorage> &storage, HttpInterface &http_client);
+  Repository(const Config &config, boost::shared_ptr<INvStorage> storage, HttpInterface &http_client);
   bool putManifest(const Json::Value &version_manifests);
   Json::Value signVersionManifest(const Json::Value &version_manifests);
   void addSecondary(const std::string &ecu_serial, const std::string &hardware_identifier,
@@ -61,7 +61,7 @@ class Repository {
   const Config &config;
   TufRepository director;
   TufRepository image;
-  boost::shared_ptr<INvStorage> &storage;
+  boost::shared_ptr<INvStorage> storage;
   HttpInterface &http;
 #ifdef BUILD_P11
   P11Engine p11;

--- a/tests/uptane_ci_test.cc
+++ b/tests/uptane_ci_test.cc
@@ -70,7 +70,7 @@ TEST(UptaneCI, CheckKeys) {
   boost::shared_ptr<INvStorage> storage(new FSStorage(config.storage));
   HttpClient http;
   Uptane::Repository repo(config, storage, http);
-  SotaUptaneClient sota_client(config, NULL, repo);
+  SotaUptaneClient sota_client(config, NULL, repo, storage, http);
   EXPECT_TRUE(repo.initialize());
 
   std::string ca;

--- a/tests/uptane_key_test.cc
+++ b/tests/uptane_key_test.cc
@@ -116,7 +116,7 @@ TEST(UptaneKey, CheckAllKeys) {
   HttpFake http(temp_dir.Path());
   Uptane::Repository uptane(config, storage, http);
   event::Channel events_channel;
-  SotaUptaneClient sota_client(config, &events_channel, uptane);
+  SotaUptaneClient sota_client(config, &events_channel, uptane, storage, http);
   EXPECT_TRUE(uptane.initialize());
   checkKeyTests(storage, sota_client);
 }
@@ -137,7 +137,7 @@ TEST(UptaneKey, RecoverWithoutKeys) {
     HttpFake http(temp_dir.Path());
     Uptane::Repository uptane(config, storage, http);
     event::Channel events_channel;
-    SotaUptaneClient sota_client(config, &events_channel, uptane);
+    SotaUptaneClient sota_client(config, &events_channel, uptane, storage, http);
 
     EXPECT_TRUE(uptane.initialize());
     checkKeyTests(storage, sota_client);
@@ -150,7 +150,7 @@ TEST(UptaneKey, RecoverWithoutKeys) {
     HttpFake http(temp_dir.Path());
     Uptane::Repository uptane(config, storage, http);
     event::Channel events_channel;
-    SotaUptaneClient sota_client(config, &events_channel, uptane);
+    SotaUptaneClient sota_client(config, &events_channel, uptane, storage, http);
 
     EXPECT_TRUE(uptane.initialize());
     checkKeyTests(storage, sota_client);
@@ -169,7 +169,7 @@ TEST(UptaneKey, RecoverWithoutKeys) {
     HttpFake http(temp_dir.Path());
     Uptane::Repository uptane(config, storage, http);
     event::Channel events_channel;
-    SotaUptaneClient sota_client(config, &events_channel, uptane);
+    SotaUptaneClient sota_client(config, &events_channel, uptane, storage, http);
 
     EXPECT_TRUE(uptane.initialize());
     checkKeyTests(storage, sota_client);

--- a/tests/uptane_serial_test.cc
+++ b/tests/uptane_serial_test.cc
@@ -62,11 +62,11 @@ TEST(Uptane, RandomSerial) {
   HttpFake http(temp_dir.Path());
 
   Uptane::Repository uptane_1(conf_1, storage_1, http);
-  SotaUptaneClient uptane_client1(conf_1, NULL, uptane_1);
+  SotaUptaneClient uptane_client1(conf_1, NULL, uptane_1, storage_1, http);
   EXPECT_TRUE(uptane_1.initialize());
 
   Uptane::Repository uptane_2(conf_2, storage_2, http);
-  SotaUptaneClient uptane_client2(conf_2, NULL, uptane_2);
+  SotaUptaneClient uptane_client2(conf_2, NULL, uptane_2, storage_2, http);
   EXPECT_TRUE(uptane_2.initialize());
 
   std::vector<std::pair<std::string, std::string> > ecu_serials_1;
@@ -119,7 +119,7 @@ TEST(Uptane, ReloadSerial) {
     boost::shared_ptr<INvStorage> storage(new FSStorage(conf.storage));
     HttpFake http(temp_dir.Path());
     Uptane::Repository uptane(conf, storage, http);
-    SotaUptaneClient uptane_client(conf, NULL, uptane);
+    SotaUptaneClient uptane_client(conf, NULL, uptane, storage, http);
     EXPECT_TRUE(uptane.initialize());
     EXPECT_TRUE(storage->loadEcuSerials(&ecu_serials_1));
     EXPECT_EQ(ecu_serials_1.size(), 2);
@@ -139,7 +139,7 @@ TEST(Uptane, ReloadSerial) {
     boost::shared_ptr<INvStorage> storage(new FSStorage(conf.storage));
     HttpFake http(temp_dir.Path());
     Uptane::Repository uptane(conf, storage, http);
-    SotaUptaneClient uptane_client(conf, NULL, uptane);
+    SotaUptaneClient uptane_client(conf, NULL, uptane, storage, http);
     EXPECT_TRUE(uptane.initialize());
     EXPECT_TRUE(storage->loadEcuSerials(&ecu_serials_2));
     EXPECT_EQ(ecu_serials_2.size(), 2);
@@ -181,7 +181,7 @@ TEST(Uptane, LegacySerial) {
     boost::shared_ptr<INvStorage> storage(new FSStorage(conf.storage));
     HttpFake http(temp_dir.Path());
     Uptane::Repository uptane(conf, storage, http);
-    SotaUptaneClient uptane_client(conf, NULL, uptane);
+    SotaUptaneClient uptane_client(conf, NULL, uptane, storage, http);
     EXPECT_TRUE(uptane.initialize());
     EXPECT_TRUE(storage->loadEcuSerials(&ecu_serials_1));
     EXPECT_EQ(ecu_serials_1.size(), 3);
@@ -200,7 +200,7 @@ TEST(Uptane, LegacySerial) {
     boost::shared_ptr<INvStorage> storage(new FSStorage(conf.storage));
     HttpFake http(temp_dir.Path());
     Uptane::Repository uptane(conf, storage, http);
-    SotaUptaneClient uptane_client(conf, NULL, uptane);
+    SotaUptaneClient uptane_client(conf, NULL, uptane, storage, http);
     EXPECT_TRUE(uptane.initialize());
     EXPECT_TRUE(storage->loadEcuSerials(&ecu_serials_2));
     EXPECT_EQ(ecu_serials_2.size(), 3);

--- a/tests/uptane_test.cc
+++ b/tests/uptane_test.cc
@@ -479,7 +479,7 @@ TEST(Uptane, PutManifest) {
   boost::shared_ptr<INvStorage> storage(new FSStorage(config.storage));
   HttpFake http(temp_dir.Path());
   Uptane::Repository uptane(config, storage, http);
-  SotaUptaneClient sota_client(config, NULL, uptane);
+  SotaUptaneClient sota_client(config, NULL, uptane, storage, http);
   EXPECT_TRUE(uptane.initialize());
 
   EXPECT_TRUE(uptane.putManifest(sota_client.AssembleManifest()));
@@ -517,7 +517,7 @@ TEST(Uptane, RunForeverNoUpdates) {
   boost::shared_ptr<INvStorage> storage(new FSStorage(conf.storage));
   HttpFake http(temp_dir.Path());
   Uptane::Repository repo(conf, storage, http);
-  SotaUptaneClient up(conf, &events_channel, repo);
+  SotaUptaneClient up(conf, &events_channel, repo, storage, http);
   up.runForever(&commands_channel);
 
   boost::shared_ptr<event::BaseEvent> event;
@@ -572,7 +572,7 @@ TEST(Uptane, RunForeverHasUpdates) {
   boost::shared_ptr<INvStorage> storage(new FSStorage(conf.storage));
   HttpFake http(temp_dir.Path());
   Uptane::Repository repo(conf, storage, http);
-  SotaUptaneClient up(conf, &events_channel, repo);
+  SotaUptaneClient up(conf, &events_channel, repo, storage, http);
   up.runForever(&commands_channel);
 
   boost::shared_ptr<event::BaseEvent> event;
@@ -613,7 +613,7 @@ TEST(Uptane, RunForeverInstall) {
   boost::shared_ptr<INvStorage> storage(new FSStorage(conf.storage));
   HttpFake http(temp_dir.Path());
   Uptane::Repository repo(conf, storage, http);
-  SotaUptaneClient up(conf, &events_channel, repo);
+  SotaUptaneClient up(conf, &events_channel, repo, storage, http);
   up.runForever(&commands_channel);
 
   // test_manifest is defined in httpfake.h
@@ -663,7 +663,7 @@ TEST(Uptane, UptaneSecondaryAdd) {
   HttpFake http(temp_dir.Path());
   Uptane::Repository uptane(config, storage, http);
   event::Channel events_channel;
-  SotaUptaneClient sota_client(config, &events_channel, uptane);
+  SotaUptaneClient sota_client(config, &events_channel, uptane, storage, http);
   EXPECT_TRUE(uptane.initialize());
   Json::Value ecu_data = Utils::parseJSONFile(temp_dir / "post.json");
   EXPECT_EQ(ecu_data["ecus"].size(), 2);
@@ -698,7 +698,7 @@ TEST(Uptane, ProvisionOnServer) {
   commands_channel << boost::make_shared<command::GetUpdateRequests>();
   commands_channel << boost::make_shared<command::Shutdown>();
   Uptane::Repository repo(config, storage, http);
-  SotaUptaneClient up(config, &events_channel, repo);
+  SotaUptaneClient up(config, &events_channel, repo, storage, http);
   up.runForever(&commands_channel);
 }
 


### PR DESCRIPTION
SotaUptaneClient now requires both Storage and HttpClient as members, but at least they are just references and Storage is even const.

This isn't necessarily the best solution, but it is better than using friend. I'm open to further discussion on where to go from here.