### PR TITLE
Suppress some valgrind errors

### DIFF
--- a/tests/aktualizr.supp
+++ b/tests/aktualizr.supp
@@ -46,3 +46,13 @@
    ...
    obj:*/lib/*/*
 }
+{
+   boost 1.66.0 unique_path
+   Memcheck:Cond
+   ...
+   fun:_ZN5boost10filesystem11path_traits7convertEPKwS3_RNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKSt7codecvtIwc11__mbstate_tE
+   fun:_ZN5boost10filesystem6detail11unique_pathERKNS0_4pathEPNS_6system10error_codeE
+   fun:_ZN5boost10filesystem11unique_pathERKNS0_4pathE
+   ...
+}
+

--- a/tests/aktualizr.supp
+++ b/tests/aktualizr.supp
@@ -20,6 +20,15 @@
    ...
 }
 {
+   gobject _dl_init
+   Memcheck:Leak
+   fun:calloc
+   fun:g_malloc0
+   ...
+   fun:_dl_init
+   ...
+}
+{
    ignore_externa_libs_Cond
    Memcheck:Cond
    ...


### PR DESCRIPTION
These two classes of problem broke a large part of the valgrind checks on my machine.

I don't really know if these rules are too broad or too specific, but probably one of the twos.

(error samples in the commit messages)
  