### PR TITLE
Add timeout for sending

### DIFF
--- a/partial/machine/kea128/app/isotp_dispatch.c
+++ b/partial/machine/kea128/app/isotp_dispatch.c
@@ -61,6 +61,11 @@ void isotp_dispatch() {
 		else
 			sending_ts = time_get();
 	}
+
+	if(sending && time_passed(sending_ts) > 1000) {
+		sending = 0;
+		/* TODO: some error callback?*/
+	}
 }
 
 int isotp_dispatch_send(const uint8_t* data, uint16_t size, uint32_t af) {


### PR DESCRIPTION
The timeout is quite arbitrary, we need to read the standard more carefully to figure out what it should be.
Host side (test-isotp-interface) should be made more robust as well.