### PR TITLE
Make use of boost::make_shared helper

### DIFF
--- a/src/dbusgateway/dbusgateway.cc
+++ b/src/dbusgateway/dbusgateway.cc
@@ -1,6 +1,7 @@
 #include "dbusgateway.h"
 
 #include <boost/shared_ptr.hpp>
+#include <boost/smart_ptr/make_shared.hpp>
 
 #include "logging.h"
 #include "types.h"
@@ -132,9 +133,9 @@ void DbusGateway::run() {
       }
     }
     if (dbus_message_is_method_call(msg, config.dbus.interface.c_str(), "initiateDownload")) {
-      *command_channel << boost::shared_ptr<command::StartDownload>(new command::StartDownload(string_param));
+      *command_channel << boost::make_shared<command::StartDownload>(string_param);
     } else if (dbus_message_is_method_call(msg, config.dbus.interface.c_str(), "abortDownload")) {
-      *command_channel << boost::shared_ptr<command::AbortDownload>(new command::AbortDownload(string_param));
+      *command_channel << boost::make_shared<command::AbortDownload>(string_param);
     } else if (dbus_message_is_method_call(msg, config.dbus.interface.c_str(), "updateReport")) {
       data::UpdateReport update_report;
       update_report.update_id = string_param;
@@ -154,7 +155,7 @@ void DbusGateway::run() {
         dbus_message_unref(msg);
         continue;
       }
-      *command_channel << boost::shared_ptr<command::SendUpdateReport>(new command::SendUpdateReport(update_report));
+      *command_channel << boost::make_shared<command::SendUpdateReport>(update_report);
     }
 
     int message_type = dbus_message_get_type(msg);

--- a/src/gatewaymanager.cc
+++ b/src/gatewaymanager.cc
@@ -11,11 +11,11 @@
 
 GatewayManager::GatewayManager(const Config &config, command::Channel *commands_channel_in) {
   if (config.gateway.socket) {
-    gateways.push_back(boost::shared_ptr<Gateway>(new SocketGateway(config, commands_channel_in)));
+    gateways.push_back(boost::make_shared<SocketGateway>(config, commands_channel_in));
   }
 #ifdef WITH_GENIVI
   if (config.gateway.dbus) {
-    gateways.push_back(boost::shared_ptr<Gateway>(new DbusGateway(config, commands_channel_in)));
+    gateways.push_back(boost::make_shared<DbusGateway>(config, commands_channel_in));
   }
 #endif
 }

--- a/src/invstorage.cc
+++ b/src/invstorage.cc
@@ -2,6 +2,8 @@
 #include "fsstorage.h"
 #include "sqlstorage.h"
 
+#include <boost/smart_ptr/make_shared.hpp>
+
 #include "logging.h"
 #include "utils.h"
 
@@ -64,15 +66,15 @@ boost::shared_ptr<INvStorage> INvStorage::newStorage(const StorageConfig& config
         old_config.tls_pkey_path = "pkey.pem";
         old_config.tls_clientcert_path = "client.pem";
 
-        boost::shared_ptr<INvStorage> sql_storage(new SQLStorage(config));
-        boost::shared_ptr<INvStorage> fs_storage(new FSStorage(old_config));
+        boost::shared_ptr<INvStorage> sql_storage = boost::make_shared<SQLStorage>(config);
+        boost::shared_ptr<INvStorage> fs_storage = boost::make_shared<FSStorage>(old_config);
         INvStorage::FSSToSQLS(fs_storage, sql_storage);
         return sql_storage;
       }
-      return boost::shared_ptr<INvStorage>(new SQLStorage(config));
+      return boost::make_shared<SQLStorage>(config);
     case kFileSystem:
     default:
-      return boost::shared_ptr<INvStorage>(new FSStorage(config));
+      return boost::make_shared<FSStorage>(config);
   }
 }
 

--- a/tests/dbusgateway_test.cc
+++ b/tests/dbusgateway_test.cc
@@ -5,6 +5,7 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/smart_ptr/make_shared.hpp>
 
 #include "commands.h"
 #include "config.h"
@@ -77,7 +78,7 @@ TEST(CommandsTest, DownloadCompleteSignal_sent) {
   download_complete.update_id = "testupdateid";
   download_complete.update_image = "/tmp/img.test";
   download_complete.signature = "signature";
-  gateway.processEvent(boost::shared_ptr<event::BaseEvent>(new event::DownloadComplete(download_complete)));
+  gateway.processEvent(boost::make_shared<event::DownloadComplete>(download_complete));
   sleep(5);
 
   std::ifstream file_stream("/tmp/dbustestclient.txt");
@@ -99,7 +100,7 @@ TEST(CommandsTest, UpdateAvailableSignal_sent) {
   update_available.signature = "signature";
   update_available.size = 200;
   gateway.fireUpdateAvailableEvent(update_available);
-  gateway.processEvent(boost::shared_ptr<event::BaseEvent>(new event::UpdateAvailable(update_available)));
+  gateway.processEvent(boost::make_shared<event::UpdateAvailable>(update_available));
 
   sleep(5);
 
@@ -117,7 +118,7 @@ TEST(CommandsTest, InstalledSoftwareNeededSignal_sent) {
 
   DbusGateway gateway(conf, chan);
 
-  gateway.processEvent(boost::shared_ptr<event::BaseEvent>(new event::InstalledSoftwareNeeded()));
+  gateway.processEvent(boost::make_shared<event::InstalledSoftwareNeeded>());
   sleep(5);
 
   std::ifstream file_stream("/tmp/dbustestclient.txt");

--- a/tests/swm_test.cc
+++ b/tests/swm_test.cc
@@ -5,6 +5,7 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/smart_ptr/make_shared.hpp>
 
 #include "commands.h"
 #include "config.h"
@@ -24,7 +25,7 @@ TEST(SWMTest, DownloadComplete_method_called) {
   download_complete.update_id = "testupdateid";
   download_complete.update_image = "/tmp/img.test";
   download_complete.signature = "signature";
-  gateway.processEvent(boost::shared_ptr<event::BaseEvent>(new event::DownloadComplete(download_complete)));
+  gateway.processEvent(boost::make_shared<event::DownloadComplete>(download_complete));
   sleep(2);
 
   std::ifstream file_stream("/tmp/dbustestswm.txt");

--- a/tests/uptane_ci_test.cc
+++ b/tests/uptane_ci_test.cc
@@ -26,7 +26,7 @@ TEST(UptaneCI, OneCycleUpdate) {
   pt.put("storage.path", temp_dir.Path());
   pt.put("uptane.metadata_path", temp_dir.Path());
   Config config(pt);
-  boost::shared_ptr<INvStorage> storage(new FSStorage(config.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(config.storage);
   HttpClient http;
   Uptane::Repository repo(config, storage, http);
 
@@ -67,7 +67,7 @@ TEST(UptaneCI, CheckKeys) {
   ecu_config.metadata_path = (temp_dir / "secondary_metadata").string();
   config.uptane.secondary_configs.push_back(ecu_config);
 
-  boost::shared_ptr<INvStorage> storage(new FSStorage(config.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(config.storage);
   HttpClient http;
   Uptane::Repository repo(config, storage, http);
   SotaUptaneClient sota_client(config, NULL, repo, storage, http);

--- a/tests/uptane_implicit_test.cc
+++ b/tests/uptane_implicit_test.cc
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <boost/filesystem.hpp>
+#include <boost/smart_ptr/make_shared.hpp>
 
 #include "fsstorage.h"
 #include "httpfake.h"
@@ -25,7 +26,7 @@ TEST(UptaneImplicit, ImplicitFailure) {
   config.storage.tls_pkey_path = "pkey.pem";
   config.postUpdateValues();
 
-  boost::shared_ptr<INvStorage> storage(new FSStorage(config.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(config.storage);
   HttpFake http(temp_dir.Path());
   Uptane::Repository uptane(config, storage, http);
   EXPECT_FALSE(uptane.initialize());
@@ -44,7 +45,7 @@ TEST(UptaneImplicit, ImplicitIncomplete) {
   config.storage.tls_pkey_path = "pkey.pem";
   config.uptane.device_id = "device_id";
   config.postUpdateValues();
-  boost::shared_ptr<INvStorage> storage(new FSStorage(config.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(config.storage);
   HttpFake http(temp_dir.Path());
   Uptane::Repository uptane(config, storage, http);
 
@@ -96,7 +97,7 @@ TEST(UptaneImplicit, ImplicitProvision) {
   config.storage.tls_clientcert_path = "client.pem";
   config.storage.tls_pkey_path = "pkey.pem";
 
-  boost::shared_ptr<INvStorage> storage(new FSStorage(config.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(config.storage);
   HttpFake http(temp_dir.Path());
   Uptane::Repository uptane(config, storage, http);
   EXPECT_TRUE(uptane.initialize());

--- a/tests/uptane_key_test.cc
+++ b/tests/uptane_key_test.cc
@@ -7,6 +7,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/polymorphic_pointer_cast.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/smart_ptr/make_shared.hpp>
 
 #include "fsstorage.h"
 #include "httpfake.h"
@@ -112,7 +113,7 @@ TEST(UptaneKey, CheckAllKeys) {
   TemporaryDirectory temp_dir;
   initKeyTests(config, ecu_config1, ecu_config2, temp_dir);
 
-  boost::shared_ptr<INvStorage> storage(new FSStorage(config.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(config.storage);
   HttpFake http(temp_dir.Path());
   Uptane::Repository uptane(config, storage, http);
   event::Channel events_channel;
@@ -133,7 +134,7 @@ TEST(UptaneKey, RecoverWithoutKeys) {
   initKeyTests(config, ecu_config1, ecu_config2, temp_dir);
 
   {
-    boost::shared_ptr<INvStorage> storage(new FSStorage(config.storage));
+    boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(config.storage);
     HttpFake http(temp_dir.Path());
     Uptane::Repository uptane(config, storage, http);
     event::Channel events_channel;
@@ -146,7 +147,7 @@ TEST(UptaneKey, RecoverWithoutKeys) {
     storage->clearTlsCreds();
   }
   {
-    boost::shared_ptr<INvStorage> storage(new FSStorage(config.storage));
+    boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(config.storage);
     HttpFake http(temp_dir.Path());
     Uptane::Repository uptane(config, storage, http);
     event::Channel events_channel;
@@ -165,7 +166,7 @@ TEST(UptaneKey, RecoverWithoutKeys) {
   boost::filesystem::remove(ecu_config2.full_client_dir / ecu_config2.ecu_private_key);
 
   {
-    boost::shared_ptr<INvStorage> storage(new FSStorage(config.storage));
+    boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(config.storage);
     HttpFake http(temp_dir.Path());
     Uptane::Repository uptane(config, storage, http);
     event::Channel events_channel;

--- a/tests/uptane_network_test.cc
+++ b/tests/uptane_network_test.cc
@@ -10,6 +10,8 @@
 #include <utility>
 #include <vector>
 
+#include <boost/smart_ptr/make_shared.hpp>
+
 #include "fsstorage.h"
 #include "httpclient.h"
 #include "logging.h"
@@ -33,7 +35,7 @@ bool doInit(StorageType storage_type, const std::string &device_register_state, 
 
   bool result;
   HttpClient http;
-  boost::shared_ptr<INvStorage> fs(new FSStorage(conf.storage));
+  boost::shared_ptr<INvStorage> fs = boost::make_shared<FSStorage>(conf.storage);
   {
     Uptane::Repository uptane = Uptane::Repository(conf, fs, http);
     result = uptane.initialize();

--- a/tests/uptane_serial_test.cc
+++ b/tests/uptane_serial_test.cc
@@ -6,6 +6,7 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
+#include <boost/smart_ptr/make_shared.hpp>
 
 #include "fsstorage.h"
 #include "httpfake.h"
@@ -57,8 +58,8 @@ TEST(Uptane, RandomSerial) {
   ecu_config.full_client_dir = temp_dir.Path() / "sec_2";
   conf_2.uptane.secondary_configs.push_back(ecu_config);
 
-  boost::shared_ptr<INvStorage> storage_1(new FSStorage(conf_1.storage));
-  boost::shared_ptr<INvStorage> storage_2(new FSStorage(conf_2.storage));
+  boost::shared_ptr<INvStorage> storage_1 = boost::make_shared<FSStorage>(conf_1.storage);
+  boost::shared_ptr<INvStorage> storage_2 = boost::make_shared<FSStorage>(conf_2.storage);
   HttpFake http(temp_dir.Path());
 
   Uptane::Repository uptane_1(conf_1, storage_1, http);
@@ -116,7 +117,7 @@ TEST(Uptane, ReloadSerial) {
     conf.storage.uptane_public_key_path = "public.key";
     conf.uptane.secondary_configs.push_back(ecu_config);
 
-    boost::shared_ptr<INvStorage> storage(new FSStorage(conf.storage));
+    boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(conf.storage);
     HttpFake http(temp_dir.Path());
     Uptane::Repository uptane(conf, storage, http);
     SotaUptaneClient uptane_client(conf, NULL, uptane, storage, http);
@@ -136,7 +137,7 @@ TEST(Uptane, ReloadSerial) {
     conf.storage.uptane_public_key_path = "public.key";
     conf.uptane.secondary_configs.push_back(ecu_config);
 
-    boost::shared_ptr<INvStorage> storage(new FSStorage(conf.storage));
+    boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(conf.storage);
     HttpFake http(temp_dir.Path());
     Uptane::Repository uptane(conf, storage, http);
     SotaUptaneClient uptane_client(conf, NULL, uptane, storage, http);
@@ -178,7 +179,7 @@ TEST(Uptane, LegacySerial) {
     conf.storage.uptane_private_key_path = "private.key";
     conf.storage.uptane_public_key_path = "public.key";
 
-    boost::shared_ptr<INvStorage> storage(new FSStorage(conf.storage));
+    boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(conf.storage);
     HttpFake http(temp_dir.Path());
     Uptane::Repository uptane(conf, storage, http);
     SotaUptaneClient uptane_client(conf, NULL, uptane, storage, http);
@@ -197,7 +198,7 @@ TEST(Uptane, LegacySerial) {
     conf.storage.uptane_private_key_path = "private.key";
     conf.storage.uptane_public_key_path = "public.key";
 
-    boost::shared_ptr<INvStorage> storage(new FSStorage(conf.storage));
+    boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(conf.storage);
     HttpFake http(temp_dir.Path());
     Uptane::Repository uptane(conf, storage, http);
     SotaUptaneClient uptane_client(conf, NULL, uptane, storage, http);

--- a/tests/uptane_test.cc
+++ b/tests/uptane_test.cc
@@ -36,7 +36,7 @@ TEST(Uptane, Verify) {
   config.uptane.repo_server = tls_server + "/repo";
 
   config.storage.path = temp_dir.Path();
-  boost::shared_ptr<INvStorage> storage(new FSStorage(config.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(config.storage);
   HttpFake http(temp_dir.Path());
   Uptane::TufRepository repo("director", tls_server + "/director", config, storage, http);
   repo.updateRoot(Uptane::Version());
@@ -51,7 +51,7 @@ TEST(Uptane, VerifyDataBad) {
   config.uptane.repo_server = tls_server + "/repo";
 
   config.storage.path = temp_dir.Path();
-  boost::shared_ptr<INvStorage> storage(new FSStorage(config.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(config.storage);
   HttpFake http(temp_dir.Path());
   Uptane::TufRepository repo("director", tls_server + "/director", config, storage, http);
   Json::Value data_json = repo.getJSON("root.json");
@@ -71,7 +71,7 @@ TEST(Uptane, VerifyDataUnknownType) {
   config.uptane.repo_server = tls_server + "/repo";
 
   config.storage.path = temp_dir.Path();
-  boost::shared_ptr<INvStorage> storage(new FSStorage(config.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(config.storage);
   HttpFake http(temp_dir.Path());
   Uptane::TufRepository repo("director", tls_server + "/director", config, storage, http);
   Json::Value data_json = repo.getJSON("root.json");
@@ -92,7 +92,7 @@ TEST(Uptane, VerifyDataBadKeyId) {
   config.uptane.repo_server = tls_server + "/repo";
 
   config.storage.path = temp_dir.Path();
-  boost::shared_ptr<INvStorage> storage(new FSStorage(config.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(config.storage);
   HttpFake http(temp_dir.Path());
   Uptane::TufRepository repo("director", tls_server + "/director", config, storage, http);
   Json::Value data_json = repo.getJSON("root.json");
@@ -112,7 +112,7 @@ TEST(Uptane, VerifyDataBadThreshold) {
   config.uptane.repo_server = tls_server + "/repo";
 
   config.storage.path = temp_dir.Path();
-  boost::shared_ptr<INvStorage> storage(new FSStorage(config.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(config.storage);
   HttpFake http(temp_dir.Path());
   Uptane::TufRepository repo("director", tls_server + "/director", config, storage, http);
   Json::Value data_json = repo.getJSON("root.json");
@@ -149,7 +149,7 @@ TEST(Uptane, Initialize) {
   EXPECT_FALSE(boost::filesystem::exists(conf.storage.path / conf.storage.tls_cacert_path));
   EXPECT_FALSE(boost::filesystem::exists(conf.storage.path / conf.storage.tls_pkey_path));
 
-  boost::shared_ptr<INvStorage> storage(new FSStorage(conf.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(conf.storage);
   std::string pkey;
   std::string cert;
   std::string ca;
@@ -188,7 +188,7 @@ TEST(Uptane, InitializeTwice) {
   EXPECT_FALSE(boost::filesystem::exists(conf.storage.path / conf.storage.tls_cacert_path));
   EXPECT_FALSE(boost::filesystem::exists(conf.storage.path / conf.storage.tls_pkey_path));
 
-  boost::shared_ptr<INvStorage> storage(new FSStorage(conf.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(conf.storage);
   std::string pkey1;
   std::string cert1;
   std::string ca1;
@@ -243,7 +243,7 @@ TEST(Uptane, PetNameProvided) {
   conf.storage.uptane_public_key_path = "public.key";
   conf.uptane.primary_ecu_serial = "testecuserial";
 
-  boost::shared_ptr<INvStorage> storage(new FSStorage(conf.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(conf.storage);
   HttpFake http(temp_dir.Path());
   Uptane::Repository uptane(conf, storage, http);
   EXPECT_TRUE(uptane.initialize());
@@ -279,7 +279,7 @@ TEST(Uptane, PetNameCreation) {
 
   std::string test_name1, test_name2;
   {
-    boost::shared_ptr<INvStorage> storage(new FSStorage(conf.storage));
+    boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(conf.storage);
     HttpFake http(temp_dir.Path());
     Uptane::Repository uptane(conf, storage, http);
     EXPECT_TRUE(uptane.initialize());
@@ -297,7 +297,7 @@ TEST(Uptane, PetNameCreation) {
     boost::filesystem::copy_file("tests/test_data/cred.zip", temp_dir.Path() / "cred.zip");
     conf.uptane.device_id = "";
 
-    boost::shared_ptr<INvStorage> storage(new FSStorage(conf.storage));
+    boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(conf.storage);
     HttpFake http(temp_dir.Path());
     Uptane::Repository uptane(conf, storage, http);
     EXPECT_TRUE(uptane.initialize());
@@ -311,7 +311,7 @@ TEST(Uptane, PetNameCreation) {
   // re-initializing the config should still read the device_id from file.
   {
     conf.uptane.device_id = "";
-    boost::shared_ptr<INvStorage> storage(new FSStorage(conf.storage));
+    boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(conf.storage);
     HttpFake http(temp_dir.Path());
     Uptane::Repository uptane(conf, storage, http);
     EXPECT_TRUE(uptane.initialize());
@@ -329,7 +329,7 @@ TEST(Uptane, PetNameCreation) {
     boost::filesystem::copy_file("tests/test_data/cred.zip", temp_dir.Path() / "cred.zip");
     conf.uptane.device_id = test_name2;
 
-    boost::shared_ptr<INvStorage> storage(new FSStorage(conf.storage));
+    boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(conf.storage);
     HttpFake http(temp_dir.Path());
     Uptane::Repository uptane(conf, storage, http);
     EXPECT_TRUE(uptane.initialize());
@@ -351,7 +351,7 @@ TEST(Uptane, Expires) {
   config.storage.path = temp_dir.Path();
   config.storage.uptane_metadata_path = "metadata";
 
-  boost::shared_ptr<INvStorage> storage(new FSStorage(config.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(config.storage);
   HttpFake http(temp_dir.Path());
   Uptane::TufRepository repo("director", tls_server + "/director", config, storage, http);
 
@@ -390,7 +390,7 @@ TEST(Uptane, Threshold) {
   config.storage.path = temp_dir.Path();
   config.storage.uptane_metadata_path = "metadata";
 
-  boost::shared_ptr<INvStorage> storage(new FSStorage(config.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(config.storage);
   HttpFake http(temp_dir.Path());
   Uptane::TufRepository repo("director", tls_server + "/director", config, storage, http);
 
@@ -437,7 +437,7 @@ TEST(Uptane, InitializeFail) {
 
   conf.uptane.primary_ecu_serial = "testecuserial";
 
-  boost::shared_ptr<INvStorage> storage(new FSStorage(conf.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(conf.storage);
   HttpFake http(temp_dir.Path());
   Uptane::Repository uptane(conf, storage, http);
 
@@ -476,7 +476,7 @@ TEST(Uptane, PutManifest) {
   ecu_config.metadata_path = temp_dir / "secondary_metadata";
   config.uptane.secondary_configs.push_back(ecu_config);
 
-  boost::shared_ptr<INvStorage> storage(new FSStorage(config.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(config.storage);
   HttpFake http(temp_dir.Path());
   Uptane::Repository uptane(config, storage, http);
   SotaUptaneClient sota_client(config, NULL, uptane, storage, http);
@@ -514,7 +514,7 @@ TEST(Uptane, RunForeverNoUpdates) {
   commands_channel << boost::make_shared<command::GetUpdateRequests>();
   commands_channel << boost::make_shared<command::Shutdown>();
 
-  boost::shared_ptr<INvStorage> storage(new FSStorage(conf.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(conf.storage);
   HttpFake http(temp_dir.Path());
   Uptane::Repository repo(conf, storage, http);
   SotaUptaneClient up(conf, &events_channel, repo, storage, http);
@@ -569,7 +569,7 @@ TEST(Uptane, RunForeverHasUpdates) {
 
   commands_channel << boost::make_shared<command::GetUpdateRequests>();
   commands_channel << boost::make_shared<command::Shutdown>();
-  boost::shared_ptr<INvStorage> storage(new FSStorage(conf.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(conf.storage);
   HttpFake http(temp_dir.Path());
   Uptane::Repository repo(conf, storage, http);
   SotaUptaneClient up(conf, &events_channel, repo, storage, http);
@@ -610,7 +610,7 @@ TEST(Uptane, RunForeverInstall) {
   packages_to_install.push_back(Uptane::Target("testostree-hash", ot_json));
   commands_channel << boost::make_shared<command::UptaneInstall>(packages_to_install);
   commands_channel << boost::make_shared<command::Shutdown>();
-  boost::shared_ptr<INvStorage> storage(new FSStorage(conf.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(conf.storage);
   HttpFake http(temp_dir.Path());
   Uptane::Repository repo(conf, storage, http);
   SotaUptaneClient up(conf, &events_channel, repo, storage, http);
@@ -659,7 +659,7 @@ TEST(Uptane, UptaneSecondaryAdd) {
   ecu_config.metadata_path = temp_dir / "secondary_metadata";
   config.uptane.secondary_configs.push_back(ecu_config);
 
-  boost::shared_ptr<INvStorage> storage(new FSStorage(config.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(config.storage);
   HttpFake http(temp_dir.Path());
   Uptane::Repository uptane(config, storage, http);
   event::Channel events_channel;
@@ -693,7 +693,7 @@ TEST(Uptane, ProvisionOnServer) {
 
   event::Channel events_channel;
   command::Channel commands_channel;
-  boost::shared_ptr<INvStorage> storage(new FSStorage(config.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(config.storage);
   HttpFake http(temp_dir.Path());
   commands_channel << boost::make_shared<command::GetUpdateRequests>();
   commands_channel << boost::make_shared<command::Shutdown>();
@@ -712,7 +712,7 @@ TEST(Uptane, CheckOldProvision) {
   config.storage.path = temp_dir.Path();
 
   HttpFake http(temp_dir.Path(), true);
-  boost::shared_ptr<INvStorage> storage(new FSStorage(config.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(config.storage);
   Uptane::Repository uptane(config, storage, http);
   EXPECT_FALSE(storage->loadEcuRegistered());
   EXPECT_TRUE(uptane.initialize());
@@ -938,7 +938,7 @@ TEST(Uptane, SaveVersion) {
   config.storage.tls_pkey_path = "pkey.pem";
   config.uptane.device_id = "device_id";
   config.postUpdateValues();
-  boost::shared_ptr<INvStorage> storage(new FSStorage(config.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(config.storage);
   HttpFake http(temp_dir.Path());
   Uptane::Repository uptane(config, storage, http);
 
@@ -961,7 +961,7 @@ TEST(Uptane, LoadVersion) {
   config.storage.tls_pkey_path = "pkey.pem";
   config.uptane.device_id = "device_id";
   config.postUpdateValues();
-  boost::shared_ptr<INvStorage> storage(new FSStorage(config.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(config.storage);
   HttpFake http(temp_dir.Path());
   Uptane::Repository uptane(config, storage, http);
 
@@ -993,7 +993,7 @@ TEST(Uptane, Pkcs11Provision) {
   config.storage.tls_cacert_path = "ca.pem";
   config.postUpdateValues();
 
-  boost::shared_ptr<INvStorage> storage(new FSStorage(config.storage));
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(config.storage);
   HttpFake http(temp_dir.Path());
   Uptane::Repository uptane(config, storage, http);
   EXPECT_TRUE(uptane.initialize());

--- a/tests/uptane_vector_tests.cc
+++ b/tests/uptane_vector_tests.cc
@@ -6,6 +6,8 @@
 #include <iostream>
 #include <string>
 
+#include <boost/smart_ptr/make_shared.hpp>
+
 #include "config.h"
 #include "fsstorage.h"
 #include "httpclient.h"
@@ -39,7 +41,7 @@ bool run_test(const std::string& test_name, const Json::Value& vector, const std
   config.ostree.sysroot = "./sysroot";
 
   try {
-    boost::shared_ptr<INvStorage> storage(new FSStorage(config.storage));
+    boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(config.storage);
     HttpClient http;
     Uptane::Repository repo(config, storage, http);
     repo.updateRoot(Uptane::Version(1));


### PR DESCRIPTION
Arguably nicer than manual wrapping of a `new ...`. Also, only does one
allocation for the object and the counter altogether.

Available since boost versions from 2014 and also part of the C++11
standard