### PR TITLE
Test/pro 4648/sota tools credentials

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -132,17 +132,7 @@ make test
 
 `make qa` will also run the test suite.
 
-Some of the tests require an Auth+ account. These are disabled by default, and can be enabled by setting the following properties, either in the cmake GUI, by passing `-DOAUTH2_TEST_CLIENT_ID= -DOAUTH2_TEST_CLIENT_SECRET=...` to cmake, or by editing `CMakeCache.txt` in the build directory to set the following options:
-
-----
-//Client ID for testing Auth+ authentication
-OAUTH2_TEST_CLIENT_ID:STRING=....
-
-//Client secret for testing Auth+ authentication
-OAUTH2_TEST_CLIENT_SECRET:STRING=...
-----
-
-Other tests require provisioning credentials. For details of the credentials format, see link:docs/credentials.adoc[credentials.adoc]. Tests that require valid credentials are disabled by default. To enable them, set `SOTA_PACKED_CREDENTIALS` in the same manner as the Auth+ properties.
+Some of the tests require provisioning credentials. For details of the credentials format, see link:docs/credentials.adoc[credentials.adoc]. Tests that require valid credentials are disabled by default. To enable them, set `SOTA_PACKED_CREDENTIALS` in the cmake GUI, by passing `-DSOTA_PACKED_CREDENTIALS=...` to cmake, or by editing `CMakeCache.txt` in the build directory.
 
 === Code Coverage
 

--- a/src/sota_tools/deploy.h
+++ b/src/sota_tools/deploy.h
@@ -14,7 +14,8 @@
  *                 the objects will be pulled over https).
  */
 bool UploadToTreehub(const OSTreeRepo::ptr src_repo, const ServerCredentials& push_credentials,
-                     const OSTreeHash& ostree_commit, const std::string& cacerts, bool dryrun, int max_curl_requests);
+                     const OSTreeHash& ostree_commit, const std::string& cacerts, const bool dryrun,
+                     const int max_curl_requests);
 
 /**
  * Use the garage-sign tool and the images targets.json keys in credentials.zip

--- a/src/sota_tools/ostree_object.cc
+++ b/src/sota_tools/ostree_object.cc
@@ -215,17 +215,22 @@ void OSTreeObject::CurlDone(CURLM *curl_multi_handle) {
       is_on_server_ = OBJECT_MISSING;
     } else {
       is_on_server_ = OBJECT_BREAKS_SERVER;
-      LOG_ERROR << "error: " << rescode;
+      LOG_ERROR << "OSTree fetch error: " << rescode;
+      if (rescode == 0) {
+        char *url = NULL;
+        curl_easy_getinfo(curl_handle_, CURLINFO_EFFECTIVE_URL, &url);
+        LOG_ERROR << "Check your OSTree server in treehub.json: " << url;
+      }
     }
   } else if (current_operation_ == OSTREE_OBJECT_UPLOADING) {
     // TODO: check that http_response_ matches the object hash
     curl_formfree(form_post_);
     form_post_ = NULL;
     if (rescode == 200) {
-      LOG_DEBUG << "Upload successful";
+      LOG_DEBUG << "OSTree upload successful";
       is_on_server_ = OBJECT_PRESENT;
     } else {
-      LOG_ERROR << "Upload error: " << rescode;
+      LOG_ERROR << "OSTree upload error: " << rescode;
       is_on_server_ = OBJECT_BREAKS_SERVER;
     }
   } else {

--- a/src/sota_tools/request_pool.cc
+++ b/src/sota_tools/request_pool.cc
@@ -34,7 +34,7 @@ void RequestPool::AddUpload(OSTreeObject::ptr request) {
   }
 }
 
-void RequestPool::LoopLaunch() {
+void RequestPool::LoopLaunch(const bool dryrun) {
   while (running_requests_ < max_requests_ && (!query_queue_.empty() || !upload_queue_.empty())) {
     OSTreeObject::ptr cur;
 
@@ -42,7 +42,9 @@ void RequestPool::LoopLaunch() {
     if (query_queue_.empty()) {
       cur = upload_queue_.front();
       upload_queue_.pop_front();
-      cur->Upload(server_, multi_);
+      if (!dryrun) {
+        cur->Upload(server_, multi_);
+      }
     } else {
       cur = query_queue_.front();
       query_queue_.pop_front();
@@ -112,8 +114,8 @@ void RequestPool::LoopListen() {
   } while (msgs_in_queue > 0);
 }
 
-void RequestPool::Loop() {
-  LoopLaunch();
+void RequestPool::Loop(const bool dryrun) {
+  LoopLaunch(dryrun);
   LoopListen();
 }
 // vim: set tabstop=2 shiftwidth=2 expandtab:

--- a/src/sota_tools/request_pool.h
+++ b/src/sota_tools/request_pool.h
@@ -20,14 +20,14 @@ class RequestPool {
   };
   bool is_idle() { return query_queue_.empty() && upload_queue_.empty() && running_requests_ == 0; }
   bool is_stopped() { return stopped_; }
-  void Loop();  // one iteration of request-listen loop, launches up to
-                // max_requests_ requests, then listens for the result
+  void Loop(const bool dryrun);  // one iteration of request-listen loop, launches up to
+                                 // max_requests_ requests, then listens for the result
   void OnQuery(requestCallBack cb) { query_cb_ = cb; }
   void OnUpload(requestCallBack cb) { upload_cb_ = cb; }
 
  private:
-  void LoopLaunch();  // launches up to max_requests_ requests from the queues
-  void LoopListen();  // listens to the result of launched requests
+  void LoopLaunch(const bool dryrun);  // launches up to max_requests_ requests from the queues
+  void LoopListen();                   // listens to the result of launched requests
 
   int max_requests_;
   int running_requests_;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -236,7 +236,7 @@ add_test(NAME test-no-config-check-message
 add_test(NAME test-help-with-other-options
          COMMAND aktualizr --help -c someconfig.toml)
 
-add_test(NAME test-help-with-notexisting-options
+add_test(NAME test-help-with-nonexistent-options
          COMMAND aktualizr --help -somebadoption)
 
 set_tests_properties(test-no-config-check-message
@@ -245,13 +245,13 @@ set_tests_properties(test-no-config-check-message
 set_tests_properties(test-help-with-other-options
                      PROPERTIES PASS_REGULAR_EXPRESSION  "aktualizr command line options")
 
-set_tests_properties(test-help-with-notexisting-options
+set_tests_properties(test-help-with-nonexistent-options
                      PROPERTIES PASS_REGULAR_EXPRESSION  "aktualizr command line options")
 
-add_test(NAME test-legacy-interface-with-notexisting-file
+add_test(NAME test-legacy-interface-with-nonexistent-file
          COMMAND aktualizr -c  ${PROJECT_SOURCE_DIR}/config/config.toml.example --legacy-interface nonexistentfile)
 
-set_tests_properties(test-legacy-interface-with-notexisting-file
+set_tests_properties(test-legacy-interface-with-nonexistent-file
                      PROPERTIES PASS_REGULAR_EXPRESSION  "Legacy external flasher not found: nonexistentfile")
 
 add_test(NAME test-secondary-config-with-nonexistent-file
@@ -321,11 +321,6 @@ if((BUILD_SOTA_TOOLS) AND (BUILD_OSTREE))
         target_compile_options(sota_tools_static_lib PUBLIC -fprofile-arcs -ftest-coverage)
     endif(BUILD_WITH_CODE_COVERAGE)
 
-    # The tests can optionally test authentication against Auth+. To do this they
-    # require a client id & secret. Specify credentials here to enable these tests
-    set(OAUTH2_TEST_CLIENT_ID "" CACHE STRING "Client ID for testing Auth+ authentication")
-    set(OAUTH2_TEST_CLIENT_SECRET "" CACHE STRING "Client Secret for testing Auth+ authentication")
-
     # Check the --help option works
     add_test(NAME option-help
         COMMAND garage-push --help)
@@ -372,30 +367,27 @@ if((BUILD_SOTA_TOOLS) AND (BUILD_OSTREE))
         COMMAND ./test-server-500 $<TARGET_FILE:garage-push>
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/sota_tools)
 
-    if (OAUTH2_TEST_CLIENT_ID)
+    add_test(NAME auth-plus-failure
+        COMMAND sota_tools/test-auth-plus-failure $<TARGET_FILE:garage-push>
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+    if(SOTA_PACKED_CREDENTIALS)
         add_test(NAME auth-plus-happy-case
             COMMAND sota_tools/test-auth-plus-happy $<TARGET_FILE:garage-push>
-            ${OAUTH2_TEST_CLIENT_ID} ${OAUTH2_TEST_CLIENT_SECRET}
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-        add_test(NAME auth-plus-failure
-            COMMAND sota_tools/test-auth-plus-failure $<TARGET_FILE:garage-push>
-            ${OAUTH2_TEST_CLIENT_ID} ${OAUTH2_TEST_CLIENT_SECRET}
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+            ${SOTA_PACKED_CREDENTIALS} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
         add_test(NAME verbose-logging
             COMMAND sota_tools/test-verbose-logging $<TARGET_FILE:garage-push>
-            ${OAUTH2_TEST_CLIENT_ID} ${OAUTH2_TEST_CLIENT_SECRET}
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+            ${SOTA_PACKED_CREDENTIALS} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
         if(STRACE)
             add_test(NAME cacert-used
                 COMMAND sota_tools/test-cacert-used $<TARGET_FILE:garage-push>
-                ${OAUTH2_TEST_CLIENT_ID} ${OAUTH2_TEST_CLIENT_SECRET} ${STRACE}
-                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+                ${SOTA_PACKED_CREDENTIALS} ${STRACE} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
         endif(STRACE)
-    endif(OAUTH2_TEST_CLIENT_ID)
+    endif(SOTA_PACKED_CREDENTIALS)
 
-# garage-deploy tests
+    # garage-deploy tests
     add_test(NAME garage-deploy-option-help
         COMMAND garage-deploy --help)
 
@@ -405,7 +397,7 @@ if((BUILD_SOTA_TOOLS) AND (BUILD_OSTREE))
 endif((BUILD_SOTA_TOOLS) AND (BUILD_OSTREE))
 
 if(BUILD_OSTREE)
-# aktualizr-info tests
+    # aktualizr-info tests
     add_test(NAME aktualizr-info-noarguments
         COMMAND ${PROJECT_SOURCE_DIR}/tests/run_aktualizr_info_tests.sh ${PROJECT_BINARY_DIR}/src/aktualizr_info/aktualizr-info WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
     set_tests_properties(aktualizr-info-noarguments PROPERTIES

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -355,10 +355,6 @@ if((BUILD_SOTA_TOOLS) AND (BUILD_OSTREE))
         COMMAND sota_tools/test-invalid-credentials $<TARGET_FILE:garage-push>
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-    add_test(NAME dry-run
-        COMMAND sota_tools/test-dry-run $<TARGET_FILE:garage-push>
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
     add_test(NAME cacert-not-found
         COMMAND sota_tools/test-cacert-not-found $<TARGET_FILE:garage-push>
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
@@ -372,6 +368,10 @@ if((BUILD_SOTA_TOOLS) AND (BUILD_OSTREE))
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
     if(SOTA_PACKED_CREDENTIALS)
+        add_test(NAME dry-run
+            COMMAND sota_tools/test-dry-run $<TARGET_FILE:garage-push>
+            ${SOTA_PACKED_CREDENTIALS} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
         add_test(NAME auth-plus-happy-case
             COMMAND sota_tools/test-auth-plus-happy $<TARGET_FILE:garage-push>
             ${SOTA_PACKED_CREDENTIALS} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/sota_tools/test-auth-plus-failure
+++ b/tests/sota_tools/test-auth-plus-failure
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -uo pipefail
+
 CREDS_FILE=$(mktemp)
 trap "rm -f $CREDS_FILE" EXIT
 cat > $CREDS_FILE <<EOF

--- a/tests/sota_tools/test-auth-plus-failure
+++ b/tests/sota_tools/test-auth-plus-failure
@@ -8,10 +8,10 @@ cat > $CREDS_FILE <<EOF
   "oauth2": {
     "client_id":"c169e6d6-d2de-4c56-ac8c-8b7671097e0c",
     "client_secret":"badsecret",
-    "server":"https://auth-plus.gw.prod01.advancedtelematic.com"
+    "server":"https://auth-plus.atsgarage.com"
   },
   "ostree":{
-    "server":"https://treehub.gw.prod01.advancedtelematic.com"
+    "server":"https://treehub.atsgarage.com/api/v3"
   }
 }
 EOF

--- a/tests/sota_tools/test-auth-plus-happy
+++ b/tests/sota_tools/test-auth-plus-happy
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
 CREDS_FILE=$(mktemp)
 trap "rm -f $CREDS_FILE" EXIT
 cat > $CREDS_FILE <<EOF

--- a/tests/sota_tools/test-auth-plus-happy
+++ b/tests/sota_tools/test-auth-plus-happy
@@ -1,18 +1,4 @@
 #!/bin/bash
 set -euo pipefail
 
-CREDS_FILE=$(mktemp)
-trap "rm -f $CREDS_FILE" EXIT
-cat > $CREDS_FILE <<EOF
-{
-  "oauth2": {
-    "client_id":"$2",
-    "client_secret":"$3",
-    "server":"https://auth-plus.gw.prod01.advancedtelematic.com"
-  },
-  "ostree":{
-    "server":"https://treehub.gw.prod01.advancedtelematic.com"
-  }
-}
-EOF
-$1 --ref master --repo sota_tools/repo --credentials $CREDS_FILE -n
+$1 --ref master --repo sota_tools/repo --credentials $2 -n

--- a/tests/sota_tools/test-bad-option
+++ b/tests/sota_tools/test-bad-option
@@ -1,4 +1,6 @@
 #!/bin/bash
-$1 --a-bad-option 
+set -uo pipefail
+
+$1 --a-bad-option
 # Invert the return code
 test $? -eq 1

--- a/tests/sota_tools/test-bare-mode-repo
+++ b/tests/sota_tools/test-bare-mode-repo
@@ -1,2 +1,5 @@
+#!/bin/bash
+set -eu
+
 TARGET="OSTree repo is not in archive-z2 format"
 $1 --ref master --repo sota_tools/bare-repo | grep -q "$TARGET"

--- a/tests/sota_tools/test-cacert-not-found
+++ b/tests/sota_tools/test-cacert-not-found
@@ -1,2 +1,5 @@
+#!/bin/bash
+set -eu
+
 TARGET="cacert path nope.pem does not exist"
 $1 --ref master --cacert nope.pem --repo sota_tools/repo --credentials sota_tools/sota_tools_basic_auth.json -n | grep -q "$TARGET"

--- a/tests/sota_tools/test-cacert-used
+++ b/tests/sota_tools/test-cacert-used
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -u
+
 CREDS_FILE=$(mktemp)
 trap "rm -f $CREDS_FILE" EXIT
 cat > $CREDS_FILE <<EOF

--- a/tests/sota_tools/test-cacert-used
+++ b/tests/sota_tools/test-cacert-used
@@ -1,19 +1,5 @@
 #!/bin/bash
 set -u
 
-CREDS_FILE=$(mktemp)
-trap "rm -f $CREDS_FILE" EXIT
-cat > $CREDS_FILE <<EOF
-{
-  "oauth2": {
-    "client_id":"$2",
-    "client_secret":"$3",
-    "server":"https://auth-plus.gw.prod01.advancedtelematic.com"
-  },
-  "ostree":{
-    "server":"https://treehub.gw.prod01.advancedtelematic.com"
-  }
-}
-EOF
-$4 $1 --ref master --repo sota_tools/repo --credentials $CREDS_FILE --cacert sota_tools/testcerts.crt -n 2>&1 | grep -q ca-certificates
+$3 $1 --ref master --repo sota_tools/repo --credentials $2 --cacert sota_tools/testcerts.crt -n 2>&1 | grep -q ca-certificates
 test $? -eq 1

--- a/tests/sota_tools/test-dry-run
+++ b/tests/sota_tools/test-dry-run
@@ -1,1 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
 $1 --ref master --repo sota_tools/repo --credentials sota_tools/sota_tools_basic_auth.json -n

--- a/tests/sota_tools/test-dry-run
+++ b/tests/sota_tools/test-dry-run
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euo pipefail
 
-$1 --ref master --repo sota_tools/repo --credentials sota_tools/sota_tools_basic_auth.json -n
+$1 --ref master --repo sota_tools/repo --credentials $2 -n

--- a/tests/sota_tools/test-invalid-credentials
+++ b/tests/sota_tools/test-invalid-credentials
@@ -1,2 +1,5 @@
+#!/bin/bash
+set -eu
+
 TARGET="Unable to read invalid-credentials.zip as archive or json file"
 $1 --ref master --repo sota_tools/repo --credentials invalid-credentials.zip | grep -q "$TARGET"

--- a/tests/sota_tools/test-invalid-repo
+++ b/tests/sota_tools/test-invalid-repo
@@ -1,2 +1,5 @@
+#!/bin/bash
+set -eu
+
 TARGET="does not appear to contain a valid OSTree repository"
 $1 --ref master --repo invalid | grep -q "$TARGET"

--- a/tests/sota_tools/test-missing-credentials
+++ b/tests/sota_tools/test-missing-credentials
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -eu
+
 TARGET="Unable to read a-non-existent-file as archive or json file"
 # File not found and invalid/corrupt files are treated the same
 $1 --ref master --repo sota_tools/repo --credentials a-non-existent-file | grep -q "$TARGET"

--- a/tests/sota_tools/test-missing-ref
+++ b/tests/sota_tools/test-missing-ref
@@ -1,2 +1,5 @@
+#!/bin/bash
+set -eu
+
 TARGET="Ref badref was not found in repository sota_tools/repo"
 $1 --ref badref --repo sota_tools/repo --credentials sota_tools/auth_test_good.zip | grep -q "$TARGET"

--- a/tests/sota_tools/test-verbose-logging
+++ b/tests/sota_tools/test-verbose-logging
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -eu
+
 CREDS_FILE=$(mktemp)
 trap "rm -f $CREDS_FILE" EXIT
 cat > $CREDS_FILE <<EOF

--- a/tests/sota_tools/test-verbose-logging
+++ b/tests/sota_tools/test-verbose-logging
@@ -1,18 +1,4 @@
 #!/bin/bash
 set -eu
 
-CREDS_FILE=$(mktemp)
-trap "rm -f $CREDS_FILE" EXIT
-cat > $CREDS_FILE <<EOF
-{
-  "oauth2": {
-    "client_id":"$2",
-    "client_secret":"$3",
-    "server":"https://auth-plus.gw.prod01.advancedtelematic.com"
-  },
-  "ostree":{
-    "server":"https://treehub.gw.prod01.advancedtelematic.com"
-  }
-}
-EOF
-$1 --ref master --repo sota_tools/repo --credentials $CREDS_FILE -nv 2>&1 | grep -q "Content-Type"
+$1 --ref master --repo sota_tools/repo --credentials $2 -nv 2>&1 | grep -q "Content-Type"

--- a/tests/uptane_ci_test.cc
+++ b/tests/uptane_ci_test.cc
@@ -4,6 +4,7 @@
 #include <iostream>
 
 #include <boost/filesystem.hpp>
+#include <boost/make_shared.hpp>
 #include <boost/polymorphic_pointer_cast.hpp>
 #include <boost/shared_ptr.hpp>
 

--- a/tests/uptane_test.cc
+++ b/tests/uptane_test.cc
@@ -521,19 +521,16 @@ TEST(Uptane, RunForeverNoUpdates) {
   up.runForever(&commands_channel);
 
   boost::shared_ptr<event::BaseEvent> event;
-  if (!events_channel.hasValues()) {
-    FAIL();
-  }
+
+  EXPECT_TRUE(events_channel.hasValues());
   events_channel >> event;
   EXPECT_EQ(event->variant, "UptaneTargetsUpdated");
-  if (!events_channel.hasValues()) {
-    FAIL();
-  }
+
+  EXPECT_TRUE(events_channel.hasValues());
   events_channel >> event;
   EXPECT_EQ(event->variant, "UptaneTimestampUpdated");
-  if (!events_channel.hasValues()) {
-    FAIL();
-  }
+
+  EXPECT_TRUE(events_channel.hasValues());
   events_channel >> event;
   EXPECT_EQ(event->variant, "UptaneTimestampUpdated");
 }
@@ -576,9 +573,7 @@ TEST(Uptane, RunForeverHasUpdates) {
   up.runForever(&commands_channel);
 
   boost::shared_ptr<event::BaseEvent> event;
-  if (!events_channel.hasValues()) {
-    FAIL();
-  }
+  EXPECT_TRUE(events_channel.hasValues());
   events_channel >> event;
   EXPECT_EQ(event->variant, "UptaneTargetsUpdated");
   event::UptaneTargetsUpdated* targets_event = static_cast<event::UptaneTargetsUpdated*>(event.get());


### PR DESCRIPTION
Note that the garage-push test-dry-run still succeeds at the moment even if the fetch fails. This is because of how the return code is calculated. We might consider changing that. Either way, the -n/--dry-run option is now much more useful.