### PR TITLE
Switch to C++11 by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,11 @@ function(aktualizr_source_file_checks)
     aktualizr_clang_format(${ARGN})
 endfunction()
 
+
+# Use C++11, but without GNU or other extensions
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 # Export compile_commands.json for clang-check
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
@@ -150,10 +155,6 @@ include_directories(${LIBDBUS_INCLUDE_DIRS})
 include_directories(${sodium_INCLUDE_DIR})
 
 if (CMAKE_COMPILER_IS_GNUCXX)
-    # Still enforce C++98/03 for client-side code.
-    set(CMAKE_CXX_STANDARD 98)
-    # Do not use GNU or other extensions.
-    set(CMAKE_CXX_EXTENSIONS OFF)
     add_definitions(-fstack-protector-all)
     # Enable maximum set of warnings. -Wno-sign-compare is required because of
     # problems in gtest. -Wswitch-default and -Wconversion would be nice as

--- a/src/external_secondaries/CMakeLists.txt
+++ b/src/external_secondaries/CMakeLists.txt
@@ -12,7 +12,6 @@ target_link_libraries(example-interface
 target_compile_options(example-interface PUBLIC -DECUFLASHER_EXAMPLE)
 
 add_executable(aktualizr-validate-secondary-interface validate_secondary_interface_test.cc)
-set_property(TARGET aktualizr-validate-secondary-interface PROPERTY CXX_STANDARD 11)
 target_link_libraries(aktualizr-validate-secondary-interface ${Boost_LIBRARIES} gtest)
 
 if(BUILD_WITH_CODE_COVERAGE)

--- a/src/sota_tools/CMakeLists.txt
+++ b/src/sota_tools/CMakeLists.txt
@@ -14,7 +14,6 @@ set (SOTA_TOOLS_LIB_SRC
 )
 
 add_library(sota_tools_static_lib STATIC ${SOTA_TOOLS_LIB_SRC})
-set_property(TARGET sota_tools_static_lib PROPERTY CXX_STANDARD 11)
 
 ##### garage-push targets
 
@@ -23,7 +22,6 @@ set (GARAGE_PUSH_SRCS
 )
 
 add_executable(garage-push ${GARAGE_PUSH_SRCS})
-set_property(TARGET garage-push PROPERTY CXX_STANDARD 11)
 
 # Export compile_commands.json for clang-check
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -50,7 +48,6 @@ set (GARAGE_CHECK_SRCS
 )
 
 add_executable(garage-check ${GARAGE_CHECK_SRCS})
-set_property(TARGET garage-check PROPERTY CXX_STANDARD 11)
 
 target_link_libraries(garage-check sota_tools_static_lib aktualizr_static_lib
   ${Boost_LIBRARIES}
@@ -72,7 +69,6 @@ set (GARAGE_DEPLOY_SRCS
 )
 
 add_executable(garage-deploy ${GARAGE_DEPLOY_SRCS})
-set_property(TARGET garage-deploy PROPERTY CXX_STANDARD 11)
 target_link_libraries(garage-deploy sota_tools_static_lib aktualizr_static_lib
   ${Boost_LIBRARIES}
   ${CMAKE_THREAD_LIBS_INIT}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,15 +52,12 @@ set(TEST_SOURCES httpfake.h test_utils.cc test_utils.h)
 include(CMakeParseArguments)
 
 function(add_aktualizr_test)
-    set(options PROJECT_WORKING_DIRECTORY NO_VALGRIND CPP11)
+    set(options PROJECT_WORKING_DIRECTORY NO_VALGRIND)
     set(oneValueArgs NAME)
     set(multiValueArgs SOURCES ARGS)
     cmake_parse_arguments(AKTUALIZR_TEST "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
     add_executable(t_${AKTUALIZR_TEST_NAME} ${AKTUALIZR_TEST_SOURCES})
     target_link_libraries(t_${AKTUALIZR_TEST_NAME} aktualizr_static_lib ${TEST_LIBS})
-    if (AKTUALIZR_TEST_CPP11)
-        set_property(TARGET t_${AKTUALIZR_TEST_NAME} PROPERTY CXX_STANDARD 11)
-    endif()
     if(AKTUALIZR_TEST_PROJECT_WORKING_DIRECTORY)
         set(WD WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
     else()
@@ -291,13 +288,13 @@ add_test(NAME validate-secondary-interface
 if((BUILD_SOTA_TOOLS))
     # sota-tools tests
     add_aktualizr_test(NAME sota_tools_auth_test SOURCES sota_tools/auth_test.cc
-                       CPP11 PROJECT_WORKING_DIRECTORY NO_VALGRIND)
+                       PROJECT_WORKING_DIRECTORY NO_VALGRIND)
     target_link_libraries(t_sota_tools_auth_test sota_tools_static_lib aktualizr_static_lib ${TEST_LIBS})
     target_include_directories(t_sota_tools_auth_test
                                PUBLIC ${PROJECT_SOURCE_DIR}/src/sota_tools
                                ${PROJECT_SOURCE_DIR}/tests ${GLIB2_INCLUDE_DIRS})
 
-    add_aktualizr_test(NAME ostree_hash SOURCES sota_tools/ostree_hash_test.cc CPP11)
+    add_aktualizr_test(NAME ostree_hash SOURCES sota_tools/ostree_hash_test.cc)
     target_link_libraries(t_ostree_hash sota_tools_static_lib)
 
     # Setup coverage for sota_tools_static_lib


### PR DESCRIPTION
Now is the time to move Aktualizr to C++11.  At the moment the core of the product compiles against C++98, although we require C++11 for some of the support utilities.

C++11 came in gcc around version 4.7, and Debian oldstable is currently at gcc 4.9, so I hope that we should be able to assume C++11 now.