### PR TITLE
move all p11 dependant code to one place

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,7 +80,8 @@ if(BUILD_OSTREE)
                         uptane/tuf.cc
                         uptane/tufrepository.cc
                         uptane/uptanerepository.cc
-                        uptane/virtualsecondary.cc)
+                        uptane/virtualsecondary.cc
+                        uptane/cryptokey.cc)
 endif(BUILD_OSTREE)
 
 if(BUILD_P11)

--- a/src/crypto.cc
+++ b/src/crypto.cc
@@ -104,21 +104,6 @@ std::string Crypto::getKeyId(const std::string &key) {
   return keyid;
 }
 
-Json::Value Crypto::signTuf(ENGINE *engine, const std::string &private_key, const std::string &public_key_id,
-                            const Json::Value &in_data) {
-  std::string b64sig = Utils::toBase64(Crypto::RSAPSSSign(engine, private_key, Json::FastWriter().write(in_data)));
-  Json::Value signature;
-  signature["method"] = "rsassa-pss";
-  signature["sig"] = b64sig;
-
-  Json::Value out_data;
-  signature["keyid"] = public_key_id;
-  out_data["signed"] = in_data;
-  out_data["signatures"] = Json::Value(Json::arrayValue);
-  out_data["signatures"].append(signature);
-  return out_data;
-}
-
 bool Crypto::RSAPSSVerify(const std::string &public_key, const std::string &signature, const std::string &message) {
   RSA *rsa = NULL;
   BIO *bio = BIO_new_mem_buf(const_cast<char *>(public_key.c_str()), (int)public_key.size());

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -90,8 +90,6 @@ class Crypto {
   static std::string sha256digest(const std::string &text);
   static std::string sha512digest(const std::string &text);
   static std::string RSAPSSSign(ENGINE *engine, const std::string &private_key, const std::string &digest);
-  static Json::Value signTuf(ENGINE *engine, const std::string &private_key, const std::string &public_key,
-                             const Json::Value &in_data);
   static bool VerifySignature(const PublicKey &public_key, const std::string &signature, const std::string &message);
   static bool parseP12(FILE *p12_fp, const std::string &p12_password, std::string *out_pkey, std::string *out_cert,
                        std::string *out_ca);

--- a/src/httpclient.cc
+++ b/src/httpclient.cc
@@ -14,10 +14,6 @@
 #include <boost/move/make_unique.hpp>
 #include <boost/move/utility.hpp>
 
-#ifdef BUILD_P11
-#include <libp11.h>
-#endif
-
 #include "logging.h"
 #include "openssl_compat.h"
 

--- a/src/ostree.h
+++ b/src/ostree.h
@@ -10,6 +10,7 @@
 #include "config.h"
 #include "ostreeinterface.h"
 #include "types.h"
+#include "uptane/cryptokey.h"
 
 class OstreePackage : public OstreePackageInterface {
  public:

--- a/src/p11engine.cc
+++ b/src/p11engine.cc
@@ -58,7 +58,7 @@ P11Engine::~P11Engine() {
   }
 }
 
-PKCS11_SLOT* P11Engine::findTokenSlot() {
+PKCS11_SLOT* P11Engine::findTokenSlot() const {
   PKCS11_SLOT* slot = PKCS11_find_token(ctx_.get(), slots_.get_slots(), slots_.get_nslots());
   if (!slot || !slot->token) {
     LOG_ERROR << "Couldn't find a token";
@@ -138,7 +138,7 @@ bool P11Engine::generateUptaneKeyPair() {
   return true;
 }
 
-bool P11Engine::readTlsCert(std::string* cert_out) {
+bool P11Engine::readTlsCert(std::string* cert_out) const {
   const std::string& id = config_.tls_clientcert_id;
 
   if (config_.module.empty()) return false;

--- a/src/p11engine.h
+++ b/src/p11engine.h
@@ -30,7 +30,7 @@ class P11ContextWrapper {
       PKCS11_CTX_free(ctx);
     }
   }
-  PKCS11_CTX *get() { return ctx; }
+  PKCS11_CTX *get() const { return ctx; }
 
  private:
   PKCS11_CTX *ctx;
@@ -54,8 +54,8 @@ class P11SlotsWrapper {
   ~P11SlotsWrapper() {
     if (slots && nslots) PKCS11_release_all_slots(ctx, slots, nslots);
   }
-  PKCS11_SLOT *get_slots() { return slots; }
-  unsigned int get_nslots() { return nslots; }
+  PKCS11_SLOT *get_slots() const { return slots; }
+  unsigned int get_nslots() const { return nslots; }
 
  private:
   PKCS11_CTX *ctx;
@@ -73,7 +73,7 @@ class P11Engine {
   std::string getTlsPkeyId() const { return uri_prefix_ + config_.tls_pkey_id; }
   std::string getTlsCertId() const { return uri_prefix_ + config_.tls_clientcert_id; }
   bool readUptanePublicKey(std::string *key);
-  bool readTlsCert(std::string *cert_out);
+  bool readTlsCert(std::string *cert_out) const;
   bool generateUptaneKeyPair();
 
  private:
@@ -83,7 +83,7 @@ class P11Engine {
   P11ContextWrapper ctx_;
   P11SlotsWrapper slots_;
 
-  PKCS11_SLOT *findTokenSlot();
+  PKCS11_SLOT *findTokenSlot() const;
 };
 
 #endif

--- a/src/sotauptaneclient.cc
+++ b/src/sotauptaneclient.cc
@@ -8,6 +8,7 @@
 #include "crypto.h"
 #include "logging.h"
 #include "packagemanagerfactory.h"
+#include "uptane/cryptokey.h"
 #include "uptane/exceptions.h"
 #include "uptane/secondaryconfig.h"
 #include "uptane/secondaryfactory.h"
@@ -64,47 +65,7 @@ data::InstallOutcome SotaUptaneClient::PackageInstall(const Uptane::Target &targ
   try {
     boost::shared_ptr<PackageInterface> package = pacman->makePackage(
         target.filename(), boost::algorithm::to_lower_copy(target.sha256Hash()), config.uptane.ostree_server);
-
-    data::PackageManagerCredentials cred;
-    // All three files should live until package->install terminates
-    TemporaryFile tmp_ca_file("ostree-ca");
-    TemporaryFile tmp_pkey_file("ostree-pkey");
-    TemporaryFile tmp_cert_file("ostree-cert");
-
-    std::string ca;
-    if (!storage->loadTlsCa(&ca)) return data::InstallOutcome(data::INSTALL_FAILED, "CA file is absent");
-
-    tmp_ca_file.PutContents(ca);
-
-    cred.ca_file = tmp_ca_file.Path().native();
-#ifdef BUILD_P11
-    if (config.tls.pkey_source == kPkcs11)
-      cred.pkey_file = uptane_repo.pkcs11_tls_keyname;
-    else {
-      std::string pkey;
-      if (!storage->loadTlsPkey(&pkey)) return data::InstallOutcome(data::INSTALL_FAILED, "TLS primary key is absent");
-      tmp_pkey_file.PutContents(pkey);
-      cred.pkey_file = tmp_pkey_file.Path().native();
-    }
-
-    if (config.tls.cert_source == kPkcs11)
-      cred.cert_file = uptane_repo.pkcs11_tls_certname;
-    else {
-      std::string cert;
-      if (!storage->loadTlsCert(&cert)) return data::InstallOutcome(data::INSTALL_FAILED, "TLS certificate is absent");
-      tmp_cert_file.PutContents(cert);
-      cred.cert_file = tmp_cert_file.Path().native();
-    }
-#else
-    std::string pkey;
-    std::string cert;
-    if (!storage->loadTlsCert(&cert)) return data::InstallOutcome(data::INSTALL_FAILED, "TLS certificate is absent");
-    if (!storage->loadTlsPkey(&pkey)) return data::InstallOutcome(data::INSTALL_FAILED, "TLS primary key is absent");
-    tmp_pkey_file.PutContents(pkey);
-    tmp_cert_file.PutContents(cert);
-    cred.pkey_file = tmp_pkey_file.Path().native();
-    cred.cert_file = tmp_cert_file.Path().native();
-#endif
+    data::PackageManagerCredentials cred(CryptoKey(storage, config));
     return package->install(cred, config.pacman);
   } catch (std::exception &ex) {
     return data::InstallOutcome(data::INSTALL_FAILED, ex.what());

--- a/src/types.cc
+++ b/src/types.cc
@@ -241,5 +241,17 @@ InstalledSoftware InstalledSoftware::fromJson(const std::string& json_str) {
   installed_software.firmwares = firmwares;
   return installed_software;
 }
+#ifdef BUILD_OSTREE
+PackageManagerCredentials::PackageManagerCredentials(const CryptoKey& cryptokey)
+    : tmp_ca_file("ostree-ca"), tmp_pkey_file("ostree-pkey"), tmp_cert_file("ostree-cert") {
+  ca_file = cryptokey.getCa();
+  if (ca_file.find("pkcs11:") != 0) {
+    tmp_ca_file.PutContents(cryptokey.getCa());
+    ca_file = tmp_ca_file.Path().string();
+  }
+  tmp_pkey_file.PutContents(cryptokey.getPkey());
+  tmp_cert_file.PutContents(cryptokey.getCert());
+}
+#endif
 }
 // vim: set tabstop=2 shiftwidth=2 expandtab:

--- a/src/types.h
+++ b/src/types.h
@@ -2,6 +2,7 @@
 #define TYPES_H_
 
 #include <json/json.h>
+#include "uptane/cryptokey.h"
 
 namespace data {
 
@@ -133,12 +134,20 @@ struct InstalledSoftware {
   static InstalledSoftware fromJson(const std::string& json_str);
 };
 
+#ifdef BUILD_OSTREE
 struct PackageManagerCredentials {
+  PackageManagerCredentials(const CryptoKey& cryptokey);
   std::string access_token;
   std::string ca_file;
   std::string cert_file;
   std::string pkey_file;
+
+ private:
+  TemporaryFile tmp_ca_file;
+  TemporaryFile tmp_pkey_file;
+  TemporaryFile tmp_cert_file;
 };
+#endif
 }
 
 #endif

--- a/src/uptane/cryptokey.cc
+++ b/src/uptane/cryptokey.cc
@@ -1,0 +1,170 @@
+#include "cryptokey.h"
+
+#include <boost/scoped_array.hpp>
+#include <stdexcept>
+
+CryptoKey::CryptoKey(const boost::shared_ptr<INvStorage> &backend, const Config &config)
+    : backend_(backend),
+      config_(config)
+#ifdef BUILD_P11
+      ,
+      p11_(config_.p11)
+#endif
+{
+}
+
+std::string CryptoKey::getPkey() const {
+  std::string pkey;
+#ifdef BUILD_P11
+  if (config_.tls.pkey_source == kPkcs11) {
+    pkey = p11_.getTlsPkeyId();
+  }
+#endif
+  if (config_.tls.pkey_source == kFile) {
+    backend_->loadTlsPkey(&pkey);
+  }
+  return pkey;
+}
+
+std::string CryptoKey::getCert() const {
+  std::string cert;
+#ifdef BUILD_P11
+  if (config_.tls.cert_source == kPkcs11) {
+    cert = p11_.getTlsCertId();
+  }
+#endif
+  if (config_.tls.cert_source == kFile) {
+    backend_->loadTlsCert(&cert);
+  }
+  return cert;
+}
+
+std::string CryptoKey::getCa() const {
+  std::string ca;
+#ifdef BUILD_P11
+  if (config_.tls.ca_source == kPkcs11) {
+    ca = p11_.getTlsCacertId();
+  }
+#endif
+  if (config_.tls.ca_source == kFile) {
+    backend_->loadTlsCa(&ca);
+  }
+  return ca;
+}
+
+std::string CryptoKey::getCN() const {
+  std::string not_found_cert_message = "Certificate is not found, can't extract device_id";
+  std::string cert;
+  if (config_.tls.cert_source == kFile) {
+    if (!backend_->loadTlsCert(&cert)) {
+      throw std::runtime_error(not_found_cert_message);
+    }
+  } else {  // kPkcs11
+#ifdef BUILD_P11
+    if (!p11_.readTlsCert(&cert)) {
+      throw std::runtime_error(not_found_cert_message);
+    }
+#else
+    throw std::runtime_error("Aktualizr was built without PKCS#11 support, can't extract device_id");
+#endif
+  }
+
+  BIO *bio = BIO_new_mem_buf(const_cast<char *>(cert.c_str()), (int)cert.size());
+  X509 *x = PEM_read_bio_X509(bio, NULL, 0, NULL);
+  BIO_free_all(bio);
+  if (!x) throw std::runtime_error("Could not parse certificate");
+
+  int len = X509_NAME_get_text_by_NID(X509_get_subject_name(x), NID_commonName, NULL, 0);
+  if (len < 0) {
+    X509_free(x);
+    throw std::runtime_error("Could not get CN from certificate");
+  }
+  boost::scoped_array<char> buf(new char[len + 1]);
+  X509_NAME_get_text_by_NID(X509_get_subject_name(x), NID_commonName, buf.get(), len + 1);
+  std::string cn(buf.get());
+  X509_free(x);
+  return cn;
+}
+
+void CryptoKey::copyCertsToCurl(HttpInterface *http) {
+  std::string pkey = getPkey();
+  std::string cert = getCert();
+  std::string ca = getCa();
+
+  if (pkey.size() && cert.size() && ca.size()) {
+    http->setCerts(ca, config_.tls.ca_source, cert, config_.tls.cert_source, pkey, config_.tls.pkey_source);
+  }
+}
+
+Json::Value CryptoKey::signTuf(const Json::Value &in_data) {
+  ENGINE *crypto_engine = NULL;
+  std::string private_key;
+#ifdef BUILD_P11
+  if (config_.uptane.key_source == kPkcs11) crypto_engine = p11_.getEngine();
+#endif
+  if (config_.uptane.key_source == kFile) {
+    backend_->loadPrimaryPrivate(&private_key);
+  }
+  std::string b64sig =
+      Utils::toBase64(Crypto::RSAPSSSign(crypto_engine, private_key, Json::FastWriter().write(in_data)));
+  Json::Value signature;
+  signature["method"] = "rsassa-pss";
+  signature["sig"] = b64sig;
+
+  Json::Value out_data;
+  signature["keyid"] = Crypto::getKeyId(getUptanePublicKey());
+  out_data["signed"] = in_data;
+  out_data["signatures"] = Json::Value(Json::arrayValue);
+  out_data["signatures"].append(signature);
+  return out_data;
+}
+
+std::string CryptoKey::getUptanePublicKey() {
+  std::string primary_public;
+  if (config_.uptane.key_source == kFile) {
+    if (!backend_->loadPrimaryPublic(&primary_public)) {
+      throw std::runtime_error("Could not get uptane public key!");
+    }
+  } else {
+#ifdef BUILD_P11
+    // dummy read to check if the key is present
+    if (!p11_.readUptanePublicKey(&primary_public)) {
+      throw std::runtime_error("Could not get uptane public key!");
+    }
+#else
+    throw std::runtime_error("Aktualizr builded without pkcs11 support!");
+#endif
+  }
+  return primary_public;
+}
+
+std::string CryptoKey::generateUptaneKeyPair() {
+  std::string primary_public;
+
+  if (config_.uptane.key_source == kFile) {
+    std::string primary_private;
+    if (!backend_->loadPrimaryKeys(&primary_public, &primary_private)) {
+      if (Crypto::generateRSAKeyPair(&primary_public, &primary_private)) {
+        backend_->storePrimaryKeys(primary_public, primary_private);
+      }
+    }
+    if (primary_public.empty() && primary_private.empty()) {
+      throw std::runtime_error("Could not get uptane keys");
+    }
+  } else {
+#ifdef BUILD_P11
+    // dummy read to check if the key is present
+    if (!p11_.readUptanePublicKey(&primary_public)) {
+      p11_.generateUptaneKeyPair();
+    }
+    // realy read the key
+    if (primary_public.empty() && !p11_.readUptanePublicKey(&primary_public)) {
+      throw std::runtime_error("Could not get uptane keys");
+    }
+    return primary_public;
+#else
+    throw std::runtime_error("Aktualizr builded without pkcs11 support!");
+#endif
+  }
+  return primary_public;
+}

--- a/src/uptane/cryptokey.h
+++ b/src/uptane/cryptokey.h
@@ -1,0 +1,37 @@
+#ifndef ONDISKCRYPTOKEY_H_
+#define ONDISKCRYPTOKEY_H_
+
+#include "invstorage.h"
+#include "config.h"
+#include "httpinterface.h"
+#ifdef BUILD_P11
+#include "p11engine.h"
+#endif
+#include <boost/shared_ptr.hpp>
+
+
+
+class CryptoKey {
+  public:
+    //std::string RSAPSSSign(const std::string &message);
+    // Contains the logic from HttpClient::setCerts()
+    void copyCertsToCurl(HttpInterface* http);
+    CryptoKey(const boost::shared_ptr<INvStorage> &backend, const Config& config);
+    std::string getPkey() const;
+    std::string getCert() const;
+    std::string getCa() const;
+    std::string getCN() const;
+    bool isOk() const {return (getPkey().size() && getCert().size() && getCa().size());}
+    std::string generateUptaneKeyPair();
+    std::string getUptanePublicKey();
+    Json::Value signTuf(const Json::Value &in_data);
+  private:
+    boost::shared_ptr<INvStorage> backend_;
+    Config config_;
+#ifdef BUILD_P11
+    P11Engine p11_;
+#endif
+
+};
+
+#endif // ONDISKCRYPTOKEY_H_

--- a/src/uptane/managedsecondary.cc
+++ b/src/uptane/managedsecondary.cc
@@ -130,7 +130,18 @@ Json::Value ManagedSecondary::getManifest() {
   manifest["previous_timeserver_time"] = "1970-01-01T00:00:00Z";
   manifest["timeserver_time"] = "1970-01-01T00:00:00Z";
 
-  Json::Value signed_ecu_version = Crypto::signTuf(NULL, private_key, public_key_id, manifest);
+  Json::Value signed_ecu_version;
+
+  std::string b64sig = Utils::toBase64(Crypto::RSAPSSSign(NULL, private_key, Json::FastWriter().write(manifest)));
+  Json::Value signature;
+  signature["method"] = "rsassa-pss";
+  signature["sig"] = b64sig;
+
+  signature["keyid"] = public_key_id;
+  signed_ecu_version["signed"] = manifest;
+  signed_ecu_version["signatures"] = Json::Value(Json::arrayValue);
+  signed_ecu_version["signatures"].append(signature);
+
   return signed_ecu_version;
 }
 

--- a/src/uptane/uptanerepository.cc
+++ b/src/uptane/uptanerepository.cc
@@ -25,11 +25,8 @@ Repository::Repository(const Config &config_in, boost::shared_ptr<INvStorage> st
       image("repo", config.uptane.repo_server, config, storage_in, http_client),
       storage(storage_in),
       http(http_client),
-#ifdef BUILD_P11
-      p11(config.p11),
-#endif
-      manifests(Json::arrayValue) {
-}
+      keys_(storage, config),
+      manifests(Json::arrayValue) {}
 
 void Repository::updateRoot(Version version) {
   director.updateRoot(version);
@@ -41,23 +38,13 @@ bool Repository::putManifest(const Json::Value &version_manifests) {
   manifest["primary_ecu_serial"] = primary_ecu_serial;
   manifest["ecu_version_manifest"] = version_manifests;
 
-  ENGINE *crypto_engine = NULL;
-#ifdef BUILD_P11
-  if (key_source == kPkcs11) crypto_engine = p11.getEngine();
-#endif
-  Json::Value tuf_signed = Crypto::signTuf(crypto_engine, primary_private_key_uri, primary_public_key_id, manifest);
+  Json::Value tuf_signed = keys_.signTuf(manifest);
   HttpResponse response = http.put(config.uptane.director_server + "/manifest", tuf_signed);
   return response.isOk();
 }
 
 Json::Value Repository::signVersionManifest(const Json::Value &primary_version_manifest) {
-  ENGINE *crypto_engine = NULL;
-#ifdef BUILD_P11
-  if (key_source == kPkcs11) crypto_engine = p11.getEngine();
-#endif
-
-  Json::Value ecu_version_signed =
-      Crypto::signTuf(crypto_engine, primary_private_key_uri, primary_public_key_id, primary_version_manifest);
+  Json::Value ecu_version_signed = keys_.signTuf(primary_version_manifest);
   return ecu_version_signed;
 }
 

--- a/src/uptane/uptanerepository.h
+++ b/src/uptane/uptanerepository.h
@@ -9,12 +9,9 @@
 #include "httpinterface.h"
 #include "invstorage.h"
 #include "logging.h"
+#include "uptane/cryptokey.h"
 #include "uptane/secondaryinterface.h"
 #include "uptane/tufrepository.h"
-
-#ifdef BUILD_P11
-#include "p11engine.h"
-#endif
 
 namespace Uptane {
 
@@ -63,18 +60,13 @@ class Repository {
   TufRepository image;
   boost::shared_ptr<INvStorage> storage;
   HttpInterface &http;
-#ifdef BUILD_P11
-  P11Engine p11;
-#endif
+
+  CryptoKey keys_;
+
   Json::Value manifests;
 
   std::string primary_ecu_serial;
   std::string primary_hardware_id_;
-
-  CryptoSource key_source;
-  std::string primary_public_key_uri;
-  std::string primary_private_key_uri;
-  std::string primary_public_key_id;
 
   // ECU serial => (ECU hardware ID, ECU public_key)
   std::map<std::string, std::pair<std::string, std::string> > secondary_info;
@@ -83,22 +75,19 @@ class Repository {
   bool getMeta();
 
   // implemented in uptane/initialize.cc
-  bool initDeviceId(const ProvisionConfig &provision_config, const UptaneConfig &uptane_config,
-                    const TlsConfig &tls_config);
+  bool initDeviceId(const ProvisionConfig &provision_config, const UptaneConfig &uptane_config);
   void resetDeviceId();
   bool initEcuSerials(const UptaneConfig &uptane_config);
   void resetEcuSerials();
-  bool initPrimaryEcuKeys(const UptaneConfig &uptane_config);
+  bool initPrimaryEcuKeys();
   bool initSecondaryEcuKeys();
 
   void resetEcuKeys();
-  InitRetCode initTlsCreds(const ProvisionConfig &provision_config, const TlsConfig &tls_config);
+  InitRetCode initTlsCreds(const ProvisionConfig &provision_config);
   void resetTlsCreds();
-  InitRetCode initEcuRegister(const UptaneConfig &uptane_config);
-  bool loadSetTlsCreds(const TlsConfig &tls_config);
+  InitRetCode initEcuRegister();
+  bool loadSetTlsCreds();
   void setEcuSerialMembers(const std::pair<std::string, std::string> &ecu_serials);
-  void setEcuKeysMembers(const std::string &primary_public, const std::string &primary_private,
-                         const std::string &primary_public_id, CryptoSource source);
 };
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,9 +36,13 @@ endif(BUILD_GENIVI)
 add_dependencies(build_tests aktualizr)
 
 
-if((BUILD_SOTA_TOOLS) AND (BUILD_OSTREE))
-    add_dependencies(build_tests garage-push aktualizr-info)
-endif((BUILD_SOTA_TOOLS) AND (BUILD_OSTREE))
+if(BUILD_SOTA_TOOLS)
+    add_dependencies(build_tests garage-push garage-deploy-deb)
+endif(BUILD_SOTA_TOOLS)
+
+if (BUILD_OSTREE)
+    add_dependencies(build_tests aktualizr-info)
+endif (BUILD_OSTREE)
 
 add_custom_target(check COMMAND CTEST_OUTPUT_ON_FAILURE=1 ${CMAKE_CTEST_COMMAND}
                   -E test_valgrind_uptane_vectors\\|test_build DEPENDS build_tests)

--- a/tests/crypto_test.cc
+++ b/tests/crypto_test.cc
@@ -7,8 +7,11 @@
 #include <json/json.h>
 #include <boost/algorithm/hex.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/make_shared.hpp>
 
 #include "crypto.h"
+#include "fsstorage.h"
+#include "uptane/cryptokey.h"
 #include "utils.h"
 
 #ifdef BUILD_P11
@@ -43,7 +46,57 @@ TEST(crypto, sign_verify_rsa_file) {
   EXPECT_TRUE(signe_is_ok);
 }
 
+TEST(crypto, sign_tuf) {
+  std::string private_key = Utils::readFile("tests/test_data/priv.key");
+  std::string public_key = Utils::readFile("tests/test_data/public.key");
+  Config config;
+  TemporaryDirectory temp_dir;
+  config.storage.path = temp_dir.Path();
+  boost::shared_ptr<FSStorage> storage = boost::make_shared<FSStorage>(FSStorage(config.storage));
+  storage->storePrimaryKeys(public_key, private_key);
+  CryptoKey keys(storage, config);
+
+  Json::Value tosign_json;
+  tosign_json["mykey"] = "value";
+  Json::Value signed_json = keys.signTuf(tosign_json);
+  EXPECT_EQ(signed_json["signed"]["mykey"].asString(), "value");
+  EXPECT_EQ(signed_json["signatures"][0]["keyid"].asString(),
+            "6a809c62b4f6c2ae11abfb260a6a9a57d205fc2887ab9c83bd6be0790293e187");
+  EXPECT_EQ(signed_json["signatures"][0]["sig"].asString().size() != 0, true);
+}
+
 #ifdef BUILD_P11
+
+TEST(crypto, sign_tuf_pkcs11) {
+  std::string private_key = Utils::readFile("tests/test_data/priv.key");
+  std::string public_key = Utils::readFile("tests/test_data/public.key");
+
+  Json::Value tosign_json;
+  tosign_json["mykey"] = "value";
+
+  P11Config p11_conf;
+  p11_conf.module = TEST_PKCS11_MODULE_PATH;
+  p11_conf.pass = "1234";
+  p11_conf.uptane_key_id = "03";
+  Config config;
+  config.p11 = p11_conf;
+
+  P11Engine p11(p11_conf);
+
+  TemporaryDirectory temp_dir;
+  config.storage.path = temp_dir.Path();
+  boost::shared_ptr<FSStorage> storage = boost::make_shared<FSStorage>(FSStorage(config.storage));
+  storage->storePrimaryKeys(public_key, private_key);
+  CryptoKey keys(storage, config);
+
+  EXPECT_TRUE(keys.getUptanePublicKey().size());
+  Json::Value signed_json = keys.signTuf(tosign_json);
+  EXPECT_EQ(signed_json["signed"]["mykey"].asString(), "value");
+  EXPECT_EQ(signed_json["signatures"][0]["keyid"].asString(),
+            "6a809c62b4f6c2ae11abfb260a6a9a57d205fc2887ab9c83bd6be0790293e187");
+  EXPECT_EQ(signed_json["signatures"][0]["sig"].asString().size() != 0, true);
+}
+
 TEST(crypto, sign_verify_rsa_p11) {
   P11Config config;
   config.module = TEST_PKCS11_MODULE_PATH;

--- a/tests/crypto_test.cc
+++ b/tests/crypto_test.cc
@@ -43,19 +43,6 @@ TEST(crypto, sign_verify_rsa_file) {
   EXPECT_TRUE(signe_is_ok);
 }
 
-TEST(crypto, sign_tuf) {
-  Json::Value tosign_json;
-  tosign_json["mykey"] = "value";
-
-  std::string private_key = Utils::readFile("tests/test_data/priv.key");
-  std::string public_key = Utils::readFile("tests/test_data/public.key");
-  Json::Value signed_json = Crypto::signTuf(NULL, private_key, Crypto::getKeyId(public_key), tosign_json);
-  EXPECT_EQ(signed_json["signed"]["mykey"].asString(), "value");
-  EXPECT_EQ(signed_json["signatures"][0]["keyid"].asString(),
-            "6a809c62b4f6c2ae11abfb260a6a9a57d205fc2887ab9c83bd6be0790293e187");
-  EXPECT_EQ(signed_json["signatures"][0]["sig"].asString().size() != 0, true);
-}
-
 #ifdef BUILD_P11
 TEST(crypto, sign_verify_rsa_p11) {
   P11Config config;
@@ -85,26 +72,6 @@ TEST(crypto, generate_rsa_keypair_p11) {
   EXPECT_FALSE(p11.readUptanePublicKey(&key_content));
   EXPECT_TRUE(p11.generateUptaneKeyPair());
   EXPECT_TRUE(p11.readUptanePublicKey(&key_content));
-}
-
-TEST(crypto, sign_tuf_pkcs11) {
-  Json::Value tosign_json;
-  tosign_json["mykey"] = "value";
-
-  P11Config p11_conf;
-  p11_conf.module = TEST_PKCS11_MODULE_PATH;
-  p11_conf.pass = "1234";
-  p11_conf.uptane_key_id = "03";
-  P11Engine p11(p11_conf);
-
-  std::string public_key;
-  EXPECT_TRUE(p11.readUptanePublicKey(&public_key));
-  Json::Value signed_json =
-      Crypto::signTuf(p11.getEngine(), p11.getUptaneKeyId(), Crypto::getKeyId(public_key), tosign_json);
-  EXPECT_EQ(signed_json["signed"]["mykey"].asString(), "value");
-  EXPECT_EQ(signed_json["signatures"][0]["keyid"].asString(),
-            "6a809c62b4f6c2ae11abfb260a6a9a57d205fc2887ab9c83bd6be0790293e187");
-  EXPECT_EQ(signed_json["signatures"][0]["sig"].asString().size() != 0, true);
 }
 
 TEST(crypto, certificate_pkcs11) {

--- a/tests/ostree_test.cc
+++ b/tests/ostree_test.cc
@@ -29,9 +29,15 @@ TEST(OstreePackage, ToEcuVersion) {
 
 TEST(OstreePackage, InstallBadUri) {
   OstreePackage op("branch-name-hash", "hash", "bad_uri");
+  TemporaryDirectory temp_dir;
   Config config;
   config.pacman.type = kOstree;
   config.pacman.sysroot = sysroot;
+  config.storage.path = temp_dir.Path();
+  config.storage.uptane_metadata_path = "metadata";
+  config.storage.uptane_private_key_path = "private.key";
+  config.storage.uptane_private_key_path = "public.key";
+
   CryptoKey keys(boost::make_shared<FSStorage>(FSStorage(config.storage)), config);
   data::PackageManagerCredentials cred(keys);
   data::InstallOutcome result = op.install(cred, config.pacman);

--- a/tests/ostree_test.cc
+++ b/tests/ostree_test.cc
@@ -6,8 +6,10 @@
 
 #include <boost/algorithm/hex.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/make_shared.hpp>
 
 #include "config.h"
+#include "fsstorage.h"
 #include "ostree.h"
 #include "types.h"
 #include "utils.h"
@@ -27,10 +29,11 @@ TEST(OstreePackage, ToEcuVersion) {
 
 TEST(OstreePackage, InstallBadUri) {
   OstreePackage op("branch-name-hash", "hash", "bad_uri");
-  data::PackageManagerCredentials cred;
   Config config;
   config.pacman.type = kOstree;
   config.pacman.sysroot = sysroot;
+  CryptoKey keys(boost::make_shared<FSStorage>(FSStorage(config.storage)), config);
+  data::PackageManagerCredentials cred(keys);
   data::InstallOutcome result = op.install(cred, config.pacman);
   EXPECT_EQ(result.first, data::INSTALL_FAILED);
   EXPECT_EQ(result.second, "Failed to parse uri: bad_uri");


### PR DESCRIPTION
I did it in another way that Phil suggested. The reason for this is that we have source flag for each key. So currently I just moved all pkcs11 related code to one class.