### PR TITLE
Pass secret key as (encrypted) plaintext.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ deploy:
                   condition: $DOCKERFILE = Dockerfile.deb-stable
 
           api_key:
-                  secure: ${GITHUB_API_KEY}
+                  secure: "Z9IEs+GbPW+pxxfYofmeT4Jwjz4OpXJ6WZbv8nyN0MOZV146QExKhZA64mJ7nuXRepS7M5wFgVd0QVlmE7lLa8oNVTKujn+DmQ6701HeP9bITwv6wcDyhNOULLRBwRD2YN5lR29vHGWsjMUm8R13Wtgr/XyOG4L8fcg021B0BMtvepO9HJD4kHSNqB8pJXWVSMd5+d77BRz8Yr72oP98iBMAm94XNd5Gd2RB77YBRKlR7XEV2DxW346C9xI48crMRAKAyp/35vTCTMT04In4FpSexSue0q5dGqfQZf2I5fpGtSbwwJIb3ct/T0CUcW8mDQL01LtG3Hm2qNXKn8aCse6MrVoktUWBTA+tn7DMGq6zY4XXkyC7OisBYg9eel8HacSPrCXDB9C80aJht9a7AZIHehLC4yUomhYmnQDotvHoc3JrJXMSq4HE31WwIBn0xmOpr4ts0nnAprl3bRCQcv10J4MU4zK+BEYET+sLs1stqeION/AYTr0OxWVfbUhRdVepAjDh/mNLYO7raDb/PTZb4upunjS5a1RK+U+aW8ct85RPamZ+8+ZTo8Ofj5VGQiVJmmmrlVkDyBzXwJL3WonnZwuU6QDaaYCFUuzyVqmEuYZNc3i6jNUs0Yptw2YjKww6ayV5msyGaA0QZ3vdGWRk9K7JQQhE7CII2N4yzvI="
 
         - provider: releases
           file: /persistent/aktualizr.deb
@@ -47,4 +47,4 @@ deploy:
                   repo: advancedtelematic/aktualizr
                   condition: $DOCKERFILE = Dockerfile.16.04
           api_key:
-                  secure: ${GITHUB_API_KEY}
+                  secure: "Z9IEs+GbPW+pxxfYofmeT4Jwjz4OpXJ6WZbv8nyN0MOZV146QExKhZA64mJ7nuXRepS7M5wFgVd0QVlmE7lLa8oNVTKujn+DmQ6701HeP9bITwv6wcDyhNOULLRBwRD2YN5lR29vHGWsjMUm8R13Wtgr/XyOG4L8fcg021B0BMtvepO9HJD4kHSNqB8pJXWVSMd5+d77BRz8Yr72oP98iBMAm94XNd5Gd2RB77YBRKlR7XEV2DxW346C9xI48crMRAKAyp/35vTCTMT04In4FpSexSue0q5dGqfQZf2I5fpGtSbwwJIb3ct/T0CUcW8mDQL01LtG3Hm2qNXKn8aCse6MrVoktUWBTA+tn7DMGq6zY4XXkyC7OisBYg9eel8HacSPrCXDB9C80aJht9a7AZIHehLC4yUomhYmnQDotvHoc3JrJXMSq4HE31WwIBn0xmOpr4ts0nnAprl3bRCQcv10J4MU4zK+BEYET+sLs1stqeION/AYTr0OxWVfbUhRdVepAjDh/mNLYO7raDb/PTZb4upunjS5a1RK+U+aW8ct85RPamZ+8+ZTo8Ofj5VGQiVJmmmrlVkDyBzXwJL3WonnZwuU6QDaaYCFUuzyVqmEuYZNc3i6jNUs0Yptw2YjKww6ayV5msyGaA0QZ3vdGWRk9K7JQQhE7CII2N4yzvI="

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,8 @@ deploy:
                   repo: advancedtelematic/aktualizr
                   condition: $DOCKERFILE = Dockerfile.deb-stable
 
-          api_key: ${GITHUB_API_KEY}
+          api_key:
+                  secure: ${GITHUB_API_KEY}
 
         - provider: releases
           file: /persistent/aktualizr.deb
@@ -45,4 +46,5 @@ deploy:
                   all_branches: true
                   repo: advancedtelematic/aktualizr
                   condition: $DOCKERFILE = Dockerfile.16.04
-          api_key: ${GITHUB_API_KEY}
+          api_key:
+                  secure: ${GITHUB_API_KEY}


### PR DESCRIPTION
The way @patriotyk originally implemented passing github tokens looks like the only officially supported one. Travis docs claim that the "secure" key cannot be used by anyone outside advancedtelematic.