### PR TITLE
Add P11EngineGuard to count existing P11 users

### DIFF
--- a/src/p11engine.cc
+++ b/src/p11engine.cc
@@ -12,6 +12,9 @@
 #define kPkcs11Path "/usr/lib/engines/libpkcs11.so"
 #endif
 
+P11Engine* P11EngineGuard::instance = NULL;
+int P11EngineGuard::ref_counter = 0;
+
 P11Engine::P11Engine(const P11Config& config) : config_(config), ctx_(config_.module), slots_(ctx_.get()) {
   if (config_.module.empty()) return;
 

--- a/src/uptane/cryptokey.cc
+++ b/src/uptane/cryptokey.cc
@@ -8,7 +8,7 @@ CryptoKey::CryptoKey(const boost::shared_ptr<INvStorage> &backend, const Config 
       config_(config)
 #ifdef BUILD_P11
       ,
-      p11_(config_.p11)
+      p11_(config.p11)
 #endif
 {
 }
@@ -17,7 +17,7 @@ std::string CryptoKey::getPkey() const {
   std::string pkey;
 #ifdef BUILD_P11
   if (config_.tls.pkey_source == kPkcs11) {
-    pkey = p11_.getTlsPkeyId();
+    pkey = p11_->getTlsPkeyId();
   }
 #endif
   if (config_.tls.pkey_source == kFile) {
@@ -30,7 +30,7 @@ std::string CryptoKey::getCert() const {
   std::string cert;
 #ifdef BUILD_P11
   if (config_.tls.cert_source == kPkcs11) {
-    cert = p11_.getTlsCertId();
+    cert = p11_->getTlsCertId();
   }
 #endif
   if (config_.tls.cert_source == kFile) {
@@ -43,7 +43,7 @@ std::string CryptoKey::getCa() const {
   std::string ca;
 #ifdef BUILD_P11
   if (config_.tls.ca_source == kPkcs11) {
-    ca = p11_.getTlsCacertId();
+    ca = p11_->getTlsCacertId();
   }
 #endif
   if (config_.tls.ca_source == kFile) {
@@ -61,7 +61,7 @@ std::string CryptoKey::getCN() const {
     }
   } else {  // kPkcs11
 #ifdef BUILD_P11
-    if (!p11_.readTlsCert(&cert)) {
+    if (!p11_->readTlsCert(&cert)) {
       throw std::runtime_error(not_found_cert_message);
     }
 #else
@@ -100,7 +100,7 @@ Json::Value CryptoKey::signTuf(const Json::Value &in_data) {
   ENGINE *crypto_engine = NULL;
   std::string private_key;
 #ifdef BUILD_P11
-  if (config_.uptane.key_source == kPkcs11) crypto_engine = p11_.getEngine();
+  if (config_.uptane.key_source == kPkcs11) crypto_engine = p11_->getEngine();
 #endif
   if (config_.uptane.key_source == kFile) {
     backend_->loadPrimaryPrivate(&private_key);
@@ -128,7 +128,7 @@ std::string CryptoKey::getUptanePublicKey() {
   } else {
 #ifdef BUILD_P11
     // dummy read to check if the key is present
-    if (!p11_.readUptanePublicKey(&primary_public)) {
+    if (!p11_->readUptanePublicKey(&primary_public)) {
       throw std::runtime_error("Could not get uptane public key!");
     }
 #else
@@ -154,11 +154,11 @@ std::string CryptoKey::generateUptaneKeyPair() {
   } else {
 #ifdef BUILD_P11
     // dummy read to check if the key is present
-    if (!p11_.readUptanePublicKey(&primary_public)) {
-      p11_.generateUptaneKeyPair();
+    if (!p11_->readUptanePublicKey(&primary_public)) {
+      p11_->generateUptaneKeyPair();
     }
     // realy read the key
-    if (primary_public.empty() && !p11_.readUptanePublicKey(&primary_public)) {
+    if (primary_public.empty() && !p11_->readUptanePublicKey(&primary_public)) {
       throw std::runtime_error("Could not get uptane keys");
     }
     return primary_public;

--- a/src/uptane/cryptokey.h
+++ b/src/uptane/cryptokey.h
@@ -29,7 +29,7 @@ class CryptoKey {
     boost::shared_ptr<INvStorage> backend_;
     Config config_;
 #ifdef BUILD_P11
-    P11Engine p11_;
+    P11EngineGuard p11_;
 #endif
 
 };

--- a/tests/crypto_test.cc
+++ b/tests/crypto_test.cc
@@ -53,13 +53,13 @@ TEST(crypto, sign_verify_rsa_p11) {
   config.pass = "1234";
   config.uptane_key_id = "03";
 
-  P11Engine p11(config);
+  P11EngineGuard p11(config);
   std::string text = "This is text for sign";
   std::string key_content;
-  EXPECT_TRUE(p11.readUptanePublicKey(&key_content));
+  EXPECT_TRUE(p11->readUptanePublicKey(&key_content));
   PublicKey pkey(key_content, "rsa");
-  std::string private_key = p11.getUptaneKeyId();
-  std::string signature = Utils::toBase64(Crypto::RSAPSSSign(p11.getEngine(), private_key, text));
+  std::string private_key = p11->getUptaneKeyId();
+  std::string signature = Utils::toBase64(Crypto::RSAPSSSign(p11->getEngine(), private_key, text));
   bool signe_is_ok = Crypto::VerifySignature(pkey, signature, text);
   EXPECT_TRUE(signe_is_ok);
 }
@@ -70,11 +70,11 @@ TEST(crypto, generate_rsa_keypair_p11) {
   config.pass = "1234";
   config.uptane_key_id = "05";
 
-  P11Engine p11(config);
+  P11EngineGuard p11(config);
   std::string key_content;
-  EXPECT_FALSE(p11.readUptanePublicKey(&key_content));
-  EXPECT_TRUE(p11.generateUptaneKeyPair());
-  EXPECT_TRUE(p11.readUptanePublicKey(&key_content));
+  EXPECT_FALSE(p11->readUptanePublicKey(&key_content));
+  EXPECT_TRUE(p11->generateUptaneKeyPair());
+  EXPECT_TRUE(p11->readUptanePublicKey(&key_content));
 }
 
 TEST(crypto, certificate_pkcs11) {
@@ -82,10 +82,10 @@ TEST(crypto, certificate_pkcs11) {
   p11_conf.module = TEST_PKCS11_MODULE_PATH;
   p11_conf.pass = "1234";
   p11_conf.tls_clientcert_id = "01";
-  P11Engine p11(p11_conf);
+  P11EngineGuard p11(p11_conf);
 
   std::string cert;
-  bool res = p11.readTlsCert(&cert);
+  bool res = p11->readTlsCert(&cert);
   EXPECT_TRUE(res);
   if (!res) return;
 

--- a/tests/uptane_crypto_test.cc
+++ b/tests/uptane_crypto_test.cc
@@ -39,8 +39,6 @@ TEST(crypto, sign_tuf_pkcs11) {
   Config config;
   config.p11 = p11_conf;
 
-  P11Engine p11(p11_conf);
-
   TemporaryDirectory temp_dir;
   config.storage.path = temp_dir.Path();
   boost::shared_ptr<FSStorage> storage = boost::make_shared<FSStorage>(FSStorage(config.storage));
@@ -57,7 +55,7 @@ TEST(crypto, sign_tuf_pkcs11) {
 #endif
 
 #ifndef __NO_MAIN__
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/tests/uptane_test.cc
+++ b/tests/uptane_test.cc
@@ -995,6 +995,8 @@ TEST(Uptane, Pkcs11Provision) {
 #ifndef __NO_MAIN__
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+
+  logger_init();
   logger_set_threshold(boost::log::trivial::trace);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
The new version drops P11Engine once it has no more users (practically once Uptane::Repository gets out of scope) thus allowing reinitialization in tests. I have a feeling that I'm reimplementing a shared pointer, so if you think it can be done better I'm open to suggestions.