### PR TITLE
Only install docs if it was built.

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -23,7 +23,7 @@ if (DOXYGEN_FOUND AND DOXYGEN_DOT_FOUND)
         COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile
         COMMENT "Generating Doxygen Documentation")
     add_dependencies(docs doxygen)
-    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html/ DESTINATION share/doc/aktualizr)
+    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html/ DESTINATION share/doc/aktualizr OPTIONAL)
 else(DOXYGEN_FOUND AND DOXYGEN_DOT_FOUND)
     message(WARNING "doxygen + dot not found, skipping")
 endif(DOXYGEN_FOUND AND DOXYGEN_DOT_FOUND)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,8 +116,10 @@ endif(BUILD_WITH_CODE_COVERAGE)
 aktualizr_source_file_checks(main.cc ${SOURCES} ${HEADERS})
 
 ################## INSTALL RULES
-install(FILES ${PROJECT_SOURCE_DIR}/config/systemd/aktualizr-ubuntu.service DESTINATION /lib/systemd/system RENAME aktualizr.service  COMPONENT aktualizr)
-install(FILES ${PROJECT_SOURCE_DIR}/config/sota_ubuntu.toml DESTINATION /usr/lib/sota RENAME sota.toml  COMPONENT aktualizr)
+install(FILES ${PROJECT_SOURCE_DIR}/config/systemd/aktualizr-ubuntu.service
+        DESTINATION lib/systemd/system RENAME aktualizr.service COMPONENT aktualizr)
+install(FILES ${PROJECT_SOURCE_DIR}/config/sota_ubuntu.toml
+        DESTINATION lib/sota RENAME sota.toml COMPONENT aktualizr)
 install(TARGETS aktualizr RUNTIME DESTINATION bin COMPONENT aktualizr)
 if(INSTALL_LIB)
   install(TARGETS aktualizr_static_lib ARCHIVE DESTINATION lib LIBRARY DESTINATION lib)


### PR DESCRIPTION
This is necessary to get the meta-updater build to work correctly. Currently, the latest aktualizr fails.

Also make some installation directories relative so that things install correctly.