### PR TITLE
Move dbCheck out of main SQLStorage

### DIFF
--- a/src/sqlstorage.h
+++ b/src/sqlstorage.h
@@ -77,8 +77,9 @@ class SQLStorage : public INvStorage {
   virtual void cleanUp();
   virtual StorageType type() { return kSqlite; };
 
+  std::string getTableSchemaFromDb(const std::string& tablename);
+
   bool dbMigrate();
-  bool dbCheck();
   bool dbInit();
 
  private:
@@ -88,10 +89,6 @@ class SQLStorage : public INvStorage {
   std::map<std::string, std::string> req_params;
   std::map<std::string, std::string> req_response;
   std::vector<std::map<std::string, std::string> > req_response_table;
-
-  boost::movelib::unique_ptr<std::map<std::string, std::string> > parseSchema(int version);
-  bool tableSchemasEqual(const std::string& left, const std::string& right);
-  std::string getTableSchemaFromDb(const std::string& tablename);
 
   static int callback(void* instance_, int numcolumns, char** values, char** columns);
   int getVersion();  // non-negative integer on success or -1 on error

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -125,7 +125,8 @@ add_aktualizr_test(NAME packagemanager SOURCES packagemanager_test.cc NO_VALGRIN
 add_aktualizr_test(NAME socket_gateway SOURCES socketgateway_test.cc
                    ARGS ${PROJECT_SOURCE_DIR}/tests/fake_unix_socket/)
 
-add_aktualizr_test(NAME sqlstorage SOURCES sqlstorage_test.cc PROJECT_WORKING_DIRECTORY)
+add_aktualizr_test(NAME sqlstorage SOURCES sqlstorage_test.cc PROJECT_WORKING_DIRECTORY
+                   ARGS ${PROJECT_SOURCE_DIR}/config/schemas)
 
 add_aktualizr_test(NAME storage SOURCES storage_common_test.cc PROJECT_WORKING_DIRECTORY)
 

--- a/tests/sqlstorage_test.cc
+++ b/tests/sqlstorage_test.cc
@@ -4,6 +4,89 @@
 #include "sqlstorage.h"
 #include "utils.h"
 
+boost::filesystem::path schemas_path;
+
+static std::map<std::string, std::string> parseSchema(int version) {
+  boost::filesystem::path schema_file =
+      schemas_path / (std::string("schema.") + boost::lexical_cast<std::string>(version) + ".sql");
+  std::string schema = Utils::readFile(schema_file.string());
+  std::map<std::string, std::string> result;
+  std::vector<std::string> tokens;
+
+  enum { STATE_INIT, STATE_CREATE, STATE_TABLE, STATE_NAME };
+  boost::char_separator<char> sep(" \"\t\r\n", "(),;");
+  sql_tokenizer tok(schema, sep);
+  int parsing_state = STATE_INIT;
+
+  std::string key;
+  std::string value;
+  for (sql_tokenizer::iterator it = tok.begin(); it != tok.end(); ++it) {
+    std::string token = *it;
+    if (value.empty())
+      value = token;
+    else
+      value = value + " " + token;
+    switch (parsing_state) {
+      case STATE_INIT:
+        if (token != "CREATE") {
+          return std::map<std::string, std::string>();
+        }
+        parsing_state = STATE_CREATE;
+        break;
+      case STATE_CREATE:
+        if (token != "TABLE") {
+          return std::map<std::string, std::string>();
+        }
+        parsing_state = STATE_TABLE;
+        break;
+      case STATE_TABLE:
+        if (token == "(" || token == ")" || token == "," || token == ";") {
+          return std::map<std::string, std::string>();
+        }
+        key = token;
+        parsing_state = STATE_NAME;
+        break;
+      case STATE_NAME:
+        if (token == ";") {
+          result[key] = value;
+          key.clear();
+          value.clear();
+          parsing_state = STATE_INIT;
+        }
+        break;
+    }
+  }
+  return result;
+}
+
+static bool tableSchemasEqual(const std::string& left, const std::string& right) {
+  boost::char_separator<char> sep(" \"\t\r\n", "(),;");
+  sql_tokenizer tokl(left, sep);
+  sql_tokenizer tokr(right, sep);
+
+  sql_tokenizer::iterator it_l;
+  sql_tokenizer::iterator it_r;
+  for (it_l = tokl.begin(), it_r = tokr.begin(); it_l != tokl.end() && it_r != tokr.end(); ++it_l, ++it_r) {
+    if (*it_l != *it_r) return false;
+  }
+  return (it_l == tokl.end()) && (it_r == tokr.end());
+}
+
+static bool dbSchemaCheck(SQLStorage& storage) {
+  std::map<std::string, std::string> tables = parseSchema(kSqlSchemaVersion);
+
+  for (std::map<std::string, std::string>::iterator it = tables.begin(); it != tables.end(); ++it) {
+    std::string schema_from_db = storage.getTableSchemaFromDb(it->first);
+    if (!tableSchemasEqual(schema_from_db, it->second)) {
+      LOG_ERROR << "Schemas don't match for " << it->first;
+      LOG_ERROR << "Expected " << it->second;
+      LOG_ERROR << "Found " << schema_from_db;
+      return false;
+    }
+  }
+  return true;
+}
+
 TEST(sqlstorage, migrate) {
   TemporaryDirectory temp_dir;
   StorageConfig config;
@@ -14,9 +97,9 @@ TEST(sqlstorage, migrate) {
   SQLStorage storage(config);
   boost::filesystem::remove_all(config.sqldb_path);
 
-  EXPECT_FALSE(storage.dbCheck());
+  EXPECT_FALSE(dbSchemaCheck(storage));
   EXPECT_TRUE(storage.dbMigrate());
-  EXPECT_TRUE(storage.dbCheck());
+  EXPECT_TRUE(dbSchemaCheck(storage));
 }
 
 TEST(sqlstorage, MissingSchema) {
@@ -30,10 +113,16 @@ TEST(sqlstorage, MissingSchema) {
 }
 
 #ifndef __NO_MAIN__
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   logger_init();
   logger_set_threshold(boost::log::trivial::trace);
+
+  if (argc != 2) {
+    std::cerr << "Error: " << argv[0] << " requires the path to the schemas directory as an input argument.\n";
+    return EXIT_FAILURE;
+  }
+  schemas_path = argv[1];
   return RUN_ALL_TESTS();
 }
 #endif


### PR DESCRIPTION
Now only run as a separate test and not at every db init.

Note that `getTableSchemaFromDb` is now available as a public method to
make this work.

Following recommendations from PRO-4725