### PR TITLE
Improve resilience of example_flasher logic.

### DIFF
--- a/src/external_secondaries/example_flasher.cc
+++ b/src/external_secondaries/example_flasher.cc
@@ -1,3 +1,4 @@
+#include <unistd.h>
 #include <iostream>
 
 #include <boost/filesystem.hpp>
@@ -9,9 +10,14 @@ std::string filename;
 std::string serial;
 
 ExampleFlasher::ExampleFlasher(const unsigned int loglevel) : loglevel_(loglevel) {
-  // Assume /var/sota is available on devices but not on hosts.
+  // Use /var/sota if it is available and accessible to the current user.
+  // Generally this is true for devices but not hosts.
   if (boost::filesystem::exists("/var/sota")) {
-    filename = "/var/sota/example_serial";
+    if (!access("/var/sota", R_OK & W_OK & X_OK)) {
+      filename = "/tmp/example_serial";
+    } else {
+      filename = "/var/sota/example_serial";
+    }
   } else {
     filename = "/tmp/example_serial";
   }

--- a/src/httpclient.cc
+++ b/src/httpclient.cc
@@ -10,7 +10,6 @@
 #include <openssl/rand.h>
 #include <openssl/rsa.h>
 #include <openssl/ssl.h>
-#include <sys/stat.h>
 #include <boost/move/make_unique.hpp>
 #include <boost/move/utility.hpp>
 

--- a/tests/utils_test.cc
+++ b/tests/utils_test.cc
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include <sys/stat.h>
 #include <fstream>
 #include <set>
 


### PR DESCRIPTION
Previously it assumed if /var/sota existed it was good to use. Now it
actually checks for read-/writability before moving forward. This is
obviously still liable to fail if the filesystem changes before we
actually use it, but this is just an example that is also used for
testing.