### PR TITLE
Option to run tests in parallel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ option(BUILD_SOTA_TOOLS "Set to ON to build SOTA tools" OFF)
 option(BUILD_ISOTP "Set to ON to build ISO-TP" OFF)
 option(BUILD_OPCUA "Set to ON to compile with OPC-UA protocol support" OFF)
 option(INSTALL_LIB "Set to ON to install library and headers" OFF)
+set(TEST_JOBS "1" CACHE STRING "Number of parallel test jobs to run in 'make qa'")
 
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
     message(FATAL_ERROR "Aktualizr does not support building in the source tree. Please remove CMakeCache.txt and the CMakeFiles/ directory, then create a subdirectory to build in: mkdir build; cd build; cmake ..")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,10 +39,16 @@ endif(BUILD_SOTA_TOOLS)
 
 add_dependencies(build_tests aktualizr-info)
 
-add_custom_target(check COMMAND CTEST_OUTPUT_ON_FAILURE=1 ${CMAKE_CTEST_COMMAND}
-                  -E test_valgrind_uptane_vectors\\|test_build DEPENDS build_tests)
-add_custom_target(check-full COMMAND CTEST_OUTPUT_ON_FAILURE=1 ${CMAKE_CTEST_COMMAND}
-                  -E test_uptane_vectors DEPENDS build_tests)
+add_custom_target(check COMMAND
+                    CTEST_OUTPUT_ON_FAILURE=1
+                    CTEST_PARALLEL_LEVEL=${TEST_JOBS}
+                    ${CMAKE_CTEST_COMMAND}
+                    -E test_valgrind_uptane_vectors\\|test_build DEPENDS build_tests)
+add_custom_target(check-full COMMAND
+                    CTEST_OUTPUT_ON_FAILURE=1
+                    CTEST_PARALLEL_LEVEL=${TEST_JOBS}
+                    ${CMAKE_CTEST_COMMAND}
+                    -E test_uptane_vectors DEPENDS build_tests)
 
 # List of source files to run clang-format and clang-check on. Automatically
 # appended to by add_aktualizr_test, but anything that doesn't use that must be


### PR DESCRIPTION
This adds an option to configure the number of tests that are run in parallel. It can be set on the cmake command line or by editing CMakeCache.txt. The default is '1', because there isn't much ram on the CI server.

Change-Id: I80898affa3607ab79e8e5f1f19574a07c9c79885