### PR TITLE
Remove libostree and libdpkg dependencies for garage-deploy

### DIFF
--- a/scripts/build-ubuntu.sh
+++ b/scripts/build-ubuntu.sh
@@ -3,7 +3,7 @@ set -e
 
 mkdir -p build-ubuntu
 cd build-ubuntu
-cmake ../src
+cmake -DCMAKE_BUILD_TYPE=Release ../src
 
 make -j8
 make package

--- a/src/sota_tools/CMakeLists.txt
+++ b/src/sota_tools/CMakeLists.txt
@@ -74,9 +74,7 @@ target_link_libraries(garage-deploy sota_tools_static_lib aktualizr_static_lib
   ${CMAKE_THREAD_LIBS_INIT}
   ${CURL_LIBRARIES}
   ${GLIB2_LIBRARIES}
-  ${LibArchive_LIBRARIES}
-  ${LIBOSTREE_LIBRARIES}
-  ${LIBDPKG_LIBRARIES})
+  ${LibArchive_LIBRARIES})
 
 if(BUILD_WITH_CODE_COVERAGE)
     target_link_libraries(garage-deploy gcov)


### PR DESCRIPTION
This cleans up the dependencies in the .deb package as well.