### PR TITLE
Make name generator a standalone utility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,7 @@ add_subdirectory("src")
 add_subdirectory("src/cert_provider")
 add_subdirectory("src/implicit_writer")
 add_subdirectory("src/external_secondaries")
+add_subdirectory("src/name_generator")
 add_subdirectory("fuzz")
 add_subdirectory("config")
 

--- a/src/name_generator/CMakeLists.txt
+++ b/src/name_generator/CMakeLists.txt
@@ -1,0 +1,14 @@
+# set the name of the executable
+add_executable(aktualizr_name_generator main.cc)
+
+target_link_libraries(aktualizr_name_generator aktualizr_static_lib ${Boost_LIBRARIES})
+
+if(BUILD_WITH_CODE_COVERAGE)
+    target_link_libraries(aktualizr_name_generator gcov)
+endif(BUILD_WITH_CODE_COVERAGE)
+
+aktualizr_source_file_checks(main.cc)
+
+install(TARGETS aktualizr_name_generator RUNTIME DESTINATION bin)
+
+# vim: set tabstop=4 shiftwidth=4 expandtab:

--- a/src/name_generator/main.cc
+++ b/src/name_generator/main.cc
@@ -1,0 +1,11 @@
+#include <iostream>
+#include "utils.h"
+
+int main(int argc, char *argv[]) {
+  (void)argc;
+  (void)argv;
+
+  std::cout << Utils::genPrettyName() << std::endl;
+
+  return 0;
+}


### PR DESCRIPTION
Maybe it's not a horrible idea. Would be useful in "mock real implicit provisioning" scenario done with openssl utility.