### PR TITLE
Add support and switch between of rsa2048, rsa4096 and ed25519 keys

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -14,6 +14,7 @@
 #include <boost/uuid/uuid_io.hpp>
 
 #include "logging.h"
+#include "types.h"
 #include "uptane/secondaryconfig.h"
 
 enum ProvisionMode { kAutomatic = 0, kImplicit };
@@ -80,7 +81,8 @@ struct UptaneConfig {
         primary_ecu_hardware_id(""),
         director_server(""),
         repo_server(""),
-        key_source(kFile) {}
+        key_source(kFile),
+        key_type(kRSA2048) {}
   bool polling;
   unsigned long long polling_sec;
   std::string device_id;
@@ -89,6 +91,8 @@ struct UptaneConfig {
   std::string director_server;
   std::string repo_server;
   CryptoSource key_source;
+  KeyType key_type;
+  std::string getKeyTypeString() const { return (key_type == kED25519) ? "ED25519" : "RSA"; }
   std::vector<Uptane::SecondaryConfig> secondary_configs;
 };
 

--- a/src/crypto.cc
+++ b/src/crypto.cc
@@ -97,7 +97,6 @@ std::string Crypto::RSAPSSSign(ENGINE *engine, const std::string &private_key, c
 
 std::string Crypto::Sign(KeyType key_type, ENGINE *engine, const std::string &private_key, const std::string &message) {
   if (key_type == kED25519) {
-    std::cout << "PRIVKEY:" << private_key;
     return Crypto::ED25519Sign(boost::algorithm::unhex(private_key), message);
   } else {
     return Crypto::RSAPSSSign(engine, private_key, message);

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -89,9 +89,9 @@ class Crypto {
  public:
   static std::string sha256digest(const std::string &text);
   static std::string sha512digest(const std::string &text);
-  static std::string RSAPSSSign(ENGINE *engine, const std::string &private_key, const std::string &digest);
-  static std::string Sign(KeyType key_type, ENGINE *engine, const std::string &private_key, const std::string &digest);
-  static std::string ED25519Sign(const std::string &private_key, const std::string &digest);
+  static std::string RSAPSSSign(ENGINE *engine, const std::string &private_key, const std::string &message);
+  static std::string Sign(KeyType key_type, ENGINE *engine, const std::string &private_key, const std::string &message);
+  static std::string ED25519Sign(const std::string &private_key, const std::string &message);
 
   static bool VerifySignature(const PublicKey &public_key, const std::string &signature, const std::string &message);
   static bool parseP12(FILE *p12_fp, const std::string &p12_password, std::string *out_pkey, std::string *out_cert,

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -89,12 +89,17 @@ class Crypto {
  public:
   static std::string sha256digest(const std::string &text);
   static std::string sha512digest(const std::string &text);
-  static std::string RSAPSSSign(ENGINE *engine, const std::string &private_key, const std::string &message);
+  static std::string RSAPSSSign(ENGINE *engine, const std::string &private_key, const std::string &digest);
+  static std::string Sign(KeyType key_type, ENGINE *engine, const std::string &private_key, const std::string &digest);
+  static std::string ED25519Sign(const std::string &private_key, const std::string &digest);
+
   static bool VerifySignature(const PublicKey &public_key, const std::string &signature, const std::string &message);
   static bool parseP12(FILE *p12_fp, const std::string &p12_password, std::string *out_pkey, std::string *out_cert,
                        std::string *out_ca);
   static bool extractSubjectCN(const std::string &cert, std::string *cn);
-  static bool generateRSAKeyPair(std::string *public_key, std::string *private_key);
+  static bool generateRSAKeyPair(KeyType key_type, std::string *public_key, std::string *private_key);
+  static bool generateEDKeyPair(std::string *public_key, std::string *private_key);
+  static bool generateKeyPair(KeyType key_type, std::string *public_key, std::string *private_key);
 
   static bool RSAPSSVerify(const std::string &public_key, const std::string &signature, const std::string &message);
   static bool ED25519Verify(const std::string &public_key, const std::string &signature, const std::string &message);

--- a/src/invstorage.h
+++ b/src/invstorage.h
@@ -4,7 +4,6 @@
 #include <boost/filesystem.hpp>
 #include <memory>
 #include <string>
-#include "config.h"
 
 #include "uptane/tuf.h"
 

--- a/src/keymanager.cc
+++ b/src/keymanager.cc
@@ -188,8 +188,8 @@ Json::Value KeyManager::signTuf(const Json::Value &in_data) {
   if (config_.uptane.key_source == kFile) {
     backend_->loadPrimaryPrivate(&private_key);
   }
-  std::string b64sig =
-      Utils::toBase64(Crypto::RSAPSSSign(crypto_engine, private_key, Json::FastWriter().write(in_data)));
+  std::string b64sig = Utils::toBase64(
+      Crypto::Sign(config_.uptane.key_type, crypto_engine, private_key, Json::FastWriter().write(in_data)));
   Json::Value signature;
   signature["method"] = "rsassa-pss";
   signature["sig"] = b64sig;
@@ -227,7 +227,7 @@ std::string KeyManager::generateUptaneKeyPair() {
   if (config_.uptane.key_source == kFile) {
     std::string primary_private;
     if (!backend_->loadPrimaryKeys(&primary_public, &primary_private)) {
-      if (Crypto::generateRSAKeyPair(&primary_public, &primary_private)) {
+      if (Crypto::generateKeyPair(config_.uptane.key_type, &primary_public, &primary_private)) {
         backend_->storePrimaryKeys(primary_public, primary_private);
       }
     }

--- a/src/sotauptaneclient.cc
+++ b/src/sotauptaneclient.cc
@@ -220,7 +220,7 @@ void SotaUptaneClient::initSecondaries() {
       continue;
     }
     secondaries[sec_serial] = sec;
-    uptane_repo.addSecondary(sec_serial, sec->getHwId(), sec->getPublicKey());
+    uptane_repo.addSecondary(sec);
   }
 }
 

--- a/src/types.h
+++ b/src/types.h
@@ -4,6 +4,8 @@
 #include <json/json.h>
 #include <boost/filesystem.hpp>
 
+enum KeyType { kED25519 = 0, kRSA2048, kRSA4096 };
+
 namespace data {
 
 typedef std::string UpdateRequestId;

--- a/src/uptane/managedsecondary.cc
+++ b/src/uptane/managedsecondary.cc
@@ -14,7 +14,8 @@ ManagedSecondary::ManagedSecondary(const SecondaryConfig &sconfig_in) : Secondar
   // loadMetadata(meta_pack);
   if (!loadKeys(&public_key, &private_key)) {
     if (!Crypto::generateKeyPair(sconfig.key_type, &public_key, &private_key)) {
-      LOG_ERROR << "Could not generate rsa keys for secondary " << getSerial() << "@" << sconfig.ecu_hardware_id;
+      LOG_ERROR << "Could not generate rsa keys for secondary " << ManagedSecondary::getSerial() << "@"
+                << sconfig.ecu_hardware_id;
       throw std::runtime_error("Unable to generate secondary rsa keys");
     }
     storeKeys(public_key, private_key);

--- a/src/uptane/managedsecondary.cc
+++ b/src/uptane/managedsecondary.cc
@@ -13,9 +13,8 @@ ManagedSecondary::ManagedSecondary(const SecondaryConfig &sconfig_in) : Secondar
   // TODO: FIX
   // loadMetadata(meta_pack);
   if (!loadKeys(&public_key, &private_key)) {
-    if (!Crypto::generateRSAKeyPair(&public_key, &private_key)) {
-      LOG_ERROR << "Could not generate rsa keys for secondary " << ManagedSecondary::getSerial() << "@"
-                << sconfig.ecu_hardware_id;
+    if (!Crypto::generateKeyPair(sconfig.key_type, &public_key, &private_key)) {
+      LOG_ERROR << "Could not generate rsa keys for secondary " << getSerial() << "@" << sconfig.ecu_hardware_id;
       throw std::runtime_error("Unable to generate secondary rsa keys");
     }
     storeKeys(public_key, private_key);

--- a/src/uptane/secondaryconfig.h
+++ b/src/uptane/secondaryconfig.h
@@ -4,6 +4,7 @@
 #include <string>
 
 #include <boost/filesystem.hpp>
+#include "types.h"
 
 namespace Uptane {
 
@@ -22,6 +23,7 @@ class SecondaryConfig {
   bool partial_verifying;
   std::string ecu_private_key;
   std::string ecu_public_key;
+  KeyType key_type{kRSA2048};
 
   boost::filesystem::path full_client_dir;   // kVirtual, kLegacy
   boost::filesystem::path firmware_path;     // kVirtual, kLegacy

--- a/src/uptane/secondaryinterface.h
+++ b/src/uptane/secondaryinterface.h
@@ -31,6 +31,7 @@ class SecondaryInterface {
   virtual bool putRoot(Uptane::Root root, bool director) = 0;
 
   virtual bool sendFirmware(const std::string& data) = 0;
+  std::string getKeyType() const { return (sconfig.key_type == kED25519) ? "ED25519" : "RSA"; }
 
   const SecondaryConfig& sconfig;
 };

--- a/src/uptane/uptanerepository.cc
+++ b/src/uptane/uptanerepository.cc
@@ -43,8 +43,8 @@ bool Repository::putManifest(const Json::Value &version_manifests) {
   return response.isOk();
 }
 
-Json::Value Repository::signVersionManifest(const Json::Value &primary_version_manifest) {
-  Json::Value ecu_version_signed = keys_.signTuf(primary_version_manifest);
+Json::Value Repository::signVersionManifest(const Json::Value &primary_version_manifests) {
+  Json::Value ecu_version_signed = keys_.signTuf(primary_version_manifests);
   return ecu_version_signed;
 }
 

--- a/src/uptane/uptanerepository.h
+++ b/src/uptane/uptanerepository.h
@@ -32,11 +32,8 @@ class Repository {
  public:
   Repository(const Config &config_in, boost::shared_ptr<INvStorage> storage_in, HttpInterface &http_client);
   bool putManifest(const Json::Value &version_manifests);
-  Json::Value signVersionManifest(const Json::Value &primary_version_manifest);
-  void addSecondary(const std::string &ecu_serial, const std::string &hardware_identifier,
-                    const std::string &public_key) {
-    secondary_info[ecu_serial] = std::make_pair(hardware_identifier, public_key);
-  }
+  Json::Value signVersionManifest(const Json::Value &primary_version_manifests);
+  void addSecondary(const boost::shared_ptr<Uptane::SecondaryInterface> &sec) { secondary_info.push_back(sec); }
   std::pair<int, std::vector<Uptane::Target> > getTargets();
   std::string getPrimaryEcuSerial() const { return primary_ecu_serial; };
   std::string findInstalledVersion(const std::string &hash);
@@ -66,8 +63,7 @@ class Repository {
   std::string primary_ecu_serial;
   std::string primary_hardware_id_;
 
-  // ECU serial => (ECU hardware ID, ECU public_key)
-  std::map<std::string, std::pair<std::string, std::string> > secondary_info;
+  std::vector<boost::shared_ptr<Uptane::SecondaryInterface> > secondary_info;
 
   bool verifyMeta(const Uptane::MetaPack &meta);
 

--- a/tests/config_tests_device_id.toml
+++ b/tests/config_tests_device_id.toml
@@ -11,6 +11,7 @@ websocket_server = "127.0.0.1:3012"
 
 [uptane]
 device_id = "test-name-123"
+key_type = "ED25519"
 
 [provision]
 provision_path = "tests/test_data/cred.zip"

--- a/tests/config_tests_prov.toml
+++ b/tests/config_tests_prov.toml
@@ -19,6 +19,7 @@ server = "https://7d0a4914-c392-4ccd-a8f9-3d4ed969da07.tcpgw.prod01.advancedtele
 [uptane]
 polling = false
 polling_sec = 91
+key_type = "ED25519"
 
 [pacman]
 type = "none"

--- a/tests/crypto_test.cc
+++ b/tests/crypto_test.cc
@@ -233,10 +233,28 @@ TEST(crypto, parsep12_FAIL) {
   EXPECT_EQ(result, false);
 }
 
-TEST(crypto, generateRSAKeyPair) {
+TEST(crypto, generateRSA2048KeyPair) {
   std::string public_key;
   std::string private_key;
-  EXPECT_TRUE(Crypto::generateRSAKeyPair(&public_key, &private_key));
+  EXPECT_TRUE(Crypto::generateRSAKeyPair(kRSA2048, &public_key, &private_key));
+  EXPECT_NE(public_key.size(), 0);
+  EXPECT_NE(private_key.size(), 0);
+}
+
+TEST(crypto, generateRSA4096KeyPair) {
+  std::string public_key;
+  std::string private_key;
+  EXPECT_TRUE(Crypto::generateRSAKeyPair(kRSA4096, &public_key, &private_key));
+  EXPECT_NE(public_key.size(), 0);
+  EXPECT_NE(private_key.size(), 0);
+}
+
+TEST(crypto, generateED25519KeyPair) {
+  std::string public_key;
+  std::string private_key;
+  EXPECT_TRUE(Crypto::generateEDKeyPair(&public_key, &private_key));
+  EXPECT_NE(public_key.size(), 0);
+  EXPECT_NE(private_key.size(), 0);
 }
 
 #ifndef __NO_MAIN__

--- a/tests/keymanager_test.cc
+++ b/tests/keymanager_test.cc
@@ -20,6 +20,7 @@ TEST(KeyManager, SignTuf) {
   std::string private_key = Utils::readFile("tests/test_data/priv.key");
   std::string public_key = Utils::readFile("tests/test_data/public.key");
   Config config;
+  config.uptane.key_type = kRSA2048;
   TemporaryDirectory temp_dir;
   config.storage.path = temp_dir.Path();
   boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(config.storage);
@@ -32,6 +33,29 @@ TEST(KeyManager, SignTuf) {
   EXPECT_EQ(signed_json["signed"]["mykey"].asString(), "value");
   EXPECT_EQ(signed_json["signatures"][0]["keyid"].asString(),
             "6a809c62b4f6c2ae11abfb260a6a9a57d205fc2887ab9c83bd6be0790293e187");
+  EXPECT_NE(signed_json["signatures"][0]["sig"].asString().size(), 0);
+}
+
+TEST(KeyManager, SignED25519Tuf) {
+  std::string private_key =
+      "BD0A7539BD0365D7A9A3050390AD7B7C2033C58E354C5E0F42B9B611273BBA38BB9FFA4DCF35A89F6F40C5FA67998DD38B64A8459598CF3D"
+      "A93853388FDAC760";
+  std::string public_key = "BB9FFA4DCF35A89F6F40C5FA67998DD38B64A8459598CF3DA93853388FDAC760";
+  Config config;
+  config.uptane.key_type = kED25519;
+  TemporaryDirectory temp_dir;
+  config.storage.path = temp_dir.Path();
+  boost::shared_ptr<INvStorage> storage = boost::make_shared<FSStorage>(config.storage);
+
+  storage->storePrimaryKeys(public_key, private_key);
+  KeyManager keys(storage, config);
+
+  Json::Value tosign_json;
+  tosign_json["mykey"] = "value";
+  Json::Value signed_json = keys.signTuf(tosign_json);
+  EXPECT_EQ(signed_json["signed"]["mykey"].asString(), "value");
+  EXPECT_EQ(signed_json["signatures"][0]["keyid"].asString(),
+            "a6d0f6b52ae833175dd7724899507709231723037845715c7677670e0195f850");
   EXPECT_NE(signed_json["signatures"][0]["sig"].asString().size(), 0);
 }
 


### PR DESCRIPTION
Running all uptane related tests with command `ctest -R test_uptane` gives me the following results:
```
RSA2048 : 120 secs
ED255519: 60 secs
```
So looks like ED25519 is much faster then RSA2048. 
But server doesnt support it, so we can not use it by default yet.