### PR TITLE
Don't force CPACK_CMAKE_GENERATOR to make

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,7 +200,6 @@ endif()
 
 # General packaging configuration
 set(CPACK_GENERATOR "DEB")
-set(CPACK_CMAKE_GENERATOR "Unix Makefiles")
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "anton.gerasimov@here.com")
 set(CPACK_DEB_COMPONENT_INSTALL ON)
 set(CPACK_COMPONENTS_GROUPING ONE_PER_GROUP)


### PR DESCRIPTION
This is is normally autodetected based on the current cmake generator, and
overriding it causes the package build to fail when using ninja rather than
make. The docs say that 'few users will want to change this setting':

https://cmake.org/cmake/help/v3.0/module/CPack.html

Change-Id: Id66e01f00ca2f57f052d9d439d1087b226adeddf