### PR TITLE
Fix some atomicity issues

### DIFF
--- a/src/fsstorage.cc
+++ b/src/fsstorage.cc
@@ -22,18 +22,9 @@ FSStorage::~FSStorage() {
 }
 
 void FSStorage::storePrimaryKeys(const std::string& public_key, const std::string& private_key) {
-  storePrimaryPublic(public_key);
-  storePrimaryPrivate(private_key);
-}
-
-void FSStorage::storePrimaryPublic(const std::string& public_key) {
   boost::filesystem::path public_key_path = Utils::absolutePath(config_.path, config_.uptane_public_key_path);
   Utils::writeFile(public_key_path, public_key);
 
-  sync();
-}
-
-void FSStorage::storePrimaryPrivate(const std::string& private_key) {
   boost::filesystem::path private_key_path = Utils::absolutePath(config_.path, config_.uptane_private_key_path);
   Utils::writeFile(private_key_path, private_key);
 

--- a/src/fsstorage.cc
+++ b/src/fsstorage.cc
@@ -28,7 +28,6 @@ void FSStorage::storePrimaryKeys(const std::string& public_key, const std::strin
 
 void FSStorage::storePrimaryPublic(const std::string& public_key) {
   boost::filesystem::path public_key_path = Utils::absolutePath(config_.path, config_.uptane_public_key_path);
-  boost::filesystem::remove(public_key_path);
   Utils::writeFile(public_key_path, public_key);
 
   sync();
@@ -36,7 +35,6 @@ void FSStorage::storePrimaryPublic(const std::string& public_key) {
 
 void FSStorage::storePrimaryPrivate(const std::string& private_key) {
   boost::filesystem::path private_key_path = Utils::absolutePath(config_.path, config_.uptane_private_key_path);
-  boost::filesystem::remove(private_key_path);
   Utils::writeFile(private_key_path, private_key);
 
   sync();
@@ -79,21 +77,18 @@ void FSStorage::storeTlsCreds(const std::string& ca, const std::string& cert, co
 
 void FSStorage::storeTlsCa(const std::string& ca) {
   boost::filesystem::path ca_path(Utils::absolutePath(config_.path, config_.tls_cacert_path));
-  boost::filesystem::remove(ca_path);
   Utils::writeFile(ca_path, ca);
   sync();
 }
 
 void FSStorage::storeTlsCert(const std::string& cert) {
   boost::filesystem::path cert_path(Utils::absolutePath(config_.path, config_.tls_clientcert_path));
-  boost::filesystem::remove(cert_path);
   Utils::writeFile(cert_path, cert);
   sync();
 }
 
 void FSStorage::storeTlsPkey(const std::string& pkey) {
   boost::filesystem::path pkey_path(Utils::absolutePath(config_.path, config_.tls_pkey_path));
-  boost::filesystem::remove(pkey_path);
   Utils::writeFile(pkey_path, pkey);
   sync();
 }

--- a/src/fsstorage.h
+++ b/src/fsstorage.h
@@ -10,8 +10,6 @@ class FSStorage : public INvStorage {
   FSStorage(const StorageConfig& config);
   ~FSStorage() override;
   void storePrimaryKeys(const std::string& public_key, const std::string& private_key) override;
-  void storePrimaryPublic(const std::string& public_key) override;
-  void storePrimaryPrivate(const std::string& private_key) override;
   bool loadPrimaryKeys(std::string* public_key, std::string* private_key) override;
   bool loadPrimaryPublic(std::string* public_key) override;
   bool loadPrimaryPrivate(std::string* private_key) override;

--- a/src/invstorage.h
+++ b/src/invstorage.h
@@ -81,8 +81,6 @@ class INvStorage {
   INvStorage(const StorageConfig& config) : config_(config) {}
   virtual ~INvStorage() {}
   virtual void storePrimaryKeys(const std::string& public_key, const std::string& private_key) = 0;
-  virtual void storePrimaryPublic(const std::string& public_key) = 0;
-  virtual void storePrimaryPrivate(const std::string& private_key) = 0;
   virtual bool loadPrimaryKeys(std::string* public_key, std::string* private_key) = 0;
   virtual bool loadPrimaryPublic(std::string* public_key) = 0;
   virtual bool loadPrimaryPrivate(std::string* private_key) = 0;
@@ -143,6 +141,8 @@ class INvStorage {
  private:
   void importSimple(store_data_t store_func, load_data_t load_func, boost::filesystem::path imported_data_path);
   void importUpdateSimple(store_data_t store_func, load_data_t load_func, boost::filesystem::path imported_data_path);
+  void importPrimaryKeys(const boost::filesystem::path& import_pubkey_path,
+                         const boost::filesystem::path& import_privkey_path);
 
  protected:
   const StorageConfig& config_;

--- a/src/sql_utils.h
+++ b/src/sql_utils.h
@@ -119,6 +119,30 @@ class SQLite3Guard {
     return sqlite3_exec(handle_.get(), sql, callback, cb_arg, NULL);
   }
 
+  bool beginTransaction() {
+    int ret = exec("BEGIN TRANSACTION;", NULL, NULL);
+    if (ret != SQLITE_OK) {
+      LOG_ERROR << "Can't begin transaction: " << errmsg();
+    }
+    return ret == SQLITE_OK;
+  }
+
+  bool commitTransaction() {
+    int ret = exec("COMMIT TRANSACTION;", NULL, NULL);
+    if (ret != SQLITE_OK) {
+      LOG_ERROR << "Can't commit transaction: " << errmsg();
+    }
+    return ret == SQLITE_OK;
+  }
+
+  bool rollbackTransaction() {
+    int ret = exec("ROLLBACK TRANSACTION;", NULL, NULL);
+    if (ret != SQLITE_OK) {
+      LOG_ERROR << "Can't rollback transaction: " << errmsg();
+    }
+    return ret == SQLITE_OK;
+  }
+
   std::string errmsg() const { return sqlite3_errmsg(handle_.get()); }
 
   template <typename... Types>

--- a/src/sqlstorage.h
+++ b/src/sqlstorage.h
@@ -20,8 +20,6 @@ class SQLStorage : public INvStorage {
   SQLStorage(const StorageConfig& config);
   ~SQLStorage() override;
   void storePrimaryKeys(const std::string& public_key, const std::string& private_key) override;
-  void storePrimaryPublic(const std::string& public_key) override;
-  void storePrimaryPrivate(const std::string& private_key) override;
   bool loadPrimaryKeys(std::string* public_key, std::string* private_key) override;
   bool loadPrimaryPublic(std::string* public_key) override;
   bool loadPrimaryPrivate(std::string* private_key) override;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -135,6 +135,8 @@ add_aktualizr_test(NAME sql_utils SOURCES sql_utils_test.cc PROJECT_WORKING_DIRE
 
 add_aktualizr_test(NAME storage SOURCES storage_common_test.cc PROJECT_WORKING_DIRECTORY)
 
+add_aktualizr_test(NAME storage_atomic SOURCES storage_atomic.cc PROJECT_WORKING_DIRECTORY)
+
 add_aktualizr_test(NAME timer SOURCES timer_test.cc)
 
 add_aktualizr_test(NAME tuf SOURCES tuf_test.cc PROJECT_WORKING_DIRECTORY)

--- a/tests/storage_atomic.cc
+++ b/tests/storage_atomic.cc
@@ -120,13 +120,17 @@ void atomic_test() {
   }
 }
 
-// does not work with fs storage
+// To run these tests:
+// ./build/tests/t_storage_atomic --gtest_also_run_disabled_tests
+
 TEST(DISABLED_storage_atomic, fs) {
+  // broken on FS storage: public and private parts are stored in two different files
   storage_test_type = kFileSystem;
   atomic_test();
 }
 
-TEST(storage_atomic, sql) {
+TEST(DISABLED_storage_atomic, sql) {
+  // disabled for now because it uses too much resources for CI
   storage_test_type = kSqlite;
   atomic_test();
 }

--- a/tests/storage_atomic.cc
+++ b/tests/storage_atomic.cc
@@ -1,0 +1,141 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <random>
+#include <string>
+#include <thread>
+
+#include <boost/filesystem.hpp>
+
+#include "fsstorage.h"
+#include "sqlstorage.h"
+#include "utils.h"
+
+#include "logging.h"
+
+StorageType storage_test_type;
+
+std::unique_ptr<INvStorage> Storage(const StorageConfig& config) {
+  if (config.type == kFileSystem) {
+    return std::unique_ptr<INvStorage>(new FSStorage(config));
+  } else if (config.type == kSqlite) {
+    return std::unique_ptr<INvStorage>(new SQLStorage(config));
+  } else {
+    std::cout << "Invalid config type: " << config.type << "\n";
+    return std::unique_ptr<INvStorage>(nullptr);
+  }
+}
+
+StorageConfig MakeConfig(StorageType type, boost::filesystem::path storage_dir) {
+  StorageConfig config;
+
+  config.type = type;
+  if (type == kFileSystem) {
+    config.path = storage_dir;
+    config.uptane_metadata_path = "metadata";
+    config.uptane_public_key_path = "test_primary.pub";
+    config.uptane_private_key_path = "test_primary.priv";
+    config.tls_pkey_path = "test_tls.pkey";
+    config.tls_clientcert_path = "test_tls.cert";
+    config.tls_cacert_path = "test_tls.ca";
+  } else if (config.type == kSqlite) {
+    config.sqldb_path = storage_dir / "test.db";
+    config.schemas_path = "config/schemas";
+  } else {
+    std::cout << "Invalid config type: " << config.type << "\n";
+  }
+  return config;
+}
+
+struct TightProcess {
+  pid_t pid;
+  int pipefd[2];
+  TemporaryDirectory storage_dir;
+};
+
+static void tight_store_keys(const TightProcess& t) {
+  StorageConfig config = MakeConfig(storage_test_type, t.storage_dir.Path());
+  std::unique_ptr<INvStorage> storage = Storage(config);
+  unsigned int k = 0;
+  char c = 'r';
+
+  EXPECT_EQ(write(t.pipefd[1], &c, 1), 1);
+  while (true) {
+    storage->storePrimaryKeys(std::to_string(k), std::to_string(k));
+    k += 1;
+  }
+}
+
+static void check_consistent_state(boost::filesystem::path storage_dir) {
+  StorageConfig config = MakeConfig(storage_test_type, storage_dir);
+  std::unique_ptr<INvStorage> storage = Storage(config);
+  std::string pub, priv;
+
+  EXPECT_TRUE(storage->loadPrimaryKeys(&pub, &priv));
+
+  EXPECT_EQ(pub, priv);
+}
+
+void atomic_test() {
+  unsigned int n_procs = 70;
+  std::list<TightProcess> procs;
+
+  for (auto k = 0u; k < n_procs; k++) {
+    procs.emplace_back();
+    TightProcess& p = procs.back();
+
+    EXPECT_EQ(pipe(p.pipefd), 0);
+
+    pid_t pid = fork();
+    if (pid != 0) {
+      close(p.pipefd[1]);
+      p.pid = pid;
+
+    } else {
+      close(p.pipefd[0]);
+      tight_store_keys(p);
+      exit(0);
+    }
+  }
+
+  for (const auto& p : procs) {
+    // wait for readiness
+    char c;
+    EXPECT_EQ(read(p.pipefd[0], &c, 1), 1);
+    close(p.pipefd[0]);
+  }
+
+  std::mt19937_64 eng{12};
+  std::uniform_int_distribution<> dist{1, 30};
+  while (!procs.empty()) {
+    std::this_thread::sleep_for(std::chrono::milliseconds{dist(eng)});
+
+    TightProcess& p = procs.back();
+    kill(p.pid, SIGKILL);
+    waitpid(p.pid, NULL, 0);
+    check_consistent_state(p.storage_dir.Path());
+
+    procs.pop_back();
+  }
+}
+
+// does not work with fs storage
+TEST(DISABLED_storage_atomic, fs) {
+  storage_test_type = kFileSystem;
+  atomic_test();
+}
+
+TEST(storage_atomic, sql) {
+  storage_test_type = kSqlite;
+  atomic_test();
+}
+
+#ifndef __NO_MAIN__
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  logger_init();
+  logger_set_threshold(boost::log::trivial::trace);
+  return RUN_ALL_TESTS();
+}
+#endif


### PR DESCRIPTION
Try to avoid the unsafe pattern:

```
remove(file)
<-- bad things can happen here
write(file, newContent)
```

Both in SQL db and on the file system.

Note that problems can still occur if (for example) a public/private key pair is updated partially. This is difficult to solve on the file system but it could be desirable to have a safe `storePair()` in the SQL case and removing `storePublic()` and `storePrivate()`