### PR TITLE
Ensure that OstreeRepo is destroyed after use

### DIFF
--- a/src/ostree.h
+++ b/src/ostree.h
@@ -23,6 +23,7 @@ class OstreeManager : public PackageManagerInterface {
 
   boost::shared_ptr<OstreeDeployment> getStagedDeployment();
   static boost::shared_ptr<OstreeSysroot> LoadSysroot(const boost::filesystem::path &path);
+  static boost::shared_ptr<OstreeRepo> LoadRepo(boost::shared_ptr<OstreeSysroot> sysroot, GError **error);
   static bool addRemote(OstreeRepo *repo, const std::string &url, const KeyManager &keys);
   static data::InstallOutcome pull(const Config &config, const KeyManager &keys, const std::string &refhash);
 


### PR DESCRIPTION
Should fix the 'Couldn't load sysroot bug'. I really hope that no user was affected.

Basically there was a leak of OstreeRepo objects that caused the process to run out of file descriptors after 15-30 minutes. I'm not sure if we can test for that.

This particular error would be not so fatal if aktualizr (SotaUptaneClient to be precise) just crashed upon receiving an exception, but if it is always the best thing to do is questionable.