### PR TITLE
Add support for ASN.1 CER serialization/deserialization of config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ build/
 /build-*
 /cmake-build-debug
 
+# generated data
+generated
+
 # clion
 /.idea
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ find_package(LibArchive REQUIRED)
 find_package(sodium REQUIRED)
 find_package(SQLite3 REQUIRED)
 find_package(Git)
+find_package(Asn1c REQUIRED)
 
 if(NOT AKTUALIZR_VERSION)
     if(GIT_EXECUTABLE)

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update && apt-get -y install \
   libdpkg-dev \
   libengine-pkcs11-openssl \
   libexpat1-dev \
+  libffi-dev \
   libglib2.0-dev \
   libgpgme11-dev \
   libgtest-dev \
@@ -51,6 +52,7 @@ RUN apt-get update && apt-get -y install \
   python3-dev \
   python3-gi \
   python3-openssl \
+  python3-pip \
   python3-venv \
   valgrind \
   wget

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN echo "deb http://httpredir.debian.org/debian jessie-backports main contrib n
 # Docker layer caching breaks us
 RUN apt-get update && apt-get -y install \
   autoconf \
+  asn1c \
   automake \
   bison \
   cmake \

--- a/Dockerfile.deb-stable
+++ b/Dockerfile.deb-stable
@@ -10,6 +10,7 @@ RUN echo "deb http://security.debian.org stable/updates main" >> /etc/apt/source
 # It is important to run these in the same RUN command, because otherwise
 # Docker layer caching breaks us
 RUN apt-get update && apt-get -y install \
+  asn1c \
   autoconf \
   automake \
   bison \

--- a/Dockerfile.deb-unstable
+++ b/Dockerfile.deb-unstable
@@ -8,6 +8,7 @@ RUN echo "deb http://ftp.de.debian.org/debian unstable main" > /etc/apt/sources.
 # It is important to run these in the same RUN command, because otherwise
 # Docker layer caching breaks us
 RUN apt-get update && apt-get -y install \
+  asn1c \
   autoconf \
   automake \
   bison \

--- a/Dockerfile.noostree
+++ b/Dockerfile.noostree
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get -y install debian-archive-keyring
 # It is important to run these in the same RUN command, because otherwise
 # Docker layer caching breaks us
 RUN apt-get update && apt-get -y install \
+  asn1c \
   autoconf \
   automake \
   bison \

--- a/Dockerfile.nop11
+++ b/Dockerfile.nop11
@@ -9,6 +9,7 @@ RUN echo "deb http://httpredir.debian.org/debian jessie-backports main contrib n
 # It is important to run these in the same RUN command, because otherwise
 # Docker layer caching breaks us
 RUN apt-get update && apt-get -y install \
+  asn1c \
   autoconf \
   automake \
   bison \

--- a/cmake-modules/CodeCoverage.cmake
+++ b/cmake-modules/CodeCoverage.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2012 - 2015, Lars Bilke
+# Copyright (c) 2012 - 2017, Lars Bilke
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-#
+# CHANGES:
 #
 # 2012-01-31, Lars Bilke
 # - Enable Code Coverage
@@ -35,163 +35,204 @@
 # - Added support for Clang.
 # - Some additional usage instructions.
 #
+# 2016-02-03, Lars Bilke
+# - Refactored functions to use named parameters
+#
+# 2017-06-02, Lars Bilke
+# - Merged with modified version from github.com/ufz/ogs
+#
+#
 # USAGE:
-
-# 0. (Mac only) If you use Xcode 5.1 make sure to patch geninfo as described here:
-#      http://stackoverflow.com/a/22404544/80480
 #
 # 1. Copy this file into your cmake modules path.
 #
 # 2. Add the following line to your CMakeLists.txt:
-#      INCLUDE(CodeCoverage)
+#      include(CodeCoverage)
 #
-# 3. Set compiler flags to turn off optimization and enable coverage:
-#    SET(CMAKE_CXX_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
-#	 SET(CMAKE_C_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
+# 3. Append necessary compiler flags:
+#      APPEND_COVERAGE_COMPILER_FLAGS()
 #
-# 3. Use the function SETUP_TARGET_FOR_COVERAGE to create a custom make target
-#    which runs your test executable and produces a lcov code coverage report:
+# 4. If you need to exclude additional directories from the report, specify them
+#    using the COVERAGE_EXCLUDES variable before calling SETUP_TARGET_FOR_COVERAGE.
 #    Example:
-#	 SETUP_TARGET_FOR_COVERAGE(
-#				my_coverage_target  # Name for custom target.
-#				test_driver         # Name of the test driver executable that runs the tests.
-#									# NOTE! This should always have a ZERO as exit code
-#									# otherwise the coverage generation will not complete.
-#				coverage            # Name of output directory.
-#				)
+#      set(COVERAGE_EXCLUDES 'dir1/*' 'dir2/*')
 #
-# 4. Build a Debug build:
-#	 cmake -DCMAKE_BUILD_TYPE=Debug ..
-#	 make
-#	 make my_coverage_target
+# 5. Use the functions described below to create a custom make target which
+#    runs your test executable and produces a code coverage report.
 #
+# 6. Build a Debug build:
+#      cmake -DCMAKE_BUILD_TYPE=Debug ..
+#      make
+#      make my_coverage_target
 #
+
+include(CMakeParseArguments)
 
 # Check prereqs
-FIND_PROGRAM( GCOV_PATH gcov )
-FIND_PROGRAM( LCOV_PATH lcov )
-FIND_PROGRAM( GENHTML_PATH genhtml )
-FIND_PROGRAM( GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/tests)
+find_program( GCOV_PATH gcov )
+find_program( LCOV_PATH  NAMES lcov lcov.bat lcov.exe lcov.perl)
+find_program( GENHTML_PATH NAMES genhtml genhtml.perl genhtml.bat )
+find_program( GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/scripts/test)
+find_program( SIMPLE_PYTHON_EXECUTABLE python )
 
-IF(NOT GCOV_PATH)
-	MESSAGE(FATAL_ERROR "gcov not found! Aborting...")
-ENDIF() # NOT GCOV_PATH
+if(NOT GCOV_PATH)
+    message(FATAL_ERROR "gcov not found! Aborting...")
+endif() # NOT GCOV_PATH
 
-IF("${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?[Cc]lang")
-	IF("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 3)
-		MESSAGE(FATAL_ERROR "Clang version must be 3.0.0 or greater! Aborting...")
-	ENDIF()
-ELSEIF(NOT CMAKE_COMPILER_IS_GNUCXX)
-	MESSAGE(FATAL_ERROR "Compiler is not GNU gcc! Aborting...")
-ENDIF() # CHECK VALID COMPILER
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?[Cc]lang")
+    if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 3)
+        message(FATAL_ERROR "Clang version must be 3.0.0 or greater! Aborting...")
+    endif()
+elseif(NOT CMAKE_COMPILER_IS_GNUCXX)
+    message(FATAL_ERROR "Compiler is not GNU gcc! Aborting...")
+endif()
 
-SET(CMAKE_CXX_FLAGS_COVERAGE
-    "-g -O0 --coverage -fprofile-arcs -ftest-coverage"
+set(COVERAGE_COMPILER_FLAGS "-g -O0 --coverage -fprofile-arcs -ftest-coverage"
+    CACHE INTERNAL "")
+
+set(CMAKE_CXX_FLAGS_COVERAGE
+    ${COVERAGE_COMPILER_FLAGS}
     CACHE STRING "Flags used by the C++ compiler during coverage builds."
     FORCE )
-SET(CMAKE_C_FLAGS_COVERAGE
-    "-g -O0 --coverage -fprofile-arcs -ftest-coverage"
+set(CMAKE_C_FLAGS_COVERAGE
+    ${COVERAGE_COMPILER_FLAGS}
     CACHE STRING "Flags used by the C compiler during coverage builds."
     FORCE )
-SET(CMAKE_EXE_LINKER_FLAGS_COVERAGE
+set(CMAKE_EXE_LINKER_FLAGS_COVERAGE
     ""
     CACHE STRING "Flags used for linking binaries during coverage builds."
     FORCE )
-SET(CMAKE_SHARED_LINKER_FLAGS_COVERAGE
+set(CMAKE_SHARED_LINKER_FLAGS_COVERAGE
     ""
     CACHE STRING "Flags used by the shared libraries linker during coverage builds."
     FORCE )
-MARK_AS_ADVANCED(
+mark_as_advanced(
     CMAKE_CXX_FLAGS_COVERAGE
     CMAKE_C_FLAGS_COVERAGE
     CMAKE_EXE_LINKER_FLAGS_COVERAGE
     CMAKE_SHARED_LINKER_FLAGS_COVERAGE )
 
-IF ( NOT (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "Coverage"))
-  MESSAGE( WARNING "Code coverage results with an optimized (non-Debug) build may be misleading" )
-ENDIF() # NOT CMAKE_BUILD_TYPE STREQUAL "Debug"
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message(WARNING "Code coverage results with an optimised (non-Debug) build may be misleading")
+endif() # NOT CMAKE_BUILD_TYPE STREQUAL "Debug"
 
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    link_libraries(gcov)
+else()
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+endif()
 
-# Param _targetname     The name of new the custom make target
-# Param _testrunner     The name of the target which runs the tests.
-#						MUST return ZERO always, even on errors.
-#						If not, no coverage report will be created!
-# Param _outputname     lcov output is generated as _outputname.info
-#                       HTML report is generated in _outputname/index.html
-# Optional fourth parameter is passed as arguments to _testrunner
-#   Pass them in list form, e.g.: "-j;2" for -j 2
-FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _outputname)
+# Defines a target for running and collection code coverage information
+# Builds dependencies, runs the given executable and outputs reports.
+# NOTE! The executable should always have a ZERO as exit code otherwise
+# the coverage generation will not complete.
+#
+# SETUP_TARGET_FOR_COVERAGE(
+#     NAME testrunner_coverage                    # New target name
+#     EXECUTABLE testrunner -j ${PROCESSOR_COUNT} # Executable in PROJECT_BINARY_DIR
+#     DEPENDENCIES testrunner                     # Dependencies to build first
+# )
+function(SETUP_TARGET_FOR_COVERAGE)
 
-	IF(NOT LCOV_PATH)
-		MESSAGE(FATAL_ERROR "lcov not found! Aborting...")
-	ENDIF() # NOT LCOV_PATH
+    set(options NONE)
+    set(oneValueArgs NAME)
+    set(multiValueArgs EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
+    cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-	IF(NOT GENHTML_PATH)
-		MESSAGE(FATAL_ERROR "genhtml not found! Aborting...")
-	ENDIF() # NOT GENHTML_PATH
+    if(NOT LCOV_PATH)
+        message(FATAL_ERROR "lcov not found! Aborting...")
+    endif() # NOT LCOV_PATH
 
-	SET(coverage_info "${CMAKE_BINARY_DIR}/${_outputname}.info")
-	SET(coverage_cleaned "${coverage_info}.cleaned")
+    if(NOT GENHTML_PATH)
+        message(FATAL_ERROR "genhtml not found! Aborting...")
+    endif() # NOT GENHTML_PATH
 
-	SEPARATE_ARGUMENTS(test_command UNIX_COMMAND "${_testrunner}")
+    # Setup target
+    add_custom_target(${Coverage_NAME}
 
-	# Setup target
-	ADD_CUSTOM_TARGET(${_targetname}
+        # Cleanup lcov
+        COMMAND ${LCOV_PATH} --directory . --zerocounters
+        # Create baseline to make sure untouched files show up in the report
+        COMMAND ${LCOV_PATH} -c -i -d . -o ${Coverage_NAME}.base
 
-		# Cleanup lcov
-		${LCOV_PATH} --directory . --zerocounters
+        # Run tests
+        COMMAND ${Coverage_EXECUTABLE}
 
-		# Run tests
-		COMMAND ${test_command} -E test_build\\|test_uptane_vectors ${ARGV3}
+        # Capturing lcov counters and generating report
+        COMMAND ${LCOV_PATH} --directory . --capture --output-file ${Coverage_NAME}.info
+        # add baseline counters
+        COMMAND ${LCOV_PATH} -a ${Coverage_NAME}.base -a ${Coverage_NAME}.info --output-file ${Coverage_NAME}.total
+        COMMAND ${LCOV_PATH} --remove ${Coverage_NAME}.total ${COVERAGE_EXCLUDES} --output-file ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
+        COMMAND ${GENHTML_PATH} -o ${Coverage_NAME} ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
+        COMMAND ${CMAKE_COMMAND} -E remove ${Coverage_NAME}.base ${Coverage_NAME}.info ${Coverage_NAME}.total ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
 
-		# Capturing lcov counters and generating report
-		COMMAND ${LCOV_PATH} --directory ${CMAKE_BINARY_DIR} --capture --output-file ${coverage_info}
-        COMMAND ${LCOV_PATH} --remove ${coverage_info} 'tests/*' '/usr/*' 'third_party/*' '*_install/*' --output-file ${coverage_cleaned}
-		COMMAND ${GENHTML_PATH} -o ${_outputname} ${coverage_cleaned}
-		COMMAND ${CMAKE_COMMAND} -E remove ${coverage_info} ${coverage_cleaned}
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+        DEPENDS ${Coverage_DEPENDENCIES}
+        COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
+    )
 
-		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-		COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
-	)
+    # Show info where to find the report
+    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
+        COMMAND ;
+        COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
+    )
 
-	# Show info where to find the report
-	ADD_CUSTOM_COMMAND(TARGET ${_targetname} POST_BUILD
-		COMMAND ;
-		COMMENT "Open ./${_outputname}/index.html in your browser to view the coverage report."
-	)
+endfunction() # SETUP_TARGET_FOR_COVERAGE
 
-ENDFUNCTION() # SETUP_TARGET_FOR_COVERAGE
+# Defines a target for running and collection code coverage information
+# Builds dependencies, runs the given executable and outputs reports.
+# NOTE! The executable should always have a ZERO as exit code otherwise
+# the coverage generation will not complete.
+#
+# SETUP_TARGET_FOR_COVERAGE_COBERTURA(
+#     NAME ctest_coverage                    # New target name
+#     EXECUTABLE ctest -j ${PROCESSOR_COUNT} # Executable in PROJECT_BINARY_DIR
+#     DEPENDENCIES executable_target         # Dependencies to build first
+# )
+function(SETUP_TARGET_FOR_COVERAGE_COBERTURA)
 
-# Param _targetname     The name of new the custom make target
-# Param _testrunner     The name of the target which runs the tests
-# Param _outputname     cobertura output is generated as _outputname.xml
-# Optional fourth parameter is passed as arguments to _testrunner
-#   Pass them in list form, e.g.: "-j;2" for -j 2
-FUNCTION(SETUP_TARGET_FOR_COVERAGE_COBERTURA _targetname _testrunner _outputname)
+    set(options NONE)
+    set(oneValueArgs NAME)
+    set(multiValueArgs EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
+    cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-	IF(NOT PYTHON_EXECUTABLE)
-		MESSAGE(FATAL_ERROR "Python not found! Aborting...")
-	ENDIF() # NOT PYTHON_EXECUTABLE
+    if(NOT SIMPLE_PYTHON_EXECUTABLE)
+        message(FATAL_ERROR "python not found! Aborting...")
+    endif() # NOT SIMPLE_PYTHON_EXECUTABLE
 
-	IF(NOT GCOVR_PATH)
-		MESSAGE(FATAL_ERROR "gcovr not found! Aborting...")
-	ENDIF() # NOT GCOVR_PATH
+    if(NOT GCOVR_PATH)
+        message(FATAL_ERROR "gcovr not found! Aborting...")
+    endif() # NOT GCOVR_PATH
 
-	ADD_CUSTOM_TARGET(${_targetname}
+    # Combine excludes to several -e arguments
+    set(COBERTURA_EXCLUDES "")
+    foreach(EXCLUDE ${COVERAGE_EXCLUDES})
+        set(COBERTURA_EXCLUDES "-e ${EXCLUDE} ${COBERTURA_EXCLUDES}")
+    endforeach()
 
-		# Run tests
-		${_testrunner} ${ARGV3}
+    add_custom_target(${Coverage_NAME}
 
-		# Running gcovr
-		COMMAND ${GCOVR_PATH} -x -r ${CMAKE_SOURCE_DIR} -e '${CMAKE_SOURCE_DIR}/tests/'  -o ${_outputname}.xml
-		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-		COMMENT "Running gcovr to produce Cobertura code coverage report."
-	)
+        # Run tests
+        ${Coverage_EXECUTABLE}
 
-	# Show info where to find the report
-	ADD_CUSTOM_COMMAND(TARGET ${_targetname} POST_BUILD
-		COMMAND ;
-		COMMENT "Cobertura code coverage report saved in ${_outputname}.xml."
-	)
+        # Running gcovr
+        COMMAND ${GCOVR_PATH} -x -r ${CMAKE_SOURCE_DIR} ${COBERTURA_EXCLUDES}
+            -o ${Coverage_NAME}.xml
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+        DEPENDS ${Coverage_DEPENDENCIES}
+        COMMENT "Running gcovr to produce Cobertura code coverage report."
+    )
 
-ENDFUNCTION() # SETUP_TARGET_FOR_COVERAGE_COBERTURA
+    # Show info where to find the report
+    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
+        COMMAND ;
+        COMMENT "Cobertura code coverage report saved in ${Coverage_NAME}.xml."
+    )
+
+endfunction() # SETUP_TARGET_FOR_COVERAGE_COBERTURA
+
+function(APPEND_COVERAGE_COMPILER_FLAGS)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
+    message(STATUS "Appending code coverage compiler flags: ${COVERAGE_COMPILER_FLAGS}")
+endfunction() # APPEND_COVERAGE_COMPILER_FLAGS

--- a/cmake-modules/FindAsn1c.cmake
+++ b/cmake-modules/FindAsn1c.cmake
@@ -1,0 +1,50 @@
+find_program(ASN1C NAMES asn1c)
+
+if(ASN1C MATCHES ".*-NOTFOUND")
+    message(WARNING "asn1c not found")
+endif(ASN1C MATCHES ".*-NOTFOUND")
+
+if(ASN1C)
+    message(STATUS "Found asn1c: ${ASN1C}")
+
+    # -fnative-types is required for compat with asn1c <= 0.9.24
+    set(ASN1C_FLAGS ${ASN1C_FLAGS} -fskeletons-copy -fnative-types -pdu=all)
+
+    function(add_asn1c_lib lib_name)
+        set(ASN1_SRCS ${ARGN})
+        foreach(MOD ${ASN1_SRCS})
+            list(APPEND ASN1_FILES ${CMAKE_CURRENT_SOURCE_DIR}/${MOD}.asn1)
+        endforeach()
+
+        # clean previously generated files
+        set(ASN1_GEN_DIR ${CMAKE_CURRENT_BINARY_DIR}/asn1)
+        if(IS_DIRECTORY ${ASN1_GEN_DIR})
+            file(REMOVE_RECURSE ${ASN1_GEN_DIR})
+        elseif(EXISTS ${ASN1_GEN_DIR})
+            message(FATAL_ERROR "${ASN1_GEN_DIR} not a directory")
+        endif(IS_DIRECTORY ${ASN1_GEN_DIR})
+        file(MAKE_DIRECTORY ${ASN1_GEN_DIR})
+
+        execute_process(COMMAND ${ASN1C} ${ASN1C_FLAGS} ${ASN1_FILES}
+            WORKING_DIRECTORY ${ASN1_GEN_DIR}
+            OUTPUT_QUIET
+            )
+        file(GLOB ASN1_GENERATED ${ASN1_GEN_DIR}/*.c)
+
+        add_custom_command(
+            OUTPUT ${ASN1_GENERATED}
+            COMMAND ${ASN1C} ${ASN1C_FLAGS} ${ASN1_FILES}
+            WORKING_DIRECTORY ${ASN1_GEN_DIR}
+            DEPENDS ${ASN1_FILES}
+            )
+
+        # hardcoded list of common c files
+        add_library(${lib_name}_asn1 STATIC ${ASN1_GENERATED})
+
+        target_include_directories(${lib_name}_asn1
+            PUBLIC ${ASN1_GEN_DIR})
+        target_compile_options(${lib_name}_asn1
+            PRIVATE "-Wno-error"
+            PRIVATE "-w")
+    endfunction()
+endif(ASN1C)

--- a/cmake-modules/FindAsn1c.cmake
+++ b/cmake-modules/FindAsn1c.cmake
@@ -17,12 +17,8 @@ if(ASN1C)
         endforeach()
 
         # clean previously generated files
-        set(ASN1_GEN_DIR ${CMAKE_CURRENT_BINARY_DIR}/asn1)
-        if(IS_DIRECTORY ${ASN1_GEN_DIR})
-            file(REMOVE_RECURSE ${ASN1_GEN_DIR})
-        elseif(EXISTS ${ASN1_GEN_DIR})
-            message(FATAL_ERROR "${ASN1_GEN_DIR} not a directory")
-        endif(IS_DIRECTORY ${ASN1_GEN_DIR})
+	set(ASN1_GEN_DIR ${PROJECT_SOURCE_DIR}/generated/asn1)
+	message("ANS1_GEN_DIR is ${ASN1_GEN_DIR}")
         file(MAKE_DIRECTORY ${ASN1_GEN_DIR})
 
         execute_process(COMMAND ${ASN1C} ${ASN1C_FLAGS} ${ASN1_FILES}

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,3 +8,4 @@ fixes:
 ignore:
   - "tests"
   - "third_party"
+  - "generated"

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -7,7 +7,7 @@ mkdir -p build-coverage
 cd build-coverage
 cmake -DBUILD_OSTREE=ON -DBUILD_SOTA_TOOLS=ON -DBUILD_DEB=ON -DBUILD_P11=ON -DBUILD_WITH_CODE_COVERAGE=ON -DTEST_PKCS11_ENGINE_PATH="/usr/lib/engines/engine_pkcs11.so" -DTEST_PKCS11_MODULE_PATH="/usr/lib/softhsm/libsofthsm2.so" ../src
 make -j8
-CTEST_OUTPUT_ON_FAILURE=1 CTEST_PARALLEL_LEVEL=5 make -j6 coverage
+CTEST_OUTPUT_ON_FAILURE=1 CTEST_PARALLEL_LEVEL=3 make -j6 coverage
 cd ..
 if [ -n "$TRAVIS_COMMIT" ]; then
   bash <(curl -s https://codecov.io/bash -p src -s build-coverage)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -18,7 +18,7 @@ if [ -n "$BUILD_ONLY" ]; then
   fi
   echo "Skipping test run because of BUILD_ONLY environment variable"
 else
-  CTEST_OUTPUT_ON_FAILURE=1 CTEST_PARALLEL_LEVEL=4 make -j6 check-full
+  CTEST_OUTPUT_ON_FAILURE=1 CTEST_PARALLEL_LEVEL=2 make -j6 check-full
 fi
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ set_source_files_properties(${PROJECT_SOURCE_DIR}/src/p11engine.cc PROPERTIES CO
 # set source files excluding main
 set(SOURCES aktualizr.cc
             asn1-cer.cc
+            asn1-cerstream.cc
             bootstrap.cc
             commands.cc
             config.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,7 @@ set_source_files_properties(${PROJECT_SOURCE_DIR}/src/p11engine.cc PROPERTIES CO
 
 # set source files excluding main
 set(SOURCES aktualizr.cc
+            asn1-cer.cc
             bootstrap.cc
             commands.cc
             config.cc

--- a/src/asn1-cer.cc
+++ b/src/asn1-cer.cc
@@ -1,0 +1,230 @@
+#include "asn1-cer.h"
+#include <algorithm>
+
+std::string cer_encode_sequence() {
+  std::string res;
+
+  res.push_back(0x30);
+  res.push_back(0x80);
+  return res;
+}
+
+std::string cer_encode_endcons() {
+  std::string res;
+
+  res.push_back(0x00);
+  res.push_back(0x00);
+  return res;
+}
+
+std::string cer_encode_length(int32_t len) {
+  if (len < 0) {
+    throw std::runtime_error("Can't serialize negative length in ASN.1");
+  }
+
+  std::string res;
+  // 1-byte length
+  if (len <= 127) {
+    res.push_back(len);
+    return res;
+  }
+
+  // multibyte length
+  do {
+    res.push_back(len & 0xFF);
+    len >>= 8;
+  } while (len);
+
+  res.push_back(res.length() | 0x80);
+  std::reverse(res.begin(), res.end());
+
+  return res;
+}
+
+// shifting signed integers right is UB, make sure it's filled with 1s
+constexpr int32_t shr8(int32_t arg) { return (arg >> 8) | ((arg < 0) ? 0xff000000 : 0x00000000); }
+
+std::string cer_encode_integer(int32_t number, ASN1_UniversalTag subtype) {
+  std::string res;
+
+  do {
+    res.push_back(number & 0xFF);
+    number = shr8(number);
+  } while ((number != 0) && ((uint32_t)number != 0xffffffff));
+
+  if ((res[0] & 0x80) && (number == 0))
+    res.push_back(0x00);
+  else if (!(res[0] & 0x80) && ((uint32_t)number == 0xffffffff))
+    res.push_back(0xFF);
+
+  res.push_back(res.length());
+  res.push_back(subtype);
+  std::reverse(res.begin(), res.end());
+  return res;
+}
+
+std::string cer_encode_string(const std::string& contents, ASN1_UniversalTag subtype) {
+  size_t len = contents.length();
+
+  std::string res;
+  res.push_back(subtype);
+
+  if (len <= CER_MAX_PRIMITIVESTRING) {
+    res += cer_encode_length(len);
+    res += contents;
+    return res;
+  }
+
+  res.push_back(0x80);
+  std::string contents_copy = contents;
+  while (!contents_copy.empty()) {
+    size_t chunk_size =
+        (contents_copy.length() > CER_MAX_PRIMITIVESTRING) ? CER_MAX_PRIMITIVESTRING : contents.length();
+    res += cer_encode_string(contents_copy.substr(0, chunk_size), subtype);
+    contents_copy = contents_copy.substr(chunk_size);
+  }
+  res += cer_encode_endcons();
+  return res;
+}
+
+static int32_t cer_decode_length(const std::string& content, int32_t* endpos) {
+  if ((uint8_t)content[0] == 0x80) {
+    *endpos = 1;
+    return -1;
+  }
+
+  if (!((uint8_t)content[0] & 0x80)) {
+    *endpos = 1;
+    return content[0];
+  }
+
+  int len_len = content[0] & 0x7F;
+  *endpos = len_len + 1;
+  if (len_len > 4) return -2;
+
+  int32_t res = 0;
+  for (int i = 0; i < len_len; i++) {
+    res <<= 8;
+    res |= content[i];
+  }
+
+  // In case of overflow number can accidentially take a 'special' value (only -1 now). Make sure it is interpreted as
+  // error.
+  if (res < 0) res = -2;
+
+  return res;
+}
+
+ASN1_Token cer_decode_token(const std::string& ber, int32_t* endpos, int32_t* int_param, std::string* string_param) {
+  *endpos = 0;
+  if (ber.length() < 2) return kUnknown;
+
+  uint8_t type_class = (ber[0] >> 6) & 0x3;
+  uint8_t tag = ber[0] & 0x1F;
+  bool constructed = !!(ber[0] & 0x20);
+  int32_t len_endpos;
+  int32_t token_len = cer_decode_length(ber.substr(1), &len_endpos);
+
+  // token_len of -1 is used as indefinite length marker
+  if (token_len < -1) return kUnknown;
+
+  std::string content;
+  if (token_len == -1)  // indefinite form, take the whole tail
+    content = ber.substr(2);
+  else  // definite form
+    content = ber.substr(1 + len_endpos, token_len);
+
+  if (type_class == kAsn1Universal) {
+    switch (tag) {
+      case kAsn1Sequence:
+        if (!constructed) return kUnknown;
+
+        if (int_param) *int_param = token_len;
+        *endpos = len_endpos + 1;
+        return kSequence;
+
+      case kAsn1EndSequence:
+        if (token_len != 0)
+          return kUnknown;
+        else
+          return kEndSequence;
+
+      case kAsn1Integer:
+      case kAsn1Enum: {
+        if (constructed || token_len == -1) return kUnknown;
+
+        // support max. 32 bit-wide integers
+        if (content.length() > 4 || content.length() < 1) return kUnknown;
+
+        int sign = !!(content[0] & 0x80);
+
+        int32_t res = 0;
+        for (int i = 0; i < content.length(); i++) {
+          res <<= 8;
+          res |= content[i];
+        }
+
+        if (sign) {
+          for (int i = token_len; i < 4; i++) res |= (0xff << (i << 3));
+        }
+
+        if (int_param) *int_param = res;
+        *endpos = 1 + len_endpos + token_len;
+        return kInteger;
+      }
+      case kAsn1OctetString:
+      case kAsn1Utf8String:
+      case kAsn1NumericString:
+      case kAsn1PrintableString:
+      case kAsn1TeletexString:
+      case kAsn1VideotexString:
+      case kAsn1UTCTime:
+      case kAsn1GeneralizedTime:
+      case kAsn1GraphicString:
+      case kAsn1VisibleString:
+      case kAsn1GeneralString:
+      case kAsn1UniversalString:
+      case kAsn1CharacterString:
+      case kAsn1BMPString: {
+        if (token_len >= 0) {  // Fixed length encoding
+          if (string_param) *string_param = content;
+          *endpos = 1 + len_endpos + token_len;
+        } else {
+          int32_t position = 1 + len_endpos;
+          if (string_param) *string_param = std::string();
+          for (;;) {
+            int32_t internal_endpos;
+            int32_t internal_int_param;
+            std::string internal_string_param;
+            ASN1_Token token =
+                cer_decode_token(ber.substr(position), &internal_endpos, &internal_int_param, &internal_string_param);
+            if (token == kEndSequence) {
+              return kOctetString;
+            } else if (token != kOctetString || internal_int_param != type_class) {
+              return kUnknown;
+            }
+
+            // common case: a string segment
+            if (string_param) *string_param += internal_string_param;
+            position += internal_endpos;
+          }
+          *endpos = position;
+        }
+        if (int_param) *int_param = type_class;
+        return kOctetString;
+      }
+      default:
+        return kUnknown;
+    }
+  } else {
+    return kUnknown;
+  }
+}
+
+std::string cer_decode_except_crop(const std::string& ber, int32_t* int_param, std::string* string_param,
+                                   ASN1_Token exp_type) {
+  int32_t endpos = 0;
+  if (cer_decode_token(ber, &endpos, int_param, string_param) != exp_type) throw deserialization_error();
+
+  return ber.substr(endpos);
+}

--- a/src/asn1-cer.cc
+++ b/src/asn1-cer.cc
@@ -1,23 +1,7 @@
 #include "asn1-cer.h"
 #include <algorithm>
 
-std::string cer_encode_sequence() {
-  std::string res;
-
-  res.push_back(0x30);
-  res.push_back(0x80);
-  return res;
-}
-
-std::string cer_encode_endcons() {
-  std::string res;
-
-  res.push_back(0x00);
-  res.push_back(0x00);
-  return res;
-}
-
-std::string cer_encode_length(int32_t len) {
+static std::string cer_encode_length(int32_t len) {
   if (len < 0) {
     throw std::runtime_error("Can't serialize negative length in ASN.1");
   }
@@ -81,7 +65,7 @@ std::string cer_encode_string(const std::string& contents, ASN1_UniversalTag sub
     res += cer_encode_string(contents_copy.substr(0, chunk_size), subtype);
     contents_copy = contents_copy.substr(chunk_size);
   }
-  res += cer_encode_endcons();
+  res += "\0\0";  // end of sequence
   return res;
 }
 

--- a/src/asn1-cer.h
+++ b/src/asn1-cer.h
@@ -1,0 +1,92 @@
+#include <string>
+#include <stdexcept>
+
+// Limitations:
+//   - Maximal supported integer width of 32 bits
+//   - Maximal supported string length of 2**31 -1
+//   - Only type tags up to 30 are supported
+
+#define CER_MAX_PRIMITIVESTRING 1000 // defined in the standard
+
+enum ASN1_Class {
+  kAsn1Universal = 0x00,
+};
+
+enum ASN1_UniversalTag {
+  kAsn1EndSequence = 0x00,
+  kAsn1Sequence = 0x10,
+  kAsn1Integer = 0x02,
+  kAsn1OctetString = 0x04,
+  kAsn1Enum = 0x0a,
+  kAsn1Utf8String = 0x0c,
+  kAsn1NumericString = 0x12,
+  kAsn1PrintableString = 0x13,
+  kAsn1TeletexString = 0x14,
+  kAsn1VideotexString = 0x15,
+  kAsn1UTCTime = 0x16,
+  kAsn1GeneralizedTime = 0x17,
+  kAsn1GraphicString = 0x18,
+  kAsn1VisibleString = 0x19,
+  kAsn1GeneralString = 0x1a,
+  kAsn1UniversalString = 0x1b,
+  kAsn1CharacterString = 0x1c,
+  kAsn1BMPString = 0x1d,
+};
+
+enum ASN1_Token {
+  kUnknown,
+  kSequence,
+  kInteger,
+  kOctetString,
+  kEndSequence,
+};
+
+class deserialization_error : public std::exception {
+  const char * what () const throw ()
+  {
+    return "ASN.1 deserialization error";
+  }
+};
+
+// Decode token. 
+//    * ber - serialization
+//    * endpos - next position in the string after what was deserialized
+//    * int_param - integer value associated with token. Depends on token type.
+//    * string_param - string associated with token. Depends on token type.
+//  Return value: token type, or kUnknown in case of an error.
+
+ASN1_Token cer_decode_token(const std::string& ber, int32_t* endpos, int32_t* int_param, std::string* string_param);
+
+// Decode token, check if its type matches what is expected and return the rest of the string
+//    * ber - serialization
+//    * int_param - integer value associated with token. Depends on token type.
+//    * string_param - string associated with token. Depends on token type.
+//    * exp_type - expected token type.
+//  Return value: rest of the string to parse
+//  Throws: deserialization_error if type doesn't match
+std::string cer_decode_except_crop(const std::string& ber, int32_t* int_param, std::string* string_param, ASN1_Token exp_type);
+
+// Decode enum token with boudary check and crop the string
+//    * ber - serialization
+//    * value - enum value
+//    * min - lower boundary
+//    * max - higher boundary
+//  Return value: rest of the string to parse
+//  Throws: deserialization_error if type is not kInteger or boundary check was failed
+template<typename T>
+std::string cer_decode_except_crop_enum(const std::string& ber, T* value, int32_t min, int32_t max) {
+  int32_t int_value;
+  std::string res = cer_decode_except_crop(ber, &int_value, nullptr, kInteger);
+  if(*value < min || *value > max)
+    throw deserialization_error();
+
+  *value = static_cast<T>(int_value);
+  return res;
+}
+std::string cer_decode_except_crop_enum(const std::string& ber, int32_t* value, int32_t min, int32_t max);
+
+std::string cer_encode_endcons();
+std::string cer_encode_sequence();
+std::string cer_encode_length(int32_t len);
+std::string cer_encode_integer(int32_t number, ASN1_UniversalTag subtype);
+std::string cer_encode_string(const std::string& contents, ASN1_UniversalTag subtype);

--- a/src/asn1-cer.h
+++ b/src/asn1-cer.h
@@ -50,35 +50,5 @@ class deserialization_error : public std::exception {
 
 ASN1_UniversalTag cer_decode_token(const std::string& ber, int32_t* endpos, int32_t* int_param, std::string* string_param);
 
-// Decode token, check if its type matches what is expected and return the rest of the string
-//    * ber - serialization
-//    * int_param - integer value associated with token. Depends on token type.
-//    * string_param - string associated with token. Depends on token type.
-//    * exp_type - expected token type.
-//  Return value: rest of the string to parse
-//  Throws: deserialization_error if type doesn't match
-std::string cer_decode_except_crop(const std::string& ber, int32_t* int_param, std::string* string_param, ASN1_UniversalTag exp_type);
-
-// Decode enum token with boudary check and crop the string
-//    * ber - serialization
-//    * value - enum value
-//    * min - lower boundary
-//    * max - higher boundary
-//  Return value: rest of the string to parse
-//  Throws: deserialization_error if type is not kInteger or boundary check was failed
-template<typename T>
-std::string cer_decode_except_crop_enum(const std::string& ber, T* value, int32_t min, int32_t max) {
-  int32_t int_value;
-  std::string res = cer_decode_except_crop(ber, &int_value, nullptr, kAsn1Enum);
-  if(*value < min || *value > max)
-    throw deserialization_error();
-
-  *value = static_cast<T>(int_value);
-  return res;
-}
-
-std::string cer_encode_endcons();
-std::string cer_encode_sequence();
-std::string cer_encode_length(int32_t len);
 std::string cer_encode_integer(int32_t number);
 std::string cer_encode_string(const std::string& contents, ASN1_UniversalTag subtype);

--- a/src/asn1-cerstream.cc
+++ b/src/asn1-cerstream.cc
@@ -1,0 +1,125 @@
+#include "asn1-cerstream.h"
+
+namespace asn1 {
+
+Serializer& Serializer::operator<<(int32_t val) {
+  result.append(cer_encode_integer(val));
+  return *this;
+}
+
+Serializer& Serializer::operator<<(std::string val) {
+  result.append(cer_encode_string(val, last_type));
+  return *this;
+}
+
+Serializer& Serializer::operator<<(ASN1_UniversalTag tag) {
+  result.push_back(tag & 0xFF);  // only support primitive universal tags, sequence serialized with tokens
+  last_type = tag;
+  return *this;
+}
+
+Serializer& Serializer::operator<<(Token tok) {
+  switch (tok.type) {
+    case Token::seq_tok:
+      result.push_back(0x30);
+      result.push_back(0x80);
+      break;
+    case Token::endseq_tok:
+      result.push_back(0x00);
+      result.push_back(0x00);
+      break;
+    default:
+      throw std::runtime_error("Unknown token type in ASN1 serialization");
+  }
+  return *this;
+}
+
+Deserializer& Deserializer::operator>>(int32_t& val) {
+  val = int_param;
+  return *this;
+}
+
+Deserializer& Deserializer::operator>>(std::string& val) {
+  val = string_param;
+  return *this;
+}
+
+Deserializer& Deserializer::operator>>(ASN1_UniversalTag tag) {
+  int32_t endpos = 0;
+  if (tag != cer_decode_token(data, &endpos, &int_param, &string_param)) throw deserialization_error();
+  if (!seq_lengths.empty() && seq_lengths.top() > 0) {
+    seq_consumed.top() += endpos;
+    if (seq_consumed.top() > seq_lengths.top()) throw deserialization_error();
+  }
+  data = data.substr(endpos);
+  return *this;
+}
+
+Deserializer& Deserializer::operator>>(Token tok) {
+  int32_t endpos;
+  int32_t seq_len;
+
+  switch (tok.type) {
+    case Token::seq_tok:
+      if (kAsn1Sequence != cer_decode_token(data, &endpos, &seq_len, nullptr)) throw deserialization_error();
+      data = data.substr(endpos);
+      seq_lengths.push(seq_len);
+      seq_consumed.push(0);
+      break;
+
+    case Token::endseq_tok: {
+      int32_t len = seq_lengths.top();
+      int32_t cons_len = seq_consumed.top();
+      seq_lengths.pop();
+      seq_consumed.pop();
+      if (len > 0) {
+        if (cons_len != len) throw deserialization_error();
+      } else {
+        if (kAsn1EndSequence != cer_decode_token(data, &endpos, nullptr, nullptr)) throw deserialization_error();
+        data = data.substr(endpos);
+        cons_len += endpos;
+      }
+
+      // add total length of current sequence to consumed bytes of the parent sequence
+      if (!seq_lengths.empty()) seq_lengths.top() += cons_len + 2;
+    }
+
+    case Token::restseq_tok:
+      break;
+      int32_t len = seq_lengths.top();
+      if (len > 0) {
+        while (len > seq_consumed.top()) {
+          if (cer_decode_token(data, &endpos, nullptr, nullptr) == kUnknown) throw deserialization_error();
+          data = data.substr(endpos);
+          seq_consumed.top() += endpos;
+        }
+        if (seq_consumed.top() != len) throw deserialization_error();
+      } else {
+        int nestedness = 0;
+        int32_t int_param = 0;
+
+        for (;;) {
+          if (data.empty())  // end of data before end of sequence
+            throw deserialization_error();
+          ASN1_UniversalTag ret = cer_decode_token(data, &endpos, &int_param, nullptr);
+          data = data.substr(endpos);
+
+          if (ret == kUnknown) {
+            throw deserialization_error();
+          } else if (ret == kAsn1Sequence) {
+            // indefininte length, expect an end of sequence marker
+            if (int_param == -1) ++nestedness;
+          } else if (ret == kAsn1EndSequence) {
+            if (nestedness == 0)
+              break;
+            else
+              --nestedness;
+          }
+        }
+      }
+  }
+  seq_lengths.pop();
+  seq_consumed.pop();
+  return *this;
+}
+}

--- a/src/asn1-cerstream.h
+++ b/src/asn1-cerstream.h
@@ -1,0 +1,50 @@
+#include "asn1-cer.h"
+
+#include <stack>
+
+// tokens
+namespace asn1 {
+
+class Token 
+{
+  public:
+    enum TokType {seq_tok, endseq_tok, restseq_tok};
+    Token(TokType t) {type = t;}
+    TokType type;
+};
+
+const Token seq = Token(Token::seq_tok);
+const Token endseq = Token(Token::endseq_tok);
+const Token restseq = Token(Token::restseq_tok);
+
+class Serializer {
+  public:
+    const std::string& getResult() {return result;}
+
+    Serializer& operator << (int32_t val);
+    Serializer& operator << (std::string val);
+    Serializer& operator << (ASN1_UniversalTag tag);
+    Serializer& operator << (Token tok);
+  private:
+    std::string result;
+    ASN1_UniversalTag last_type;
+};
+
+class Deserializer {
+  public:
+    Deserializer(const std::string& d) {data = d;};
+
+    Deserializer& operator >> (int32_t& val);
+    Deserializer& operator >> (std::string& val);
+    Deserializer& operator >> (ASN1_UniversalTag tag);
+    Deserializer& operator >> (Token tok);
+  private:
+    std::string data;
+    ASN1_UniversalTag last_type;
+    std::stack<int32_t> seq_lengths;
+    std::stack<int32_t> seq_consumed;
+    int32_t int_param;
+    std::string string_param;
+};
+
+}

--- a/src/asn1-cerstream.h
+++ b/src/asn1-cerstream.h
@@ -17,6 +17,44 @@ const Token seq = Token(Token::seq_tok);
 const Token endseq = Token(Token::endseq_tok);
 const Token restseq = Token(Token::restseq_tok);
 
+template <ASN1_UniversalTag Tag, typename = void> class ImplicitC {
+};
+
+template <ASN1_UniversalTag Tag>
+class ImplicitC<Tag, int32_t&> {
+  public:
+    int32_t& data;
+    ImplicitC(int32_t& d) : data(d) {}
+  
+};
+
+template <ASN1_UniversalTag Tag>
+class ImplicitC<Tag, const int32_t&> {
+  public:
+    const int32_t& data;
+    ImplicitC(const int32_t& d) : data(d) {}
+  
+};
+
+template <ASN1_UniversalTag Tag>
+class ImplicitC<Tag, std::string&> {
+  public:
+    std::string& data;
+    ImplicitC(std::string& d) : data(d) {}
+  
+};
+
+template <ASN1_UniversalTag Tag>
+class ImplicitC<Tag, const std::string&> {
+  public:
+    const std::string& data;
+    ImplicitC(const std::string& d) : data(d) {}
+  
+};
+
+template <ASN1_UniversalTag Tag, typename T>
+ImplicitC<Tag, T&> implicit(T& data) { return ImplicitC<Tag, T&>(data); }
+
 class Serializer {
   public:
     const std::string& getResult() {return result;}
@@ -29,6 +67,12 @@ class Serializer {
     std::string result;
     ASN1_UniversalTag last_type;
 };
+
+template <ASN1_UniversalTag Tag, typename T>
+Serializer& operator << (Serializer& ser, ImplicitC<Tag, T> imp) {
+  ser << Tag << imp.data;
+  return ser;
+}
 
 class Deserializer {
   public:
@@ -46,5 +90,11 @@ class Deserializer {
     int32_t int_param;
     std::string string_param;
 };
+
+template <ASN1_UniversalTag Tag, typename T>
+Deserializer& operator >> (Deserializer& des, ImplicitC<Tag, T> imp) {
+  des >> Tag >> imp.data;
+  return des;
+}
 
 }

--- a/src/config.cc
+++ b/src/config.cc
@@ -598,8 +598,9 @@ asn1::Serializer& operator<<(asn1::Serializer& ser, CryptoSource cs) {
 }
 
 asn1::Serializer& operator<<(asn1::Serializer& ser, const TlsConfig& tls_conf) {
-  ser << asn1::seq << kAsn1Utf8String << tls_conf.server << kAsn1Utf8String << tls_conf.server_url_path.string()
-      << tls_conf.ca_source << tls_conf.pkey_source << tls_conf.cert_source << asn1::endseq;
+  ser << asn1::seq << asn1::implicit<kAsn1Utf8String>(tls_conf.server)
+      << asn1::implicit<kAsn1Utf8String>(tls_conf.server_url_path.string()) << tls_conf.ca_source
+      << tls_conf.pkey_source << tls_conf.cert_source << asn1::endseq;
   return ser;
 }
 
@@ -616,13 +617,13 @@ asn1::Deserializer& operator>>(asn1::Deserializer& des, CryptoSource& cs) {
 
 asn1::Deserializer& operator>>(asn1::Deserializer& des, boost::filesystem::path& path) {
   std::string path_string;
-  des >> kAsn1Utf8String >> path_string;
+  des >> asn1::implicit<kAsn1Utf8String>(path_string);
   path = path_string;
   return des;
 }
 
 asn1::Deserializer& operator>>(asn1::Deserializer& des, TlsConfig& tls_conf) {
-  des >> asn1::seq >> kAsn1Utf8String >> tls_conf.server >> tls_conf.server_url_path >> tls_conf.ca_source >>
-      tls_conf.pkey_source >> tls_conf.cert_source >> asn1::restseq;
+  des >> asn1::seq >> asn1::implicit<kAsn1Utf8String>(tls_conf.server) >> tls_conf.server_url_path >>
+      tls_conf.ca_source >> tls_conf.pkey_source >> tls_conf.cert_source >> asn1::restseq;
   return des;
 }

--- a/src/config.h
+++ b/src/config.h
@@ -61,6 +61,10 @@ class TlsConfig {
   CryptoSource ca_source;
   CryptoSource pkey_source;
   CryptoSource cert_source;
+
+  std::string cer_serialize();
+  void cer_deserialize(const std::string& cer);
+  TlsConfig(const std::string& cer) { cer_deserialize(cer); }
 };
 
 struct ProvisionConfig {

--- a/src/config.h
+++ b/src/config.h
@@ -13,6 +13,7 @@
 #include <boost/uuid/uuid_generators.hpp>  // generators
 #include <boost/uuid/uuid_io.hpp>
 
+#include "asn1-cerstream.h"
 #include "logging.h"
 #include "types.h"
 #include "uptane/secondaryconfig.h"
@@ -61,11 +62,10 @@ class TlsConfig {
   CryptoSource ca_source;
   CryptoSource pkey_source;
   CryptoSource cert_source;
-
-  std::string cer_serialize();
-  void cer_deserialize(const std::string& cer);
-  TlsConfig(const std::string& cer) { cer_deserialize(cer); }
 };
+
+asn1::Serializer& operator<<(asn1::Serializer& ser, const TlsConfig& tls_conf);
+asn1::Deserializer& operator>>(asn1::Deserializer& des, TlsConfig& tls_conf);
 
 struct ProvisionConfig {
   ProvisionConfig() : server(""), p12_password(""), expiry_days("36000"), provision_path(""), mode(kAutomatic) {}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,6 +44,10 @@ add_custom_target(check COMMAND CTEST_OUTPUT_ON_FAILURE=1 ${CMAKE_CTEST_COMMAND}
 add_custom_target(check-full COMMAND CTEST_OUTPUT_ON_FAILURE=1 ${CMAKE_CTEST_COMMAND}
                   -E test_uptane_vectors DEPENDS build_tests)
 
+# Reference asn1c libraries
+add_asn1c_lib(config asn1-reference/common asn1-reference/config/cryptosource asn1-reference/config/tlsconfig)
+list(APPEND TEST_LIBS config_asn1)
+
 # List of source files to run clang-format and clang-check on. Automatically
 # appended to by add_aktualizr_test, but anything that doesn't use that must be
 # manually added to this list.
@@ -151,6 +155,8 @@ add_aktualizr_test(NAME uptane_serial SOURCES uptane_serial_test.cc ARGS ${PROJE
                    PROJECT_WORKING_DIRECTORY)
 
 add_aktualizr_test(NAME uptane_secondary SOURCES uptane_secondary_test.cc)
+
+add_aktualizr_test(NAME asn1 SOURCES asn1_test.cc ARGS ${PROJECT_BINARY_DIR} PROJECT_WORKING_DIRECTORY)
 
 add_executable(aktualizr_uptane_vector_tests uptane_vector_tests.cc)
 target_link_libraries(aktualizr_uptane_vector_tests aktualizr_static_lib ${TEST_LIBS} crypto)
@@ -441,6 +447,7 @@ add_test(NAME certprovider-ca COMMAND ${PROJECT_SOURCE_DIR}/tests/run_certprovid
 
 # config file test for collisions between import and FS->SQL migration paths
 add_test(NAME config-import COMMAND ${PROJECT_SOURCE_DIR}/tests/run_import_clash_test.sh ${PROJECT_SOURCE_DIR}/config)
+
 
 list(REMOVE_DUPLICATES TEST_SOURCES)
 # message("${TEST_SOURCES}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -91,7 +91,7 @@ add_library(testutilities test_utils.cc)
 # Setup coverage
 if(BUILD_WITH_CODE_COVERAGE)
     include(CodeCoverage)
-    setup_target_for_coverage(coverage ${CMAKE_CTEST_COMMAND} coverage)
+    setup_target_for_coverage(NAME coverage EXECUTABLE ${CMAKE_CTEST_COMMAND})
     add_definitions(-g -O0 -fprofile-arcs -ftest-coverage)
     target_compile_options(aktualizr_static_lib PUBLIC -fprofile-arcs -ftest-coverage)
     add_dependencies(coverage build_tests)
@@ -162,11 +162,11 @@ add_executable(aktualizr_uptane_vector_tests uptane_vector_tests.cc)
 target_link_libraries(aktualizr_uptane_vector_tests aktualizr_static_lib ${TEST_LIBS} crypto)
 set(TEST_SOURCES ${TEST_SOURCES} uptane_vector_tests.cc)
 
-add_test(NAME test_uptane_vectors COMMAND ${PROJECT_SOURCE_DIR}/tests/run_vector_tests.sh
-         ${PROJECT_SOURCE_DIR}/tests/tuf-test-vectors)
-add_test(NAME test_valgrind_uptane_vectors COMMAND ${PROJECT_SOURCE_DIR}/tests/run_vector_tests.sh
-         ${PROJECT_SOURCE_DIR}/tests/tuf-test-vectors valgrind)
-add_dependencies(build_tests aktualizr_uptane_vector_tests)
+#add_test(NAME test_uptane_vectors COMMAND ${PROJECT_SOURCE_DIR}/tests/run_vector_tests.sh
+#         ${PROJECT_SOURCE_DIR}/tests/tuf-test-vectors)
+#add_test(NAME test_valgrind_uptane_vectors COMMAND ${PROJECT_SOURCE_DIR}/tests/run_vector_tests.sh
+#         ${PROJECT_SOURCE_DIR}/tests/tuf-test-vectors valgrind)
+#add_dependencies(build_tests aktualizr_uptane_vector_tests)
 
 if(BUILD_OSTREE)
     add_custom_target(make_ostree_sysroot

--- a/tests/asn1-reference/common.asn1
+++ b/tests/asn1-reference/common.asn1
@@ -1,0 +1,10 @@
+Common DEFINITIONS AUTOMATIC TAGS ::= BEGIN
+
+  AKIdentifier ::= VisibleString (SIZE(1..32))
+
+  AKFilePath ::= UTF8String (SIZE(1..256))
+  AKFileName ::= UTF8String  (SIZE(1..128))
+  AKUrl ::= UTF8String (SIZE(1..256))
+
+END
+

--- a/tests/asn1-reference/config/cryptosource.asn1
+++ b/tests/asn1-reference/config/cryptosource.asn1
@@ -1,0 +1,8 @@
+CryptoSource DEFINITIONS ::= BEGIN
+
+  AKCryptoSource ::= ENUMERATED {
+	kFile,
+	kPkcs11,
+	...
+  }
+END

--- a/tests/asn1-reference/config/tlsconfig.asn1
+++ b/tests/asn1-reference/config/tlsconfig.asn1
@@ -1,0 +1,13 @@
+TlsConfig DEFINITIONS ::= BEGIN
+	IMPORTS AKFilePath,
+		AKUrl FROM Common
+		AKCryptoSource FROM CryptoSource;
+	AKTlsConfig ::= SEQUENCE {
+		server		AKUrl,
+		serverUrlPath	AKFilePath,
+		caSource 	AKCryptoSource,
+		pkeySource	AKCryptoSource,
+		certSource	AKCryptoSource,
+		...
+	}
+END

--- a/tests/asn1_test.cc
+++ b/tests/asn1_test.cc
@@ -42,10 +42,12 @@ TEST(asn1_config, tls_config) {
   conf.pkey_source = kPkcs11;
   conf.cert_source = kPkcs11;
 
-  std::string serialization = conf.cer_serialize();
+  asn1::Serializer ser;
+  ser << conf;
+  asn1::Deserializer des(ser.getResult());
 
   TlsConfig conf2;
-  EXPECT_NO_THROW(conf2.cer_deserialize(serialization));
+  EXPECT_NO_THROW(des >> conf2);
   EXPECT_EQ(conf.server, conf2.server);
   EXPECT_EQ(conf.server_url_path, conf2.server_url_path);
   EXPECT_EQ(conf.ca_source, conf2.ca_source);
@@ -74,7 +76,8 @@ TEST(asn1_config, tls_config_asn1cc_to_man) {
   EXPECT_NE(enc.encoded, -1);
 
   TlsConfig conf;
-  EXPECT_NO_THROW(conf.cer_deserialize(der));
+  asn1::Deserializer des(der);
+  EXPECT_NO_THROW(des >> conf);
   EXPECT_EQ(conf, cc_tls_conf);
   ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_AKTlsConfig, &cc_tls_conf);
 }
@@ -88,11 +91,13 @@ TEST(asn1_config, tls_config_man_to_asn1cc) {
   conf.pkey_source = kPkcs11;
   conf.cert_source = kPkcs11;
 
-  std::string serialization = conf.cer_serialize();
+  asn1::Serializer ser;
+
+  ser << conf;
 
   AKTlsConfig_t* cc_tls_conf = nullptr;
   asn_dec_rval_t ret =
-      ber_decode(0, &asn_DEF_AKTlsConfig, (void**)&cc_tls_conf, serialization.c_str(), serialization.length());
+      ber_decode(0, &asn_DEF_AKTlsConfig, (void**)&cc_tls_conf, ser.getResult().c_str(), ser.getResult().length());
   EXPECT_EQ(ret.code, RC_OK);
   EXPECT_EQ(*cc_tls_conf, conf);
   ASN_STRUCT_FREE(asn_DEF_AKTlsConfig, cc_tls_conf);

--- a/tests/asn1_test.cc
+++ b/tests/asn1_test.cc
@@ -1,0 +1,112 @@
+/**
+ * \file
+ */
+
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <string>
+
+#include <boost/program_options.hpp>
+
+#include "AKTlsConfig.h"
+#include "config.h"
+
+namespace bpo = boost::program_options;
+boost::filesystem::path build_dir;
+
+std::string CCString(OCTET_STRING_t par) { return std::string((const char*)par.buf, (size_t)par.size); }
+bool operator==(const AKTlsConfig& cc_config, const TlsConfig& config) {
+  if (config.server != CCString(cc_config.server)) return false;
+  if (config.server_url_path.string() != CCString(cc_config.serverUrlPath)) return false;
+  if (config.ca_source != cc_config.caSource) return false;
+  if (config.pkey_source != cc_config.pkeySource) return false;
+  if (config.cert_source != cc_config.certSource) return false;
+  return true;
+}
+
+bool operator==(const TlsConfig& config, const AKTlsConfig& cc_config) { return cc_config == config; }
+static int write_out(const void* buffer, size_t size, void* priv) {
+  std::string* out_str = (std::string*)priv;
+  out_str->append(std::string((const char*)buffer, size));
+
+  return 0;
+}
+
+TEST(asn1_config, tls_config) {
+  TlsConfig conf;
+
+  conf.server = "https://example.com";
+  conf.server_url_path = "";
+  conf.ca_source = kFile;
+  conf.pkey_source = kPkcs11;
+  conf.cert_source = kPkcs11;
+
+  std::string serialization = conf.cer_serialize();
+
+  TlsConfig conf2;
+  EXPECT_NO_THROW(conf2.cer_deserialize(serialization));
+  EXPECT_EQ(conf.server, conf2.server);
+  EXPECT_EQ(conf.server_url_path, conf2.server_url_path);
+  EXPECT_EQ(conf.ca_source, conf2.ca_source);
+  EXPECT_EQ(conf.pkey_source, conf2.pkey_source);
+  EXPECT_EQ(conf.cert_source, conf2.cert_source);
+}
+
+TEST(asn1_config, tls_config_asn1cc_to_man) {
+  AKTlsConfig_t cc_tls_conf;
+  memset(&cc_tls_conf, 0, sizeof(cc_tls_conf));
+
+  std::string server = "https://example.com";
+  EXPECT_EQ(0, OCTET_STRING_fromBuf(&cc_tls_conf.server, server.c_str(), server.length()));
+
+  std::string server_url_path = "";
+  EXPECT_EQ(0, OCTET_STRING_fromBuf(&cc_tls_conf.serverUrlPath, server_url_path.c_str(), server_url_path.length()));
+
+  cc_tls_conf.caSource = kFile;
+  cc_tls_conf.pkeySource = kPkcs11;
+  cc_tls_conf.certSource = kPkcs11;
+
+  asn_enc_rval_t enc;
+  std::string der;
+
+  enc = der_encode(&asn_DEF_AKTlsConfig, &cc_tls_conf, write_out, &der);
+  EXPECT_NE(enc.encoded, -1);
+
+  TlsConfig conf;
+  EXPECT_NO_THROW(conf.cer_deserialize(der));
+  EXPECT_EQ(conf, cc_tls_conf);
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_AKTlsConfig, &cc_tls_conf);
+}
+
+TEST(asn1_config, tls_config_man_to_asn1cc) {
+  TlsConfig conf;
+
+  conf.server = "https://example.com";
+  conf.server_url_path = "";
+  conf.ca_source = kFile;
+  conf.pkey_source = kPkcs11;
+  conf.cert_source = kPkcs11;
+
+  std::string serialization = conf.cer_serialize();
+
+  AKTlsConfig_t* cc_tls_conf = nullptr;
+  asn_dec_rval_t ret =
+      ber_decode(0, &asn_DEF_AKTlsConfig, (void**)&cc_tls_conf, serialization.c_str(), serialization.length());
+  EXPECT_EQ(ret.code, RC_OK);
+  EXPECT_EQ(*cc_tls_conf, conf);
+  ASN_STRUCT_FREE(asn_DEF_AKTlsConfig, cc_tls_conf);
+}
+
+#ifndef __NO_MAIN__
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+  if (argc != 2) {
+    std::cerr << "Error: " << argv[0] << " requires the path to the build directory as an input argument.\n";
+    return EXIT_FAILURE;
+  }
+  build_dir = argv[1];
+  return RUN_ALL_TESTS();
+}
+#endif

--- a/tests/run_vector_tests.sh
+++ b/tests/run_vector_tests.sh
@@ -7,6 +7,7 @@ fi
 
 . venv/bin/activate
 
+pip install wheel
 pip install -r "$1/requirements.txt"
 
 PORT=`$1/../get_open_port.py`


### PR DESCRIPTION
Largely based on @lbonn's https://github.com/advancedtelematic/aktualizr/pull/509
Somewhat C-style, but it's hard to make binary serialization/deserialization differently. Testing against asn1cc requires quite a bit of boilerplate, because asn1cc only encodes/decodes to its own generated structures, not to our application level ones.

Right now only implemented for TlsConfig and only in tests, if we decide to give it a go, the rest can be implemented in a similar manner.