### PR TITLE
Aktualizr secondary config

### DIFF
--- a/config/aktualizr_secondary/config.toml.example
+++ b/config/aktualizr_secondary/config.toml.example
@@ -1,0 +1,2 @@
+[network]
+port = 9030

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,6 +44,7 @@ set(HEADERS aktualizr.h
             eventsinterpreter.h
             exceptions.h
             fsstorage.h
+            gateway.h
             gatewaymanager.h
             httpclient.h
             httpinterface.h

--- a/src/aktualizr_secondary/CMakeLists.txt
+++ b/src/aktualizr_secondary/CMakeLists.txt
@@ -1,7 +1,15 @@
-set(AKTUALIZR_SECONDARY_SRC main.cc )
+set(AKTUALIZR_SECONDARY_SRC main.cc)
+
+set(AKTUALIZR_SECONDARY_LIB_SRC
+    aktualizr_secondary_config.cc
+    )
+
+add_library(aktualizr_secondary_static_lib STATIC ${AKTUALIZR_SECONDARY_LIB_SRC})
 
 add_executable(aktualizr-secondary ${AKTUALIZR_SECONDARY_SRC})
-target_link_libraries(aktualizr-secondary aktualizr_static_lib
+target_link_libraries(aktualizr-secondary
+  aktualizr_secondary_static_lib
+  aktualizr_static_lib
   ${Boost_LIBRARIES}
   ${OPENSSL_LIBRARIES}
   ${sodium_LIBRARY_RELEASE}
@@ -15,6 +23,10 @@ install(TARGETS aktualizr-secondary
         COMPONENT aktualizr
         RUNTIME DESTINATION bin)
 
-aktualizr_source_file_checks(${AKTUALIZR_SECONDARY_SRC})
+set(ALL_AKTUALIZR_SECONDARY_HEADERS
+    aktualizr_secondary_config.h
+    )
+
+aktualizr_source_file_checks(${AKTUALIZR_SECONDARY_SRC} ${AKTUALIZR_SECONDARY_LIB_SRC} ${ALL_AKTUALIZR_SECONDARY_HEADERS})
 
 # vim: set tabstop=4 shiftwidth=4 expandtab:

--- a/src/aktualizr_secondary/aktualizr_secondary_config.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_config.cc
@@ -1,0 +1,46 @@
+#include <sstream>
+
+#include "aktualizr_secondary_config.h"
+#include "config_utils.h"
+
+AktualizrSecondaryConfig::AktualizrSecondaryConfig(const boost::filesystem::path& filename,
+                                                   const boost::program_options::variables_map& cmd) {
+  updateFromToml(filename);
+  updateFromCommandLine(cmd);
+}
+
+AktualizrSecondaryConfig::AktualizrSecondaryConfig(const boost::filesystem::path& filename) {
+  updateFromToml(filename);
+}
+
+void AktualizrSecondaryConfig::updateFromCommandLine(const boost::program_options::variables_map& cmd) {
+  if (cmd.count("server-port") != 0) {
+    network.port = cmd["server-port"].as<int>();
+  }
+}
+
+void AktualizrSecondaryConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt) {
+  // Keep this order the same as in secondary_config.h and writeToFile().
+  CopyFromConfig(network.port, "network.port", boost::log::trivial::info, pt);
+}
+
+std::ostream& operator<<(std::ostream& os, const AktualizrSecondaryConfig& cfg) {
+  return os << "\tServer listening port: " << cfg.network.port << std::endl;
+}
+
+void AktualizrSecondaryConfig::updateFromToml(const boost::filesystem::path& filename) {
+  boost::property_tree::ptree pt;
+  boost::property_tree::ini_parser::read_ini(filename.string(), pt);
+  updateFromPropertyTree(pt);
+  LOG_TRACE << "config read from " << filename << " :\n" << (*this);
+}
+
+void AktualizrSecondaryConfig::writeToFile(const boost::filesystem::path& filename) {
+  // Keep this order the same as in secondary_config.h and updateFromPropertyTree().
+  std::ofstream sink(filename.c_str(), std::ofstream::out);
+  sink << std::boolalpha;
+
+  sink << "[network]\n";
+  writeOption(sink, network.port, "port");
+  sink << "\n";
+}

--- a/src/aktualizr_secondary/aktualizr_secondary_config.h
+++ b/src/aktualizr_secondary/aktualizr_secondary_config.h
@@ -1,0 +1,28 @@
+#ifndef AKTUALIZR_SECONDARY_CONFIG_H_
+#define AKTUALIZR_SECONDARY_CONFIG_H_
+
+#include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
+#include <boost/property_tree/ini_parser.hpp>
+
+struct AktualizrSecondaryNetConfig {
+  int port{9030};
+};
+
+class AktualizrSecondaryConfig {
+ public:
+  AktualizrSecondaryConfig() {}
+  AktualizrSecondaryConfig(const boost::filesystem::path& filename, const boost::program_options::variables_map& cmd);
+  AktualizrSecondaryConfig(const boost::filesystem::path& filename);
+
+  void writeToFile(const boost::filesystem::path& filename);
+
+  AktualizrSecondaryNetConfig network;
+
+ private:
+  void updateFromCommandLine(const boost::program_options::variables_map& cmd);
+  void updateFromPropertyTree(const boost::property_tree::ptree& pt);
+  void updateFromToml(const boost::filesystem::path& filename);
+};
+
+#endif  // AKTUALIZR_SECONDARY_CONFIG_H_

--- a/src/aktualizr_secondary/main.cc
+++ b/src/aktualizr_secondary/main.cc
@@ -4,6 +4,8 @@
 
 #include <openssl/ssl.h>
 
+#include "aktualizr_secondary_config.h"
+
 #include "logging.h"
 
 namespace bpo = boost::program_options;
@@ -26,7 +28,8 @@ bpo::variables_map parse_options(int argc, char *argv[]) {
       ("help,h", "print usage")
       ("version,v", "Current aktualizr-secondary version")
       ("loglevel", bpo::value<int>(), "set log level 0-4 (trace, debug, warning, info, error)")
-      ("config,c", bpo::value<std::string>()->required(), "toml configuration file");
+      ("config,c", bpo::value<std::string>()->required(), "toml configuration file")
+      ("server-port,p", bpo::value<int>(), "command server listening port");
   // clang-format on
 
   bpo::variables_map vm;

--- a/src/cert_provider/main.cc
+++ b/src/cert_provider/main.cc
@@ -11,7 +11,6 @@
 #include "json/json.h"
 
 #include "bootstrap.h"
-#include "config.h"
 #include "crypto.h"
 #include "httpclient.h"
 #include "logging.h"

--- a/src/config.cc
+++ b/src/config.cc
@@ -220,7 +220,6 @@ void Config::updateFromTomlString(const std::string& contents) {
 void Config::updateFromPropertyTree(const boost::property_tree::ptree& pt) {
   // Keep this order the same as in config.h and writeToFile().
 
-  CopyFromConfig(gateway.http, "gateway.http", boost::log::trivial::info, pt);
   CopyFromConfig(gateway.socket, "gateway.socket", boost::log::trivial::info, pt);
 
   CopyFromConfig(network.socket_commands_path, "network.socket_commands_path", boost::log::trivial::trace, pt);
@@ -343,9 +342,6 @@ void Config::updateFromPropertyTree(const boost::property_tree::ptree& pt) {
 void Config::updateFromCommandLine(const boost::program_options::variables_map& cmd) {
   if (cmd.count("poll-once") != 0) {
     uptane.polling = false;
-  }
-  if (cmd.count("gateway-http") != 0) {
-    gateway.http = cmd["gateway-http"].as<bool>();
   }
   if (cmd.count("gateway-socket") != 0) {
     gateway.socket = cmd["gateway-socket"].as<bool>();
@@ -506,7 +502,6 @@ void Config::writeToFile(const boost::filesystem::path& filename) {
   sink << std::boolalpha;
 
   sink << "[gateway]\n";
-  writeOption(sink, gateway.http, "http");
   writeOption(sink, gateway.socket, "socket");
   sink << "\n";
 

--- a/src/config.h
+++ b/src/config.h
@@ -27,8 +27,7 @@ std::ostream& operator<<(std::ostream& os, CryptoSource cs);
 // updateFromPropertyTree() in config.cc.
 
 struct GatewayConfig {
-  GatewayConfig() : http(true), socket(false) {}
-  bool http;
+  GatewayConfig() : socket(false) {}
   bool socket;
 };
 

--- a/src/config.h
+++ b/src/config.h
@@ -112,7 +112,6 @@ struct ImportConfig {
 class Config {
  public:
   Config();
-  Config(const boost::property_tree::ptree& pt);
   Config(const boost::filesystem::path& filename, const boost::program_options::variables_map& cmd);
   Config(const boost::filesystem::path& filename);
 
@@ -132,17 +131,6 @@ class Config {
   ImportConfig import;
 
  private:
-  static std::string stripQuotes(const std::string& value);
-  static std::string addQuotes(const std::string& value);
-  template <typename T>
-  static T StripQuotesFromStrings(const T& value);
-  template <typename T>
-  static void CopyFromConfig(T& dest, const std::string& option_name, boost::log::trivial::severity_level warning_level,
-                             const boost::property_tree::ptree& pt);
-  template <typename T>
-  static T addQuotesToStrings(const T& value);
-  template <typename T>
-  static void writeOption(std::ofstream& sink, const T& data, const std::string& option_name);
   void updateFromPropertyTree(const boost::property_tree::ptree& pt);
   void updateFromToml(const boost::filesystem::path& filename);
   void updateFromCommandLine(const boost::program_options::variables_map& cmd);

--- a/src/config.h
+++ b/src/config.h
@@ -27,22 +27,16 @@ std::ostream& operator<<(std::ostream& os, CryptoSource cs);
 // updateFromPropertyTree() in config.cc.
 
 struct GatewayConfig {
-  GatewayConfig() : socket(false) {}
-  bool socket;
+  bool socket{false};
 };
 
 struct NetworkConfig {
-  NetworkConfig() : socket_commands_path("/tmp/sota-commands.socket"), socket_events_path("/tmp/sota-events.socket") {
-    socket_events.push_back("DownloadComplete");
-    socket_events.push_back("DownloadFailed");
-  }
-  std::string socket_commands_path;
-  std::string socket_events_path;
-  std::vector<std::string> socket_events;
+  std::string socket_commands_path{"/tmp/sota-commands.socket"};
+  std::string socket_events_path{"/tmp/sota-events.socket"};
+  std::vector<std::string> socket_events{"DownloadComplete", "DownloadFailed"};
 };
 
 struct P11Config {
-  P11Config() {}
   boost::filesystem::path module;
   std::string pass;
   std::string uptane_key_id;
@@ -51,93 +45,63 @@ struct P11Config {
   std::string tls_clientcert_id;
 };
 
-class TlsConfig {
- public:
-  TlsConfig() : server(""), server_url_path(""), ca_source(kFile), pkey_source(kFile), cert_source(kFile) {}
-
+struct TlsConfig {
   std::string server;
   boost::filesystem::path server_url_path;
-  CryptoSource ca_source;
-  CryptoSource pkey_source;
-  CryptoSource cert_source;
+  CryptoSource ca_source{kFile};
+  CryptoSource pkey_source{kFile};
+  CryptoSource cert_source{kFile};
 };
 
 struct ProvisionConfig {
-  ProvisionConfig() : server(""), p12_password(""), expiry_days("36000"), provision_path(""), mode(kAutomatic) {}
   std::string server;
   std::string p12_password;
-  std::string expiry_days;
+  std::string expiry_days{"36000"};
   boost::filesystem::path provision_path;
-  ProvisionMode mode;
+  ProvisionMode mode{kAutomatic};
 };
 
 struct UptaneConfig {
-  UptaneConfig()
-      : polling(true),
-        polling_sec(10u),
-        device_id(""),
-        primary_ecu_serial(""),
-        primary_ecu_hardware_id(""),
-        director_server(""),
-        repo_server(""),
-        key_source(kFile),
-        key_type(kRSA2048) {}
-  bool polling;
-  unsigned long long polling_sec;
+  bool polling{true};
+  unsigned long long polling_sec{10u};
   std::string device_id;
   std::string primary_ecu_serial;
   std::string primary_ecu_hardware_id;
   std::string director_server;
   std::string repo_server;
-  CryptoSource key_source;
-  KeyType key_type;
+  CryptoSource key_source{kFile};
+  KeyType key_type{kRSA2048};
+  std::vector<Uptane::SecondaryConfig> secondary_configs{};
+
   std::string getKeyTypeString() const { return (key_type == kED25519) ? "ED25519" : "RSA"; }
-  std::vector<Uptane::SecondaryConfig> secondary_configs;
 };
 
 struct PackageConfig {
-  PackageConfig() : type(kOstree), os(""), sysroot(""), ostree_server(""), packages_file("/usr/package.manifest") {}
-  PackageManager type;
+  PackageManager type{kOstree};
   std::string os;
   boost::filesystem::path sysroot;
   std::string ostree_server;
-  boost::filesystem::path packages_file;
+  boost::filesystem::path packages_file{"/usr/package.manifest"};
 };
 
 struct StorageConfig {
-  StorageConfig()
-      : type(kFileSystem),
-        path("/var/sota"),
-        sqldb_path("/var/sota/storage.db"),
-        uptane_metadata_path("metadata"),
-        uptane_private_key_path("ecukey.pem"),
-        uptane_public_key_path("ecukey.pub"),
-        tls_cacert_path("ca.pem"),
-        tls_pkey_path("pkey.pem"),
-        tls_clientcert_path("client.pem"),
-        schemas_path("/usr/lib/sota/schemas") {}
-  StorageType type;
-  boost::filesystem::path path;
-  boost::filesystem::path sqldb_path;  // TODO: merge with path once SQLStorage class is complete
+  StorageType type{kFileSystem};
+  boost::filesystem::path path{"/var/sota"};
+  // TODO: merge with path once SQLStorage class is complete
+  boost::filesystem::path sqldb_path{"/var/sota/storage.db"};
   // FS storage
-  boost::filesystem::path uptane_metadata_path;
-  boost::filesystem::path uptane_private_key_path;
-  boost::filesystem::path uptane_public_key_path;
-  boost::filesystem::path tls_cacert_path;
-  boost::filesystem::path tls_pkey_path;
-  boost::filesystem::path tls_clientcert_path;
+  boost::filesystem::path uptane_metadata_path{"metadata"};
+  boost::filesystem::path uptane_private_key_path{"ecukey.pem"};
+  boost::filesystem::path uptane_public_key_path{"ecukey.pub"};
+  boost::filesystem::path tls_cacert_path{"ca.pem"};
+  boost::filesystem::path tls_pkey_path{"pkey.pem"};
+  boost::filesystem::path tls_clientcert_path{"client.pem"};
 
   // SQLite storage
-  boost::filesystem::path schemas_path;
+  boost::filesystem::path schemas_path{"/usr/lib/sota/schemas"};
 };
 
 struct ImportConfig {
-  ImportConfig()
-      : uptane_private_key_path(""),
-        uptane_public_key_path(""),
-        tls_cacert_path(""),
-        tls_pkey_path(""),
-        tls_clientcert_path("") {}
   boost::filesystem::path uptane_private_key_path;
   boost::filesystem::path uptane_public_key_path;
   boost::filesystem::path tls_cacert_path;

--- a/src/config_utils.h
+++ b/src/config_utils.h
@@ -1,0 +1,70 @@
+#ifndef CONFIG_UTILS_H_
+#define CONFIG_UTILS_H_
+
+#include <string>
+
+#include <boost/property_tree/ini_parser.hpp>
+
+#include "logging.h"
+#include "utils.h"
+
+/*
+ The following uses a small amount of template hackery to provide a nice
+ interface to load the sota.toml config file. StripQuotesFromStrings is
+ templated, and passes everything that isn't a string straight through.
+ Strings in toml are always double-quoted, and we remove them by specializing
+ StripQuotesFromStrings for std::string.
+
+ The end result is that the sequence of calls in Config::updateFromToml are
+ pretty much a direct expression of the required behaviour: load this variable
+ from this config entry, and print a warning at the
+
+ Note that default values are defined by Config's default constructor.
+ */
+
+template <typename T>
+inline T StripQuotesFromStrings(const T& value);
+
+template <>
+inline std::string StripQuotesFromStrings<std::string>(const std::string& value) {
+  return Utils::stripQuotes(value);
+}
+
+template <typename T>
+inline T StripQuotesFromStrings(const T& value) {
+  return value;
+}
+
+template <typename T>
+inline T addQuotesToStrings(const T& value);
+
+template <>
+inline std::string addQuotesToStrings<std::string>(const std::string& value) {
+  return Utils::addQuotes(value);
+}
+
+template <typename T>
+inline T addQuotesToStrings(const T& value) {
+  return value;
+}
+
+template <typename T>
+inline void writeOption(std::ofstream& sink, const T& data, const std::string& option_name) {
+  sink << option_name << " = " << addQuotesToStrings(data) << "\n";
+}
+
+template <typename T>
+inline void CopyFromConfig(T& dest, const std::string& option_name,
+                                  boost::log::trivial::severity_level warning_level,
+                                  const boost::property_tree::ptree& pt) {
+  boost::optional<T> value = pt.get_optional<T>(option_name);
+  if (value.is_initialized()) {
+    dest = StripQuotesFromStrings(value.get());
+  } else {
+    static boost::log::sources::severity_logger<boost::log::trivial::severity_level> logger;
+    BOOST_LOG_SEV(logger, static_cast<boost::log::trivial::severity_level>(warning_level))
+        << option_name << " not in config file. Using default:" << dest;
+  }
+}
+
+#endif  // CONFIG_UTILS_H_

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -16,7 +16,7 @@
 
 #include <string>
 
-#include "config.h"
+#include "types.h"
 #include "utils.h"
 
 // some older versions of openssl have BIO_new_mem_buf defined with fisrt parameter of type (void*)

--- a/src/external_secondaries/ecuinterface.h
+++ b/src/external_secondaries/ecuinterface.h
@@ -11,7 +11,7 @@ class ECUInterface {
     InstallFailureNotModified,
     InstallFailureModified
   };
-  virtual ~ECUInterface(){};
+  virtual ~ECUInterface() {}
   virtual std::string apiVersion() = 0;
   virtual std::string listEcus() = 0;
   virtual InstallStatus installSoftware(const std::string &hardware_id, const std::string &ecu_id,

--- a/src/external_secondaries/example_flasher.h
+++ b/src/external_secondaries/example_flasher.h
@@ -5,7 +5,7 @@
 
 class ExampleFlasher : public ECUInterface {
  public:
-  virtual ~ExampleFlasher(){};
+  virtual ~ExampleFlasher() {}
   ExampleFlasher(const unsigned int loglevel);
   virtual std::string apiVersion();
   virtual std::string listEcus();

--- a/src/fsstorage.h
+++ b/src/fsstorage.h
@@ -2,7 +2,6 @@
 #define FSSTORAGE_H_
 
 #include <boost/filesystem.hpp>
-#include "config.h"
 #include "invstorage.h"
 
 class FSStorage : public INvStorage {

--- a/src/gateway.h
+++ b/src/gateway.h
@@ -1,13 +1,13 @@
 #ifndef GATEWAY_H_
 #define GATEWAY_H_
 
-#include "events.h"
 #include <boost/shared_ptr.hpp>
+#include "events.h"
 
 class Gateway {
-    public:
-        virtual void processEvent(const boost::shared_ptr<event::BaseEvent> &event) = 0;
-        virtual ~Gateway(){};
+ public:
+  virtual void processEvent(const boost::shared_ptr<event::BaseEvent> &event) = 0;
+  virtual ~Gateway() {}
 };
 
 #endif /* GATEWAY_H_ */

--- a/src/httpinterface.h
+++ b/src/httpinterface.h
@@ -25,8 +25,8 @@ struct HttpResponse {
 
 class HttpInterface {
  public:
-  HttpInterface(){};
-  virtual ~HttpInterface(){};
+  HttpInterface() {}
+  virtual ~HttpInterface() {}
   virtual HttpResponse get(const std::string &url) = 0;
   virtual HttpResponse post(const std::string &url, const Json::Value &data) = 0;
   virtual HttpResponse put(const std::string &url, const Json::Value &data) = 0;

--- a/src/invstorage.h
+++ b/src/invstorage.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <string>
 
+#include "config.h"
 #include "uptane/tuf.h"
 
 class INvStorage;

--- a/src/main.cc
+++ b/src/main.cc
@@ -54,7 +54,6 @@ bpo::variables_map parse_options(int argc, char *argv[]) {
       ("version,v", "Current aktualizr version")
       ("loglevel", bpo::value<int>(), "set log level 0-4 (trace, debug, warning, info, error)")
       ("config,c", bpo::value<std::string>()->required(), "toml configuration file")
-      ("gateway-http", bpo::value<bool>(), "enable the http gateway")
       ("gateway-socket", bpo::value<bool>(), "enable the socket gateway")
       ("tls-server", bpo::value<std::string>(), "url, used for auto provisioning")
       ("repo-server", bpo::value<std::string>(), "url of the uptane repo repository")

--- a/src/packagemanagerinterface.h
+++ b/src/packagemanagerinterface.h
@@ -5,7 +5,6 @@
 
 #include <boost/shared_ptr.hpp>
 
-#include "config.h"
 #include "types.h"
 #include "uptane/tuf.h"
 

--- a/src/sqlstorage.h
+++ b/src/sqlstorage.h
@@ -5,7 +5,6 @@
 
 #include <sqlite3.h>
 
-#include "config.h"
 #include "invstorage.h"
 
 // See docs/schema-migrations.adoc

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -205,6 +205,16 @@ void Utils::hex2bin(const std::string hexstring, unsigned char *binout) {
   }
 }
 
+// Strip leading and trailing quotes
+std::string Utils::stripQuotes(const std::string &value) {
+  std::string res = value;
+  res.erase(std::remove(res.begin(), res.end(), '\"'), res.end());
+  return res;
+}
+
+// Add leading and trailing quotes
+std::string Utils::addQuotes(const std::string &value) { return "\"" + value + "\""; }
+
 Json::Value Utils::parseJSON(const std::string &json_str) {
   Json::Reader reader;
   Json::Value json_value;

--- a/src/utils.h
+++ b/src/utils.h
@@ -11,6 +11,8 @@ struct Utils {
   static std::string fromBase64(std::string);
   static std::string toBase64(const std::string &);
   static void hex2bin(const std::string hexstring, unsigned char *binout);
+  static std::string stripQuotes(const std::string &value);
+  static std::string addQuotes(const std::string &value);
   static Json::Value parseJSON(const std::string &json_str);
   static Json::Value parseJSONFile(const boost::filesystem::path &filename);
   static std::string genPrettyName();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -419,6 +419,9 @@ endif((BUILD_SOTA_TOOLS))
 add_test(NAME aktualizr-secondary-help
     COMMAND ${PROJECT_BINARY_DIR}/src/aktualizr_secondary/aktualizr-secondary --help)
 
+add_aktualizr_test(NAME aktualizr_secondary_config SOURCES aktualizr_secondary/config_test.cc PROJECT_WORKING_DIRECTORY)
+target_link_libraries(t_aktualizr_secondary_config aktualizr_secondary_static_lib)
+
 # aktualizr-info tests
 add_test(NAME aktualizr-info-noarguments
     COMMAND ${PROJECT_SOURCE_DIR}/tests/run_aktualizr_info_tests.sh ${PROJECT_BINARY_DIR}/src/aktualizr_info/aktualizr-info WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/aktualizr_secondary/config_test.cc
+++ b/tests/aktualizr_secondary/config_test.cc
@@ -1,0 +1,35 @@
+#include <gtest/gtest.h>
+
+#include "aktualizr_secondary/aktualizr_secondary_config.h"
+#include "utils.h"
+
+TEST(aktualizr_secondary_config, config_initialized_values) {
+  AktualizrSecondaryConfig conf;
+
+  EXPECT_EQ(conf.network.port, 9030);
+}
+
+TEST(aktualizr_secondary_config, config_toml_parsing) {
+  AktualizrSecondaryConfig conf("tests/aktualizr_secondary/config_tests.toml");
+
+  EXPECT_EQ(conf.network.port, 9031);
+}
+
+TEST(aktualizr_secondary_config, consistent_toml_empty) {
+  TemporaryDirectory temp_dir;
+  AktualizrSecondaryConfig config1;
+  config1.writeToFile((temp_dir / "output1.toml").string());
+  AktualizrSecondaryConfig config2((temp_dir / "output1.toml").string());
+  config2.writeToFile((temp_dir / "output2.toml").string());
+  std::string conf_str1 = Utils::readFile((temp_dir / "output1.toml").string());
+  std::string conf_str2 = Utils::readFile((temp_dir / "output2.toml").string());
+  EXPECT_EQ(conf_str1, conf_str2);
+}
+
+#ifndef __NO_MAIN__
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+  return RUN_ALL_TESTS();
+}
+#endif

--- a/tests/aktualizr_secondary/config_tests.toml
+++ b/tests/aktualizr_secondary/config_tests.toml
@@ -1,0 +1,2 @@
+[network]
+port = 9031

--- a/tests/config_test.cc
+++ b/tests/config_test.cc
@@ -25,14 +25,11 @@ TEST(config, config_initialized_values) {
 
   EXPECT_EQ(conf.uptane.polling, true);
   EXPECT_EQ(conf.uptane.polling_sec, 10u);
-
-  EXPECT_EQ(conf.gateway.http, true);
 }
 
 TEST(config, config_toml_parsing) {
   Config conf("tests/config_tests.toml");
 
-  EXPECT_EQ(conf.gateway.http, false);
   EXPECT_EQ(conf.gateway.socket, true);
 }
 
@@ -42,18 +39,15 @@ TEST(config, config_toml_parsing_empty_file) {
 
   EXPECT_EQ(conf.uptane.polling, true);
   EXPECT_EQ(conf.uptane.polling_sec, 10u);
-
-  EXPECT_EQ(conf.gateway.http, true);
 }
 
 TEST(config, config_cmdl_parsing) {
-  int argc = 5;
-  const char *argv[] = {"./aktualizr", "--gateway-http", "off", "--gateway-socket", "on"};
+  constexpr int argc = 3;
+  const char *argv[argc] = {"./aktualizr", "--gateway-socket", "on"};
 
   bpo::options_description description("CommandLine Options");
   // clang-format off
   description.add_options()
-    ("gateway-http", bpo::value<bool>(), "on/off the http gateway")
     ("gateway-socket", bpo::value<bool>(), "on/off the socket gateway");
   // clang-format on
 
@@ -61,7 +55,6 @@ TEST(config, config_cmdl_parsing) {
   bpo::store(bpo::parse_command_line(argc, argv, description), vm);
   Config conf("tests/config_tests.toml", vm);
 
-  EXPECT_FALSE(conf.gateway.http);
   EXPECT_TRUE(conf.gateway.socket);
 }
 

--- a/tests/httpclient_test.cc
+++ b/tests/httpclient_test.cc
@@ -6,7 +6,6 @@
 
 #include "json/json.h"
 
-#include "config.h"
 #include "httpclient.h"
 #include "test_utils.h"
 #include "types.h"


### PR DESCRIPTION
Notes:

- the name of the executable was changed back to `aktualizr-follower`
- some utility functions were stripped back from `config.h` and put in `config_utils.h`
- config structures use C++11 member initializers
