### PR TITLE
Enforce source checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required (VERSION 2.6)
+cmake_policy(SET CMP0009 NEW)
 
 project(aktualizr)
 
@@ -19,6 +20,8 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
 endif()
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake-modules)
+
+unset(AKTUALIZR_CHECKED_SRCS CACHE)
 
 # find all required libraries
 set(Boost_USE_STATIC_LIBS ON)
@@ -184,6 +187,10 @@ else()
 endif()
 
 function(aktualizr_source_file_checks)
+    foreach(FILE ${ARGN})
+        file(RELATIVE_PATH FULL_FN ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/${FILE})
+        set(AKTUALIZR_CHECKED_SRCS ${AKTUALIZR_CHECKED_SRCS} ${FULL_FN} CACHE INTERNAL "")
+    endforeach()
     aktualizr_clang_check(${ARGN})
     aktualizr_clang_format(${ARGN})
 
@@ -272,9 +279,7 @@ add_subdirectory("src/socket_activation")
 add_subdirectory("fuzz")
 add_subdirectory("config")
 
-if(BUILD_SOTA_TOOLS)
-    add_subdirectory("src/sota_tools")
-endif(BUILD_SOTA_TOOLS)
+add_subdirectory("src/sota_tools")
 
 add_subdirectory("src/aktualizr_secondary")
 
@@ -284,6 +289,19 @@ include(CTest)
 add_subdirectory("tests" EXCLUDE_FROM_ALL)
 
 add_subdirectory("docs")
+
+# Check if some source files were not added sent to `aktualizr_source_file_checks`
+#
+# Note: does not check `tests` directory which depends too much on conditional
+# compilation
+file(GLOB_RECURSE ALL_SOURCE_FILES RELATIVE ${CMAKE_SOURCE_DIR}
+    src/*.cc src/*.c src/*.h)
+foreach(FILE ${ALL_SOURCE_FILES})
+    list(FIND AKTUALIZR_CHECKED_SRCS ${FILE} INDEX)
+    if (${INDEX} EQUAL "-1")
+        message(FATAL_ERROR "${FILE} not checked")
+    endif ()
+endforeach()
 
 # Generate ctags
 set_source_files_properties(tags PROPERTIES GENERATED true)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,8 @@ set(SOURCES aktualizr.cc
 
 # set headers used for clang format
 set(HEADERS aktualizr.h
+            asn1-cer.h
+            asn1-cerstream.h
             bootstrap.h
             channel.h
             commands.h
@@ -56,12 +58,14 @@ set(HEADERS aktualizr.h
             openssl_compat.h
             ostree.h
             ostreereposync.h
+            p11engine.h
             packagemanagerfactory.h
             packagemanagerfake.h
             packagemanagerinterface.h
             socketgateway.h
             sotauptaneclient.h
             sqlstorage.h
+            sql_utils.h
             timer.h
             types.h
             utils.h
@@ -76,54 +80,56 @@ set(HEADERS aktualizr.h
             uptane/uptanerepository.h
             uptane/virtualsecondary.h)
 
+list(APPEND OSTREE_SOURCES ostree.cc ostreereposync.cc)
 if(BUILD_OSTREE)
-    list(APPEND SOURCES ostree.cc ostreereposync.cc)
+    list(APPEND SOURCES ${OSTREE_SOURCES})
 endif(BUILD_OSTREE)
 
+list(APPEND DEB_SOURCES deb.cc)
 if(BUILD_DEB)
-    list(APPEND SOURCES deb.cc)
+    list(APPEND SOURCES ${DEB_SOURCES})
 endif(BUILD_DEB)
 
-
+list(APPEND P11_SOURCES p11engine.cc)
 if(BUILD_P11)
-    list(APPEND SOURCES p11engine.cc)
-    list(APPEND HEADERS p11engine.h)
+    list(APPEND SOURCES ${P11_SOURCES})
 
     if(TEST_PKCS11_MODULE_PATH)
         add_definitions(-DTEST_PKCS11_MODULE_PATH="${TEST_PKCS11_MODULE_PATH}" -DTEST_PKCS11_ENGINE_PATH="${TEST_PKCS11_ENGINE_PATH}")
     endif(TEST_PKCS11_MODULE_PATH)
 endif(BUILD_P11)
 
-if(BUILD_OPCUA)
-    set(OPEN62541_SOURCES ${PROJECT_SOURCE_DIR}/third_party/open62541/open62541.c)
-    set(OPCUABRIDGE_SOURCES opcuabridge/common.cc opcuabridge/filelist.cc)
-    set(OPCUABRIDGE_HEADERS opcuabridge/boostarch.h
-                            opcuabridge/common.h
-                            opcuabridge/currenttime.h
-                            opcuabridge/ecuversionmanifest.h
-                            opcuabridge/ecuversionmanifestsigned.h
-                            opcuabridge/filedata.h
-                            opcuabridge/filelist.h
-                            opcuabridge/hash.h
-                            opcuabridge/imageblock.h
-                            opcuabridge/imagefile.h
-                            opcuabridge/image.h
-                            opcuabridge/imagerequest.h
-                            opcuabridge/metadatafile.h
-                            opcuabridge/metadatafiles.h
-                            opcuabridge/opcuabridge.h
-                            opcuabridge/signature.h
-                            opcuabridge/signed.h
-                            opcuabridge/utility.h
-                            opcuabridge/versionreport.h)
+set(OPEN62541_SOURCES ${PROJECT_SOURCE_DIR}/third_party/open62541/open62541.c)
+set(OPCUABRIDGE_SOURCES opcuabridge/common.cc opcuabridge/filelist.cc)
+set(OPCUABRIDGE_HEADERS opcuabridge/boostarch.h
+                        opcuabridge/common.h
+                        opcuabridge/currenttime.h
+                        opcuabridge/ecuversionmanifest.h
+                        opcuabridge/ecuversionmanifestsigned.h
+                        opcuabridge/filedata.h
+                        opcuabridge/filelist.h
+                        opcuabridge/hash.h
+                        opcuabridge/imageblock.h
+                        opcuabridge/imagefile.h
+                        opcuabridge/image.h
+                        opcuabridge/imagerequest.h
+                        opcuabridge/metadatafile.h
+                        opcuabridge/metadatafiles.h
+                        opcuabridge/opcuabridge.h
+                        opcuabridge/signature.h
+                        opcuabridge/signed.h
+                        opcuabridge/utility.h
+                        opcuabridge/versionreport.h)
+
+if (BUILD_OPCUA)
     set_source_files_properties(opcuabridge_messaging.cc ${OPEN62541_SOURCES} ${OPCUABRIDGE_SOURCES}
-                                PROPERTIES COMPILE_FLAGS ${OPEN62541_IGNORED_WARNINGS})
-endif(BUILD_OPCUA)
+        PROPERTIES COMPILE_FLAGS ${OPEN62541_IGNORED_WARNINGS})
+    list(APPEND SOURCES ${OPCUABRIDGE_SOURCES})
+endif (BUILD_OPCUA)
 
 # set the name of the executable
 add_executable(aktualizr main.cc)
-add_library(aktualizr_static_lib STATIC ${SOURCES} ${PROJECT_SOURCE_DIR}/third_party/jsoncpp/jsoncpp.cpp
-                                        ${OPEN62541_SOURCES} ${OPCUABRIDGE_SOURCES})
+add_library(aktualizr_static_lib STATIC ${SOURCES} ${PROJECT_SOURCE_DIR}/third_party/jsoncpp/jsoncpp.cpp)
 target_include_directories(aktualizr_static_lib PUBLIC ${LIBOSTREE_INCLUDE_DIRS})
 
 target_link_libraries(aktualizr aktualizr_static_lib
@@ -143,7 +149,10 @@ if(BUILD_WITH_CODE_COVERAGE)
 endif(BUILD_WITH_CODE_COVERAGE)
 
 ################ QA RULES
-aktualizr_source_file_checks(main.cc ${SOURCES} ${HEADERS} ${OPCUABRIDGE_SOURCES} ${OPCUABRIDGE_HEADERS})
+set(ALL_CHECKS main.cc ${SOURCES} ${HEADERS} ${OPCUABRIDGE_SOURCES} ${OPCUABRIDGE_HEADERS}
+    ${DEB_SOURCES} ${OSTREE_SOURCES} ${P11_SOURCES})
+list(REMOVE_DUPLICATES ALL_CHECKS)
+aktualizr_source_file_checks(${ALL_CHECKS})
 
 ################## INSTALL RULES
 install(TARGETS aktualizr RUNTIME DESTINATION bin COMPONENT aktualizr)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,7 @@ set(HEADERS aktualizr.h
             channel.h
             commands.h
             config.h
+            config_utils.h
             crypto.h
             deb.h
             events.h

--- a/src/asn1-cer.h
+++ b/src/asn1-cer.h
@@ -1,12 +1,12 @@
-#include <string>
 #include <stdexcept>
+#include <string>
 
 // Limitations:
 //   - Maximal supported integer width of 32 bits
 //   - Maximal supported string length of 2**31 -1
 //   - Only type tags up to 30 are supported
 
-#define CER_MAX_PRIMITIVESTRING 1000 // defined in the standard
+#define CER_MAX_PRIMITIVESTRING 1000  // defined in the standard
 
 enum ASN1_Class {
   kAsn1Universal = 0x00,
@@ -35,20 +35,18 @@ enum ASN1_UniversalTag {
 };
 
 class deserialization_error : public std::exception {
-  const char * what () const throw ()
-  {
-    return "ASN.1 deserialization error";
-  }
+  const char* what() const throw() { return "ASN.1 deserialization error"; }
 };
 
-// Decode token. 
+// Decode token.
 //    * ber - serialization
 //    * endpos - next position in the string after what was deserialized
 //    * int_param - integer value associated with token. Depends on token type.
 //    * string_param - string associated with token. Depends on token type.
 //  Return value: token type, or kUnknown in case of an error.
 
-ASN1_UniversalTag cer_decode_token(const std::string& ber, int32_t* endpos, int32_t* int_param, std::string* string_param);
+ASN1_UniversalTag cer_decode_token(const std::string& ber, int32_t* endpos, int32_t* int_param,
+                                   std::string* string_param);
 
 std::string cer_encode_integer(int32_t number);
 std::string cer_encode_string(const std::string& contents, ASN1_UniversalTag subtype);

--- a/src/asn1-cerstream.h
+++ b/src/asn1-cerstream.h
@@ -5,96 +5,94 @@
 // tokens
 namespace asn1 {
 
-class Token 
-{
-  public:
-    enum TokType {seq_tok, endseq_tok, restseq_tok};
-    Token(TokType t) {type = t;}
-    TokType type;
+class Token {
+ public:
+  enum TokType { seq_tok, endseq_tok, restseq_tok };
+  Token(TokType t) { type = t; }
+  TokType type;
 };
 
 const Token seq = Token(Token::seq_tok);
 const Token endseq = Token(Token::endseq_tok);
 const Token restseq = Token(Token::restseq_tok);
 
-template <ASN1_UniversalTag Tag, typename = void> class ImplicitC {
-};
+template <ASN1_UniversalTag Tag, typename = void>
+class ImplicitC {};
 
 template <ASN1_UniversalTag Tag>
 class ImplicitC<Tag, int32_t&> {
-  public:
-    int32_t& data;
-    ImplicitC(int32_t& d) : data(d) {}
-  
+ public:
+  int32_t& data;
+  ImplicitC(int32_t& d) : data(d) {}
 };
 
 template <ASN1_UniversalTag Tag>
 class ImplicitC<Tag, const int32_t&> {
-  public:
-    const int32_t& data;
-    ImplicitC(const int32_t& d) : data(d) {}
-  
+ public:
+  const int32_t& data;
+  ImplicitC(const int32_t& d) : data(d) {}
 };
 
 template <ASN1_UniversalTag Tag>
 class ImplicitC<Tag, std::string&> {
-  public:
-    std::string& data;
-    ImplicitC(std::string& d) : data(d) {}
-  
+ public:
+  std::string& data;
+  ImplicitC(std::string& d) : data(d) {}
 };
 
 template <ASN1_UniversalTag Tag>
 class ImplicitC<Tag, const std::string&> {
-  public:
-    const std::string& data;
-    ImplicitC(const std::string& d) : data(d) {}
-  
+ public:
+  const std::string& data;
+  ImplicitC(const std::string& d) : data(d) {}
 };
 
 template <ASN1_UniversalTag Tag, typename T>
-ImplicitC<Tag, T&> implicit(T& data) { return ImplicitC<Tag, T&>(data); }
+ImplicitC<Tag, T&> implicit(T& data) {
+  return ImplicitC<Tag, T&>(data);
+}
 
 class Serializer {
-  public:
-    const std::string& getResult() {return result;}
+ public:
+  const std::string& getResult() { return result; }
 
-    Serializer& operator << (int32_t val);
-    Serializer& operator << (std::string val);
-    Serializer& operator << (ASN1_UniversalTag tag);
-    Serializer& operator << (Token tok);
-  private:
-    std::string result;
-    ASN1_UniversalTag last_type;
+  Serializer& operator<<(int32_t val);
+  Serializer& operator<<(std::string val);
+  Serializer& operator<<(ASN1_UniversalTag tag);
+  Serializer& operator<<(Token tok);
+
+ private:
+  std::string result;
+  ASN1_UniversalTag last_type;
 };
 
 template <ASN1_UniversalTag Tag, typename T>
-Serializer& operator << (Serializer& ser, ImplicitC<Tag, T> imp) {
+Serializer& operator<<(Serializer& ser, ImplicitC<Tag, T> imp) {
   ser << Tag << imp.data;
   return ser;
 }
 
 class Deserializer {
-  public:
-    Deserializer(const std::string& d) {data = d;};
+ public:
+  Deserializer(const std::string& d) { data = d; };
 
-    Deserializer& operator >> (int32_t& val);
-    Deserializer& operator >> (std::string& val);
-    Deserializer& operator >> (ASN1_UniversalTag tag);
-    Deserializer& operator >> (Token tok);
-  private:
-    std::string data;
-    ASN1_UniversalTag last_type;
-    std::stack<int32_t> seq_lengths;
-    std::stack<int32_t> seq_consumed;
-    int32_t int_param;
-    std::string string_param;
+  Deserializer& operator>>(int32_t& val);
+  Deserializer& operator>>(std::string& val);
+  Deserializer& operator>>(ASN1_UniversalTag tag);
+  Deserializer& operator>>(Token tok);
+
+ private:
+  std::string data;
+  ASN1_UniversalTag last_type;
+  std::stack<int32_t> seq_lengths;
+  std::stack<int32_t> seq_consumed;
+  int32_t int_param;
+  std::string string_param;
 };
 
 template <ASN1_UniversalTag Tag, typename T>
-Deserializer& operator >> (Deserializer& des, ImplicitC<Tag, T> imp) {
+Deserializer& operator>>(Deserializer& des, ImplicitC<Tag, T> imp) {
   des >> Tag >> imp.data;
   return des;
 }
-
 }

--- a/src/config_utils.h
+++ b/src/config_utils.h
@@ -54,9 +54,8 @@ inline void writeOption(std::ofstream& sink, const T& data, const std::string& o
 }
 
 template <typename T>
-inline void CopyFromConfig(T& dest, const std::string& option_name,
-                                  boost::log::trivial::severity_level warning_level,
-                                  const boost::property_tree::ptree& pt) {
+inline void CopyFromConfig(T& dest, const std::string& option_name, boost::log::trivial::severity_level warning_level,
+                           const boost::property_tree::ptree& pt) {
   boost::optional<T> value = pt.get_optional<T>(option_name);
   if (value.is_initialized()) {
     dest = StripQuotesFromStrings(value.get());

--- a/src/external_secondaries/CMakeLists.txt
+++ b/src/external_secondaries/CMakeLists.txt
@@ -25,17 +25,19 @@ aktualizr_source_file_checks(${MAIN_ECU_INTERFACE_SRC} ${ECU_INTERFACE_HEADERS}
 install(TARGETS example-interface RUNTIME DESTINATION bin)
 
 
+set(ISOTP_PATH_PREFIX ../../partial/extern/isotp-c/src)
+set(BITFIELD_PATH_PREFIX ../../partial/extern/isotp-c/deps/bitfield-c/src)
+set(ISOTP_SRC ${ISOTP_PATH_PREFIX}/isotp/isotp.c
+    ${ISOTP_PATH_PREFIX}/isotp/send.c
+    ${ISOTP_PATH_PREFIX}/isotp/receive.c
+    ${BITFIELD_PATH_PREFIX}/bitfield/8byte.c
+    ${BITFIELD_PATH_PREFIX}/bitfield/bitarray.c
+    ${BITFIELD_PATH_PREFIX}/bitfield/bitfield.c)
+set(ISOTP_TEST_SRC test_isotp_interface.cc isotp_allocate.cc isotp_protocol.cc )
+set(ISOTP_TEST_HEADERS test_isotp_interface.h)
+aktualizr_source_file_checks(${ISOTP_TEST_SRC} ${ISOTP_TEST_HEADERS})
+
 if(BUILD_ISOTP)
-    set(ISOTP_PATH_PREFIX ../../partial/extern/isotp-c/src)
-    set(BITFIELD_PATH_PREFIX ../../partial/extern/isotp-c/deps/bitfield-c/src)
-    set(ISOTP_SRC ${ISOTP_PATH_PREFIX}/isotp/isotp.c
-        ${ISOTP_PATH_PREFIX}/isotp/send.c
-        ${ISOTP_PATH_PREFIX}/isotp/receive.c
-        ${BITFIELD_PATH_PREFIX}/bitfield/8byte.c
-        ${BITFIELD_PATH_PREFIX}/bitfield/bitarray.c
-        ${BITFIELD_PATH_PREFIX}/bitfield/bitfield.c)
-    set(ISOTP_TEST_SRC test_isotp_interface.cc isotp_allocate.cc isotp_protocol.cc )
-    set(ISOTP_TEST_HEADERS test_isotp_interface.h)
 
     add_executable(isotp-test-interface ${MAIN_ECU_INTERFACE_SRC} ${ISOTP_TEST_SRC} ${ISOTP_SRC})
     target_link_libraries(isotp-test-interface
@@ -49,8 +51,6 @@ if(BUILD_ISOTP)
     if(BUILD_WITH_CODE_COVERAGE)
         target_link_libraries(isotp-test-interface gcov)
     endif(BUILD_WITH_CODE_COVERAGE)
-
-    aktualizr_source_file_checks(${ISOTP_TEST_SRC} ${ISOTP_TEST_HEADERS})
 
     install(TARGETS isotp-test-interface RUNTIME DESTINATION bin)
 endif(BUILD_ISOTP)

--- a/src/opcuabridge/utility.h
+++ b/src/opcuabridge/utility.h
@@ -7,14 +7,15 @@ namespace utility {
 template <typename A, typename T>
 struct serialize_field {};
 
+// clang-format off
 #define SERIALIZE_FIELD_DECL_BEGIN(STREAM) \
   template <typename T>                    \
   struct serialize_field<STREAM, T> {      \
-  void operator()(STREAM &ar, const std::string &xml_tag, T &d)
+    void operator()(STREAM &ar, const std::string &xml_tag, T &d)
 
 #define SERIALIZE_FIELD_DECL_END \
-  }                              \
-  ;
+  };
+//clang-format on
 
 SERIALIZE_FIELD_DECL_BEGIN(DATA_SERIALIZATION_OUT_XML_STREAM) {
   ar &boost::serialization::make_nvp(xml_tag.c_str(), d);

--- a/src/socket_activation/CMakeLists.txt
+++ b/src/socket_activation/CMakeLists.txt
@@ -5,6 +5,8 @@ else()
     set(SOURCES socket_activation_dummy.cc)
 endif()
 
+aktualizr_source_file_checks(socket_activation_systemd.cc socket_activation_dummy.cc)
+
 add_library(socket_activation STATIC ${SOURCES})
 target_include_directories(socket_activation PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -13,4 +15,4 @@ if(BUILD_SYSTEMD)
     target_include_directories(socket_activation PUBLIC ${SYSTEMD_INCLUDE_DIR})
 endif()
 
-aktualizr_source_file_checks(${SOURCES} ${HEADERS})
+aktualizr_source_file_checks(${HEADERS})

--- a/src/socket_activation/socket_activation_dummy.cc
+++ b/src/socket_activation/socket_activation_dummy.cc
@@ -16,5 +16,4 @@ int listen_fds_with_names(int unset_environment, char*** names) {
 
   return 0;
 }
-
 };

--- a/src/sota_tools/CMakeLists.txt
+++ b/src/sota_tools/CMakeLists.txt
@@ -13,7 +13,11 @@ set (SOTA_TOOLS_LIB_SRC
   deploy.cc
 )
 
-add_library(sota_tools_static_lib STATIC ${SOTA_TOOLS_LIB_SRC})
+if (BUILD_SOTA_TOOLS)
+  add_library(sota_tools_static_lib STATIC ${SOTA_TOOLS_LIB_SRC})
+  target_compile_options(sota_tools_static_lib PUBLIC -std=c++11)
+  target_include_directories(sota_tools_static_lib PUBLIC ${PROJECT_SOURCE_DIR} ${GLIB2_INCLUDE_DIRS})
+endif (BUILD_SOTA_TOOLS)
 
 ##### garage-push targets
 
@@ -21,46 +25,45 @@ set (GARAGE_PUSH_SRCS
   garage_push.cc
 )
 
-add_executable(garage-push ${GARAGE_PUSH_SRCS})
+if (BUILD_SOTA_TOOLS)
+  add_executable(garage-push ${GARAGE_PUSH_SRCS})
 
-# Export compile_commands.json for clang-check
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-target_compile_options(sota_tools_static_lib PUBLIC -std=c++11)
+  target_link_libraries(garage-push sota_tools_static_lib aktualizr_static_lib
+    ${Boost_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${CURL_LIBRARIES}
+    ${GLIB2_LIBRARIES}
+    ${LibArchive_LIBRARIES})
 
-target_include_directories(sota_tools_static_lib PUBLIC ${PROJECT_SOURCE_DIR} ${GLIB2_INCLUDE_DIRS})
 
-target_link_libraries(garage-push sota_tools_static_lib aktualizr_static_lib
-  ${Boost_LIBRARIES}
-  ${CMAKE_THREAD_LIBS_INIT}
-  ${CURL_LIBRARIES}
-  ${GLIB2_LIBRARIES}
-  ${LibArchive_LIBRARIES})
-
-if(BUILD_WITH_CODE_COVERAGE)
+  if(BUILD_WITH_CODE_COVERAGE)
     target_link_libraries(garage-push gcov)
-endif(BUILD_WITH_CODE_COVERAGE)
+  endif(BUILD_WITH_CODE_COVERAGE)
 
-install(TARGETS garage-push RUNTIME DESTINATION bin)
+  install(TARGETS garage-push RUNTIME DESTINATION bin)
+endif (BUILD_SOTA_TOOLS)
 
 ##### garage-check targets
 set (GARAGE_CHECK_SRCS
   garage_check.cc
 )
 
-add_executable(garage-check ${GARAGE_CHECK_SRCS})
+if (BUILD_SOTA_TOOLS)
+  add_executable(garage-check ${GARAGE_CHECK_SRCS})
 
-target_link_libraries(garage-check sota_tools_static_lib aktualizr_static_lib
-  ${Boost_LIBRARIES}
-  ${CMAKE_THREAD_LIBS_INIT}
-  ${CURL_LIBRARIES}
-  ${GLIB2_LIBRARIES}
-  ${LibArchive_LIBRARIES})
+  target_link_libraries(garage-check sota_tools_static_lib aktualizr_static_lib
+    ${Boost_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${CURL_LIBRARIES}
+    ${GLIB2_LIBRARIES}
+    ${LibArchive_LIBRARIES})
 
-if(BUILD_WITH_CODE_COVERAGE)
+  if(BUILD_WITH_CODE_COVERAGE)
     target_link_libraries(garage-check gcov)
-endif(BUILD_WITH_CODE_COVERAGE)
+  endif(BUILD_WITH_CODE_COVERAGE)
 
-install(TARGETS garage-check RUNTIME DESTINATION bin)
+  install(TARGETS garage-check RUNTIME DESTINATION bin)
+endif (BUILD_SOTA_TOOLS)
 
 ##### garage-deploy targets
 
@@ -68,37 +71,36 @@ set (GARAGE_DEPLOY_SRCS
   garage_deploy.cc
 )
 
-add_executable(garage-deploy ${GARAGE_DEPLOY_SRCS})
-target_link_libraries(garage-deploy sota_tools_static_lib aktualizr_static_lib
-  ${Boost_LIBRARIES}
-  ${CMAKE_THREAD_LIBS_INIT}
-  ${CURL_LIBRARIES}
-  ${GLIB2_LIBRARIES}
-  ${LibArchive_LIBRARIES})
+if (BUILD_SOTA_TOOLS)
+  add_executable(garage-deploy ${GARAGE_DEPLOY_SRCS})
+  target_link_libraries(garage-deploy sota_tools_static_lib aktualizr_static_lib
+    ${Boost_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${CURL_LIBRARIES}
+    ${GLIB2_LIBRARIES}
+    ${LibArchive_LIBRARIES})
 
-if(BUILD_WITH_CODE_COVERAGE)
-    target_link_libraries(garage-deploy gcov)
-endif(BUILD_WITH_CODE_COVERAGE)
+  if(BUILD_WITH_CODE_COVERAGE)
+      target_link_libraries(garage-deploy gcov)
+  endif(BUILD_WITH_CODE_COVERAGE)
 
-add_definitions(-DGARAGE_DEPLOY_VERSION="${AKTUALIZR_VERSION}")
+  add_definitions(-DGARAGE_DEPLOY_VERSION="${AKTUALIZR_VERSION}")
 
-
-aktualizr_source_file_checks(${GARAGE_DEPLOY_SRCS})
-
-add_dependencies(build_tests garage-deploy)
+  add_dependencies(build_tests garage-deploy)
 
 
-install(TARGETS garage-deploy RUNTIME DESTINATION bin COMPONENT garage_deploy)
+  install(TARGETS garage-deploy RUNTIME DESTINATION bin COMPONENT garage_deploy)
 
-include(ExternalProject)
-ExternalProject_Add(garage-sign DEPENDS garage-deploy
-                    URL https://ats-tuf-cli-releases.s3-eu-central-1.amazonaws.com/cli-0.2.0-106-g613f9ad.tgz
-                    URL_HASH SHA256=afd869c21e2a37918eef95e0ec778b54e86a2e725a0dc0ae982be46b9c790ff6
-                    CONFIGURE_COMMAND "" BUILD_COMMAND "" INSTALL_COMMAND "")
-ExternalProject_Get_Property(garage-sign SOURCE_DIR)
+  include(ExternalProject)
+  ExternalProject_Add(garage-sign DEPENDS garage-deploy
+                      URL https://ats-tuf-cli-releases.s3-eu-central-1.amazonaws.com/cli-0.2.0-106-g613f9ad.tgz
+                      URL_HASH SHA256=afd869c21e2a37918eef95e0ec778b54e86a2e725a0dc0ae982be46b9c790ff6
+                      CONFIGURE_COMMAND "" BUILD_COMMAND "" INSTALL_COMMAND "")
+  ExternalProject_Get_Property(garage-sign SOURCE_DIR)
 
-install(PROGRAMS ${SOURCE_DIR}/bin/garage-sign DESTINATION bin COMPONENT garage_deploy)
-install(DIRECTORY ${SOURCE_DIR}/lib DESTINATION . COMPONENT garage_deploy)
+  install(PROGRAMS ${SOURCE_DIR}/bin/garage-sign DESTINATION bin COMPONENT garage_deploy)
+  install(DIRECTORY ${SOURCE_DIR}/lib DESTINATION . COMPONENT garage_deploy)
+endif (BUILD_SOTA_TOOLS)
 
 
 ##### clang-format
@@ -120,7 +122,7 @@ set(ALL_SOTA_TOOLS_HEADERS
   treehub_server.h
 )
 
-aktualizr_source_file_checks(${GARAGE_PUSH_SRCS} ${GARAGE_CHECK_SRCS} ${ALL_SOTA_TOOLS_HEADERS} ${SOTA_TOOLS_LIB_SRC})
+aktualizr_source_file_checks(${GARAGE_PUSH_SRCS} ${GARAGE_CHECK_SRCS} ${GARAGE_DEPLOY_SRCS} ${SOTA_TOOLS_LIB_SRC} ${ALL_SOTA_TOOLS_HEADERS})
 
 
 # vim: set tabstop=2 shiftwidth=2 expandtab:

--- a/src/sql_utils.h
+++ b/src/sql_utils.h
@@ -1,8 +1,8 @@
 #ifndef SQL_UTILS_H_
 #define SQL_UTILS_H_
 
-#include <memory>
 #include <list>
+#include <memory>
 
 #include <sqlite3.h>
 
@@ -55,7 +55,7 @@ class SQLiteStatement {
 
   void bindArgument(const std::string& v) {
     owned_data_.push_back(v);
-    const std::string &oe = owned_data_.back();
+    const std::string& oe = owned_data_.back();
 
     if (sqlite3_bind_text(stmt_.get(), bind_cnt_, oe.c_str(), -1, nullptr) != SQLITE_OK) {
       LOG_ERROR << "Could not bind: " << sqlite3_errmsg(db_);
@@ -63,9 +63,7 @@ class SQLiteStatement {
     }
   }
 
-  void bindArgument(const char* v) {
-    bindArgument(std::string(v));
-  }
+  void bindArgument(const char* v) { bindArgument(std::string(v)); }
 
   void bindArgument(const SQLBlob& blob) {
     owned_data_.emplace_back(blob.content);
@@ -84,9 +82,7 @@ class SQLiteStatement {
     }
   }
 
-  void bindArguments() {
-    /* end of template specialization */
-  }
+  void bindArguments() { /* end of template specialization */ }
 
   template <typename T, typename... Types>
   void bindArguments(const T& v, const Types&... args) {

--- a/src/sql_utils.h
+++ b/src/sql_utils.h
@@ -82,7 +82,8 @@ class SQLiteStatement {
     }
   }
 
-  void bindArguments() { /* end of template specialization */ }
+  /* end of template specialization */
+  void bindArguments() {}
 
   template <typename T, typename... Types>
   void bindArguments(const T& v, const Types&... args) {


### PR DESCRIPTION
It's currently very easy to forget to add new source and headers to the static checks. It causes unclean files to be committed and unnecessary review back and forth.

Example: https://github.com/advancedtelematic/aktualizr/pull/620#issuecomment-371456780

CMake now tries to match the list of source files it can find with what was added to the checks.