### PR TITLE
RFC: Provide a way to make a fixed machine id

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,11 @@ option(BUILD_SOTA_TOOLS "Set to ON to build SOTA tools" OFF)
 option(BUILD_ISOTP "Set to ON to build ISO-TP" OFF)
 option(BUILD_OPCUA "Set to ON to compile with OPC-UA protocol support" OFF)
 option(INSTALL_LIB "Set to ON to install library and headers" OFF)
+option(MACHINE "Override the machine-id value derived from /etc/hostname" OFF)
+
+if(MACHINE)
+add_definitions(-DMACHINE="${MACHINE}")
+endif(MACHINE)
 
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
     message(FATAL_ERROR "Aktualizr does not support building in the source tree. Please remove CMakeCache.txt and the CMakeFiles/ directory, then create a subdirectory to build in: mkdir build; cd build; cmake ..")

--- a/src/sotauptaneclient.cc
+++ b/src/sotauptaneclient.cc
@@ -86,6 +86,9 @@ void SotaUptaneClient::PackageInstallSetResult(const Uptane::Target &target) {
 void SotaUptaneClient::reportHwInfo() {
   Json::Value hw_info = Utils::getHardwareInfo();
   if (!hw_info.empty()) {
+#ifdef MACHINE
+    hw_info["id"] = MACHINE;
+#endif
     http.put(config.tls.server + "/core/system_info", hw_info);
   }
 }


### PR DESCRIPTION
My cmake understanding is limited, so I'm not sure this is the best
approach. However, I think I've found an issue that's worth addressing:

While testing on an rpi3 I found my machine-id being registered with
ATS Garage was showing up as the name of my device rather than its
actual hardware-id. Looking into lshw, I see they just read the value
from /etc/hostname and there's not really an easy way to probe for
this. This change allows you to define a fixed machine-id.

Signed-off-by: Andy Doan <andy@opensourcefoundries.com>