### PR TITLE
Add apt-transport-https package to all docker files to support https …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN echo "deb http://httpredir.debian.org/debian jessie-backports main contrib n
 # It is important to run these in the same RUN command, because otherwise
 # Docker layer caching breaks us
 RUN apt-get update && apt-get -y install \
+  apt-transport-https \
   autoconf \
   asn1c \
   automake \

--- a/Dockerfile.deb-stable
+++ b/Dockerfile.deb-stable
@@ -10,6 +10,7 @@ RUN echo "deb http://security.debian.org stable/updates main" >> /etc/apt/source
 # It is important to run these in the same RUN command, because otherwise
 # Docker layer caching breaks us
 RUN apt-get update && apt-get -y install \
+  apt-transport-https \
   asn1c \
   autoconf \
   automake \

--- a/Dockerfile.deb-unstable
+++ b/Dockerfile.deb-unstable
@@ -8,6 +8,7 @@ RUN echo "deb http://ftp.de.debian.org/debian unstable main" > /etc/apt/sources.
 # It is important to run these in the same RUN command, because otherwise
 # Docker layer caching breaks us
 RUN apt-get update && apt-get -y install \
+  apt-transport-https \
   asn1c \
   autoconf \
   automake \

--- a/Dockerfile.noostree
+++ b/Dockerfile.noostree
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get -y install debian-archive-keyring
 # It is important to run these in the same RUN command, because otherwise
 # Docker layer caching breaks us
 RUN apt-get update && apt-get -y install \
+  apt-transport-https \
   asn1c \
   autoconf \
   automake \

--- a/Dockerfile.nop11
+++ b/Dockerfile.nop11
@@ -9,6 +9,7 @@ RUN echo "deb http://httpredir.debian.org/debian jessie-backports main contrib n
 # It is important to run these in the same RUN command, because otherwise
 # Docker layer caching breaks us
 RUN apt-get update && apt-get -y install \
+  apt-transport-https \
   asn1c \
   autoconf \
   automake \


### PR DESCRIPTION
…hosted repositories

This PR fixes a new CI fail issue