### PR TITLE
Add dummy implementation callbacks for aktualizr_secondary

### DIFF
--- a/src/aktualizr_secondary/aktualizr_secondary.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary.cc
@@ -132,3 +132,47 @@ void AktualizrSecondary::handle_connection_msgs(SocketHandle con, std::unique_pt
   }
   LOG_INFO << "Connection closed with " << peer_name;
 }
+std::string AktualizrSecondary::getSerialResp() {
+  LOG_ERROR << "getSerialResp is not implemented yet";
+  return "";
+}
+
+std::string AktualizrSecondary::getHwIdResp() {
+  LOG_ERROR << "getHwIdResp is not implemented yet";
+  return "";
+}
+
+std::pair<KeyType, std::string> AktualizrSecondary::getPublicKeyResp() {
+  LOG_ERROR << "getPublicKeyResp is not implemented yet";
+  return std::make_pair(kUnknownKey, "");
+}
+
+Json::Value AktualizrSecondary::getManifestResp() {
+  LOG_ERROR << "getManifestResp is not implemented yet";
+  return Json::Value();
+}
+
+bool AktualizrSecondary::putMetadataResp(const Uptane::MetaPack &meta_pack) {
+  (void)meta_pack;
+  LOG_ERROR << "putMedatadatResp is not implemented yet";
+  return false;
+}
+
+int32_t AktualizrSecondary::getRootVersionResp(bool director) {
+  (void)director;
+  LOG_ERROR << "getRootVersionResp is not implemented yet";
+  return -1;
+}
+
+bool AktualizrSecondary::putRootResp(Uptane::Root root, bool director) {
+  (void)root;
+  (void)director;
+  LOG_ERROR << "putRootResp is not implemented yet";
+  return false;
+}
+
+bool AktualizrSecondary::sendFirmwareResp(const std::string &firmware) {
+  (void)firmware;
+  LOG_ERROR << "sendFirmwareResp is not implemented yet";
+  return false;
+}

--- a/src/aktualizr_secondary/aktualizr_secondary.h
+++ b/src/aktualizr_secondary/aktualizr_secondary.h
@@ -6,9 +6,11 @@
 #include "aktualizr_secondary_config.h"
 #include "aktualizr_secondary_ipc.h"
 #include "channel.h"
+#include "types.h"
+#include "uptane/tuf.h"
 
 struct SocketCloser {
-  void operator()(int *ptr) const {
+  void operator()(int* ptr) const {
     close(*ptr);
     delete ptr;
   }
@@ -18,10 +20,20 @@ using SocketHandle = std::unique_ptr<int, SocketCloser>;
 
 class AktualizrSecondary {
  public:
-  AktualizrSecondary(const AktualizrSecondaryConfig &config);
+  AktualizrSecondary(const AktualizrSecondaryConfig& config);
   void run();
   void stop();
   int listening_port() const;
+
+  // implementation of primary's SecondaryInterface
+  std::string getSerialResp();
+  std::string getHwIdResp();
+  std::pair<KeyType, std::string> getPublicKeyResp();
+  Json::Value getManifestResp();
+  bool putMetadataResp(const Uptane::MetaPack& meta_pack);
+  int32_t getRootVersionResp(bool director);
+  bool putRootResp(Uptane::Root root, bool director);
+  bool sendFirmwareResp(const std::string& firmware);
 
  private:
   void handle_connection_msgs(SocketHandle con, std::unique_ptr<sockaddr_storage> addr);

--- a/src/config.h
+++ b/src/config.h
@@ -77,7 +77,7 @@ struct UptaneConfig {
   KeyType key_type{kRSA2048};
   std::vector<Uptane::SecondaryConfig> secondary_configs{};
 
-  std::string getKeyTypeString() const { return (key_type == kED25519) ? "ED25519" : "RSA"; }
+  std::string getKeyTypeString() const { return keyTypeToString(key_type); }
 };
 
 struct PackageConfig {

--- a/src/types.cc
+++ b/src/types.cc
@@ -126,4 +126,17 @@ UpdateReport UpdateReport::fromJson(const std::string& json_str) {
   return update_report;
 }
 }
+
+std::string keyTypeToString(KeyType type) {
+  switch (type) {
+    case kED25519:
+      return "ED25519";
+    case kRSA2048:
+    case kRSA4096:
+      return "RSA";
+    default:
+      return "UNKNOWN";
+  }
+}
+
 // vim: set tabstop=2 shiftwidth=2 expandtab:

--- a/src/types.h
+++ b/src/types.h
@@ -4,7 +4,8 @@
 #include <json/json.h>
 #include <boost/filesystem.hpp>
 
-enum KeyType { kED25519 = 0, kRSA2048, kRSA4096 };
+enum KeyType { kUnknownKey = 0xff, kED25519 = 0, kRSA2048, kRSA4096 };
+std::string keyTypeToString(KeyType type);
 
 namespace data {
 

--- a/src/uptane/initialize.cc
+++ b/src/uptane/initialize.cc
@@ -183,8 +183,8 @@ InitRetCode Repository::initEcuRegister() {
     Json::Value ecu;
     ecu["hardware_identifier"] = (*it)->getHwId();
     ecu["ecu_serial"] = (*it)->getSerial();
-    ecu["clientKey"]["keytype"] = (*it)->getKeyType();
-    ecu["clientKey"]["keyval"]["public"] = (*it)->getPublicKey();
+    ecu["clientKey"]["keytype"] = keyTypeToString((*it)->getPublicKey().first);
+    ecu["clientKey"]["keyval"]["public"] = (*it)->getPublicKey().second;
     all_ecus["ecus"].append(ecu);
   }
 

--- a/src/uptane/managedsecondary.h
+++ b/src/uptane/managedsecondary.h
@@ -28,7 +28,7 @@ class ManagedSecondary : public SecondaryInterface {
       return public_key_id;
     }
   }
-  std::string getPublicKey() override { return public_key; }
+  std::pair<KeyType, std::string> getPublicKey() override { return std::make_pair(sconfig.key_type, public_key); }
   bool putMetadata(const MetaPack& meta_pack) override;
   int getRootVersion(const bool director) override;
   bool putRoot(Uptane::Root root, const bool director) override;

--- a/src/uptane/secondaryinterface.h
+++ b/src/uptane/secondaryinterface.h
@@ -23,15 +23,14 @@ class SecondaryInterface {
   virtual ~SecondaryInterface() {}
   virtual std::string getSerial() { return sconfig.ecu_serial; }
   virtual std::string getHwId() { return sconfig.ecu_hardware_id; }
-  virtual std::string getPublicKey() = 0;
+  virtual std::pair<KeyType, std::string> getPublicKey() = 0;
 
   virtual Json::Value getManifest() = 0;
   virtual bool putMetadata(const MetaPack& meta_pack) = 0;
-  virtual int getRootVersion(bool director) = 0;
+  virtual int32_t getRootVersion(bool director) = 0;
   virtual bool putRoot(Uptane::Root root, bool director) = 0;
 
   virtual bool sendFirmware(const std::string& data) = 0;
-  std::string getKeyType() const { return (sconfig.key_type == kED25519) ? "ED25519" : "RSA"; }
 
   const SecondaryConfig& sconfig;
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -457,6 +457,9 @@ target_link_libraries(t_aktualizr_secondary_config aktualizr_secondary_static_li
 add_aktualizr_test(NAME aktualizr_secondary_protocol SOURCES aktualizr_secondary/protocol_test.cc PROJECT_WORKING_DIRECTORY)
 target_link_libraries(t_aktualizr_secondary_protocol aktualizr_secondary_static_lib aktualizr_static_lib)
 
+add_aktualizr_test(NAME aktualizr_secondary_update SOURCES aktualizr_secondary/update_test.cc PROJECT_WORKING_DIRECTORY)
+target_link_libraries(t_aktualizr_secondary_update aktualizr_secondary_static_lib aktualizr_static_lib)
+
 # aktualizr-info tests
 add_test(NAME aktualizr-info-noarguments
     COMMAND ${PROJECT_SOURCE_DIR}/tests/run_aktualizr_info_tests.sh ${PROJECT_BINARY_DIR}/src/aktualizr_info/aktualizr-info WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/aktualizr_secondary/update_test.cc
+++ b/tests/aktualizr_secondary/update_test.cc
@@ -1,0 +1,71 @@
+#include <gtest/gtest.h>
+
+#include "aktualizr_secondary/aktualizr_secondary.h"
+#include "uptane/secondaryinterface.h"
+
+#include <boost/algorithm/hex.hpp>
+#include <boost/filesystem.hpp>
+
+#include "config.h"
+#include "fsstorage.h"
+#include "utils.h"
+
+class ShortCircuitSecondary : public Uptane::SecondaryInterface {
+ public:
+  ShortCircuitSecondary(const Uptane::SecondaryConfig& sconfig_in, AktualizrSecondary& sec)
+      : SecondaryInterface(sconfig_in), secondary(sec) {}
+  virtual ~ShortCircuitSecondary() {}
+
+  virtual std::string getSerial() { return secondary.getSerialResp(); }
+  virtual std::string getHwId() { return secondary.getHwIdResp(); }
+  virtual std::pair<KeyType, std::string> getPublicKey() { return secondary.getPublicKeyResp(); }
+  virtual Json::Value getManifest() { return secondary.getManifestResp(); }
+  virtual bool putMetadata(const Uptane::MetaPack& meta_pack) { return secondary.putMetadataResp(meta_pack); }
+  virtual int32_t getRootVersion(bool director) { return secondary.getRootVersionResp(director); }
+  virtual bool putRoot(Uptane::Root root, bool director) { return secondary.putRootResp(root, director); }
+  virtual bool sendFirmware(const std::string& data) { return secondary.sendFirmwareResp(data); }
+
+ private:
+  AktualizrSecondary& secondary;
+};
+
+TEST(aktualizr_secondary_protocol, DISABLED_manual_update) {
+  // secondary
+  AktualizrSecondaryConfig config;
+  config.network.port = 0;
+  AktualizrSecondary as{config};
+
+  // secondary interface
+  Uptane::SecondaryConfig config_iface;
+  ShortCircuitSecondary sec_iface{config_iface, as};
+
+  // storage
+  TemporaryDirectory temp_dir;
+  int ret = system((std::string("cp -rf test/test_data/secondary_meta/* ") + temp_dir.PathString()).c_str());
+  (void)ret;
+  StorageConfig fs_config;
+  fs_config.type = kFileSystem;
+  fs_config.path = temp_dir.Path();
+  fs_config.uptane_metadata_path = "metadata";
+  FSStorage fs_storage(fs_config);
+
+  Uptane::MetaPack metadata;
+  EXPECT_TRUE(fs_storage.loadMetadata(&metadata));
+
+  std::string firmware = Utils::readFile(temp_dir.Path() / "firmware.bin");
+
+  EXPECT_TRUE(sec_iface.putMetadata(metadata));
+  EXPECT_TRUE(sec_iface.sendFirmware(firmware));
+  Json::Value manifest = sec_iface.getManifest();
+
+  EXPECT_EQ(manifest["signed"]["installed_image"]["fileinfo"]["hashes"]["sha256"],
+            boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(firmware))));
+}
+
+#ifndef __NO_MAIN__
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+  return RUN_ALL_TESTS();
+}
+#endif


### PR DESCRIPTION
A dummy test also added. It's disabled now, when aktualizr_secondary is implemented it should be enabled and passing.

@riqkum Please use these callbacks as an interface on the secondary side. Approximate data transfer scheme could look like

```
SecondaryInterface.getManifest() <-> OPC-UA on primary <-> || <-> OPC-UA on secondary <-> AktualizrSecondary.getManifestResp()
```

(the same for other calls)