### PR TITLE
IP Uptane primary<->secondary communication

### DIFF
--- a/scripts/check-formatting.sh
+++ b/scripts/check-formatting.sh
@@ -5,10 +5,12 @@ CLANG_FORMAT=$1
 shift
 FILES=$@
 
+DIFF=$(tempfile)
 FAIL=0
-diff -u <(cat ${FILES}) <(${CLANG_FORMAT} -style=file ${FILES}) > /dev/null || FAIL=1
+diff -u <(cat ${FILES}) <(${CLANG_FORMAT} -style=file ${FILES}) > ${DIFF} || FAIL=1
 if [ ${FAIL} -eq 1 ]; then
     echo "${CLANG_FORMAT} found unformatted code! Run 'make qa' before continuing."
+    cat ${DIFF}
     exit 1
 fi
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SOURCES aktualizr.cc
             invstorage.cc
             ipsecondarydiscovery.cc
             ipuptaneconnection.cc
+            ipuptaneconnectionsplitter.cc
             keymanager.cc
             logging.cc
             socketgateway.cc
@@ -28,6 +29,7 @@ set(SOURCES aktualizr.cc
             types.cc
             utils.cc
             uptane/initialize.cc
+            uptane/ipuptanesecondary.cc
             uptane/legacysecondary.cc
             uptane/managedsecondary.cc
             uptane/partialverificationsecondary.cc
@@ -60,6 +62,7 @@ set(HEADERS aktualizr.h
             invstorage.h
             ipsecondarydiscovery.h
             ipuptaneconnection.h
+            ipuptaneconnectionsplitter.h
             keymanager.h
             logging.h
             openssl_compat.h
@@ -77,6 +80,7 @@ set(HEADERS aktualizr.h
             types.h
             utils.h
             uptane/exceptions.h
+            uptane/ipuptanesecondary.h
             uptane/legacysecondary.h
             uptane/managedsecondary.h
             uptane/partialverificationsecondary.h

--- a/src/aktualizr.cc
+++ b/src/aktualizr.cc
@@ -14,7 +14,7 @@
 #include "invstorage.h"
 #include "sotauptaneclient.h"
 
-Aktualizr::Aktualizr(const Config &config) : config_(config) {
+Aktualizr::Aktualizr(Config &config) : config_(config) {
   if (sodium_init() == -1) {  // Note that sodium_init doesn't require a matching 'sodium_deinit'
     throw std::runtime_error("Unable to initialize libsodium");
   }

--- a/src/aktualizr.h
+++ b/src/aktualizr.h
@@ -5,12 +5,12 @@
 
 class Aktualizr : public boost::noncopyable {
  public:
-  Aktualizr(const Config& config);
+  Aktualizr(Config& config);
 
   int run();
 
  private:
-  const Config& config_;
+  Config& config_;
 };
 
 #endif  // AKTUALIZR_H_

--- a/src/aktualizr_secondary/aktualizr_secondary.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary.cc
@@ -8,8 +8,7 @@
 #include "socket_activation.h"
 #include "utils.h"
 
-AktualizrSecondary::AktualizrSecondary(const AktualizrSecondaryConfig &config,
-                                       const boost::shared_ptr<INvStorage> &storage)
+AktualizrSecondary::AktualizrSecondary(const AktualizrSecondaryConfig& config, boost::shared_ptr<INvStorage>& storage)
     : config_(config), conn_(config.network.port), storage_(storage), keys_(storage_, config.keymanagerConfig()) {
   pacman = PackageManagerFactory::makePackageManager(config_.pacman, storage_);
   // note: we don't use TlsConfig here and supply the default to
@@ -61,7 +60,96 @@ void AktualizrSecondary::run() {
   // listen for messages
   std::shared_ptr<SecondaryPacket> pkt;
   while (conn_.in_channel_ >> pkt) {
-    // TODO: process message
+    sockaddr_storage& peer_addr = pkt->peer_addr;
+    Utils::setSocketPort(&peer_addr, config_.network.remote_port);
+
+    std::unique_ptr<SecondaryMessage> out_msg;
+    switch (pkt->msg->mes_type) {
+      case kSecondaryMesPublicKeyReqTag: {
+        auto ret = getPublicKeyResp();
+
+        SecondaryPublicKeyResp* out_msg_pkey = new SecondaryPublicKeyResp;
+        out_msg_pkey->type = ret.first;
+        out_msg_pkey->key = ret.second;
+        out_msg = std::unique_ptr<SecondaryMessage>{out_msg_pkey};
+        break;
+      }
+      case kSecondaryMesManifestReqTag: {
+        auto ret = getManifestResp();
+        SecondaryManifestResp* out_msg_man = new SecondaryManifestResp;
+        out_msg_man->format = kSerializationJson;
+        out_msg_man->manifest = Utils::jsonToStr(ret);
+        out_msg = std::unique_ptr<SecondaryMessage>{out_msg_man};
+        break;
+      }
+      case kSecondaryMesPutMetaReqTag: {
+        Uptane::MetaPack meta_pack;
+
+        SecondaryPutMetaReq* in_putmeta = dynamic_cast<SecondaryPutMetaReq*>(&(*pkt->msg));
+        SecondaryPutMetaResp* out_msg_putmeta = new SecondaryPutMetaResp;
+        out_msg = std::unique_ptr<SecondaryMessage>{out_msg_putmeta};
+
+        if (!in_putmeta->image_meta_present) {
+          LOG_ERROR << "Full verification secondary, image meta is expected";
+          out_msg_putmeta->result = false;
+          break;
+        }
+        if (in_putmeta->director_targets_format != kSerializationJson ||
+            in_putmeta->image_targets_format != kSerializationJson ||
+            in_putmeta->image_timestamp_format != kSerializationJson ||
+            in_putmeta->image_snapshot_format != kSerializationJson) {
+          LOG_ERROR << "Only JSON metadata is supported";
+          out_msg_putmeta->result = false;
+          break;
+        }
+
+        meta_pack.director_targets = Uptane::Targets(Utils::parseJSON(in_putmeta->director_targets));
+        meta_pack.image_targets = Uptane::Targets(Utils::parseJSON(in_putmeta->image_targets));
+        meta_pack.image_timestamp = Uptane::TimestampMeta(Utils::parseJSON(in_putmeta->image_timestamp));
+        meta_pack.image_snapshot = Uptane::Snapshot(Utils::parseJSON(in_putmeta->image_snapshot));
+        out_msg_putmeta->result = putMetadataResp(meta_pack);
+        break;
+      }
+      case kSecondaryMesRootVersionReqTag: {
+        SecondaryRootVersionReq* in_msg_rootversion = dynamic_cast<SecondaryRootVersionReq*>(&(*pkt->msg));
+        SecondaryRootVersionResp* out_msg_rootversion = new SecondaryRootVersionResp;
+        out_msg = std::unique_ptr<SecondaryMessage>{out_msg_rootversion};
+
+        out_msg_rootversion->version = getRootVersionResp(in_msg_rootversion->director);
+        break;
+      }
+      case kSecondaryMesPutRootReqTag: {
+        SecondaryPutRootReq* in_msg_putroot = dynamic_cast<SecondaryPutRootReq*>(&(*pkt->msg));
+        SecondaryPutRootResp* out_msg_putroot = new SecondaryPutRootResp;
+        out_msg = std::unique_ptr<SecondaryMessage>{out_msg_putroot};
+
+        if (in_msg_putroot->root_format != kSerializationJson) {
+          LOG_ERROR << "Only JSON metadata is supported";
+          out_msg_putroot->result = false;
+          break;
+        }
+
+        out_msg_putroot->result = putRootResp(
+            Uptane::Root(((in_msg_putroot->director) ? "director" : "repo"), Utils::parseJSON(in_msg_putroot->root)),
+            in_msg_putroot->director);
+
+        break;
+      }
+      case kSecondaryMesSendFirmwareReqTag: {
+        SecondarySendFirmwareReq* in_msg_fw = dynamic_cast<SecondarySendFirmwareReq*>(&(*pkt->msg));
+        SecondarySendFirmwareResp* out_msg_fw = new SecondarySendFirmwareResp;
+        out_msg = std::unique_ptr<SecondaryMessage>{out_msg_fw};
+
+        out_msg_fw->result = sendFirmwareResp(in_msg_fw->firmware);
+        break;
+      }
+      default:
+        LOG_ERROR << "Unexpected message tag: " << pkt->msg->mes_type;
+        continue;
+    }
+
+    std::shared_ptr<SecondaryPacket> out_pkt{new SecondaryPacket{peer_addr, std::move(out_msg)}};
+    conn_.out_channel_ << out_pkt;
   }
 }
 
@@ -126,7 +214,7 @@ bool AktualizrSecondary::putRootResp(Uptane::Root root, bool director) {
   return false;
 }
 
-bool AktualizrSecondary::sendFirmwareResp(const std::string &firmware) {
+bool AktualizrSecondary::sendFirmwareResp(const std::string& firmware) {
   (void)firmware;
   LOG_ERROR << "sendFirmwareResp is not implemented yet";
   return false;

--- a/src/aktualizr_secondary/aktualizr_secondary.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary.cc
@@ -8,7 +8,8 @@
 #include "socket_activation.h"
 #include "utils.h"
 
-AktualizrSecondary::AktualizrSecondary(const AktualizrSecondaryConfig& config, boost::shared_ptr<INvStorage>& storage)
+AktualizrSecondary::AktualizrSecondary(const AktualizrSecondaryConfig& config,
+                                       const boost::shared_ptr<INvStorage>& storage)
     : config_(config), conn_(config.network.port), storage_(storage), keys_(storage_, config.keymanagerConfig()) {
   pacman = PackageManagerFactory::makePackageManager(config_.pacman, storage_);
   // note: we don't use TlsConfig here and supply the default to
@@ -165,7 +166,7 @@ std::pair<KeyType, std::string> AktualizrSecondary::getPublicKeyResp() const {
 
 Json::Value AktualizrSecondary::getManifestResp() const { return pacman->getManifest(getSerialResp()); }
 
-bool AktualizrSecondary::putMetadataResp(const Uptane::MetaPack &meta_pack) {
+bool AktualizrSecondary::putMetadataResp(const Uptane::MetaPack& meta_pack) {
   Uptane::TimeStamp now(Uptane::TimeStamp::Now());
   detected_attack_.clear();
 
@@ -191,8 +192,8 @@ bool AktualizrSecondary::putMetadataResp(const Uptane::MetaPack &meta_pack) {
   return true;
 }
 #ifdef BUILD_OSTREE
-bool AktualizrSecondary::sendFirmwareOstreResp(const std::string &cert, const std::string &pkey,
-                                               const std::string &ca) {
+bool AktualizrSecondary::sendFirmwareOstreResp(const std::string& cert, const std::string& pkey,
+                                               const std::string& ca) {
   KeyManagerConfig keysconfig;  // by default keysource is kFile, for now it is ok.
   KeyManager keys(storage_, keysconfig);
   keys.loadKeys(&pkey, &cert, &ca);

--- a/src/aktualizr_secondary/aktualizr_secondary_config.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_config.cc
@@ -6,12 +6,14 @@
 
 void AktualizrSecondaryNetConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt) {
   CopyFromConfig(port, "port", boost::log::trivial::info, pt);
+  CopyFromConfig(remote_port, "remote_port", boost::log::trivial::info, pt);
   CopyFromConfig(discovery, "discovery", boost::log::trivial::info, pt);
   CopyFromConfig(discovery_port, "discovery_port", boost::log::trivial::info, pt);
 }
 
 void AktualizrSecondaryNetConfig::writeToStream(std::ostream& out_stream) const {
   writeOption(out_stream, port, "port");
+  writeOption(out_stream, remote_port, "remote_port");
   writeOption(out_stream, discovery, "discovery");
   writeOption(out_stream, discovery_port, "discovery_port");
 }

--- a/src/aktualizr_secondary/aktualizr_secondary_config.h
+++ b/src/aktualizr_secondary/aktualizr_secondary_config.h
@@ -8,9 +8,10 @@
 #include "config.h"
 
 struct AktualizrSecondaryNetConfig {
-  int port{9030};
+  in_port_t port{9030};
+  in_port_t remote_port{9030};
   bool discovery{true};
-  int discovery_port{9031};
+  in_port_t discovery_port{9031};
 
   void updateFromPropertyTree(const boost::property_tree::ptree& pt);
   void writeToStream(std::ostream& out_stream) const;

--- a/src/aktualizr_secondary/aktualizr_secondary_discovery.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_discovery.cc
@@ -32,18 +32,18 @@ void AktualizrSecondaryDiscovery::open_socket() {
 
   int socket_fd = socket(AF_INET6, SOCK_DGRAM, 0);
   if (socket_fd < 0) {
-    throw std::runtime_error("socket creation failed");
+    throw std::system_error(errno, std::system_category(), "socket");
   }
   SocketHandle hdl(new int(socket_fd));
 
   int v6only = 0;
   if (setsockopt(*hdl, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, sizeof(v6only)) < 0) {
-    throw std::runtime_error("setsockopt(IPV6_V6ONLY) failed");
+    throw std::system_error(errno, std::system_category(), "setsockopt(IPV6_V6ONLY)");
   }
 
   int reuseaddr = 1;
   if (setsockopt(*hdl, SOL_SOCKET, SO_REUSEADDR, &reuseaddr, sizeof(reuseaddr)) < 0) {
-    throw std::runtime_error("setsockopt(SO_REUSEADDR) failed");
+    throw std::system_error(errno, std::system_category(), "setsockopt(SO_REUSEADDR)");
   }
 
   sockaddr_in6 sa{};
@@ -53,7 +53,7 @@ void AktualizrSecondaryDiscovery::open_socket() {
   sa.sin6_addr = IN6ADDR_ANY_INIT;
 
   if (bind(*hdl, reinterpret_cast<const sockaddr *>(&sa), sizeof(sa)) < 0) {
-    throw std::runtime_error("bind failed");
+    throw std::system_error(errno, std::system_category(), "bind");
   }
 
   socket_hdl_ = std::move(hdl);

--- a/src/aktualizr_secondary_ipc.cc
+++ b/src/aktualizr_secondary_ipc.cc
@@ -22,7 +22,7 @@ asn1::Serializer& operator<<(asn1::Serializer& ser, SerializationFormat fmt) {
   return ser;
 }
 asn1::Deserializer& operator>>(asn1::Deserializer& des, SerializationFormat& fmt) {
-  int32_t fmt_i;
+  int32_t fmt_i = -1;
 
   des >> asn1::implicit<kAsn1Enum>(fmt_i);
 
@@ -38,10 +38,8 @@ asn1::Serializer& operator<<(asn1::Serializer& ser, const SecondaryPublicKeyReq&
   ser << asn1::seq << asn1::endseq;
   return ser;
 }
-void printStringHex(const std::string& s);
 asn1::Deserializer& operator>>(asn1::Deserializer& des, SecondaryPublicKeyReq& data) {
   (void)data;
-
   des >> asn1::seq >> asn1::endseq;
   return des;
 }
@@ -85,6 +83,7 @@ asn1::Serializer& operator<<(asn1::Serializer& ser, const SecondaryPutMetaReq& d
   ser << asn1::endseq;
   return ser;
 }
+
 asn1::Deserializer& operator>>(asn1::Deserializer& des, SecondaryPutMetaReq& data) {
   des >> asn1::seq >> data.director_targets_format >> asn1::implicit<kAsn1OctetString>(data.director_targets) >>
       asn1::optional >> asn1::seq >> data.image_snapshot_format >>

--- a/src/aktualizr_secondary_ipc.h
+++ b/src/aktualizr_secondary_ipc.h
@@ -28,7 +28,9 @@ enum SecondaryMesTypeTag {
 
 struct SecondaryMessage {
   SecondaryMesTypeTag mes_type;
+  virtual ~SecondaryMessage() {}
   virtual void serialize(asn1::Serializer& ser) const = 0;
+  virtual bool operator==(const SecondaryMessage& other) const { return mes_type == other.mes_type; }
 };
 asn1::Deserializer& operator>>(asn1::Deserializer& des, std::unique_ptr<SecondaryMessage>& data);
 asn1::Serializer& operator<<(asn1::Serializer& ser, const SecondaryMessage& data);
@@ -40,22 +42,34 @@ enum SerializationFormat {
 
 struct SecondaryPublicKeyReq : public SecondaryMessage {
   SecondaryPublicKeyReq() { mes_type = kSecondaryMesPublicKeyReqTag; }
+  virtual ~SecondaryPublicKeyReq() {}
   virtual void serialize(asn1::Serializer& ser) const { ser << *this; }
+  virtual bool operator==(const SecondaryMessage& other) const override { return SecondaryMessage::operator==(other); }
+
   friend asn1::Serializer& operator<<(asn1::Serializer& ser, const SecondaryPublicKeyReq& data);
   friend asn1::Deserializer& operator>>(asn1::Deserializer& des, SecondaryPublicKeyReq& data);
 };
 
 struct SecondaryPublicKeyResp : public SecondaryMessage {
   SecondaryPublicKeyResp() { mes_type = kSecondaryMesPublicKeyRespTag; }
+  virtual ~SecondaryPublicKeyResp() {}
   virtual void serialize(asn1::Serializer& ser) const { ser << *this; }
+  virtual bool operator==(const SecondaryMessage& other) const override {
+    const SecondaryPublicKeyResp& other_ = dynamic_cast<const SecondaryPublicKeyResp&>(other);
+    return SecondaryMessage::operator==(other) && type == other_.type && key == other_.key;
+  }
+
   friend asn1::Serializer& operator<<(asn1::Serializer& ser, const SecondaryPublicKeyResp& data);
   friend asn1::Deserializer& operator>>(asn1::Deserializer& des, SecondaryPublicKeyResp& data);
-  KeyType type;
+  KeyType type{kRSA2048};
   std::string key;
 };
 
 struct SecondaryManifestReq : public SecondaryMessage {
   SecondaryManifestReq() { mes_type = kSecondaryMesManifestReqTag; }
+  virtual ~SecondaryManifestReq() {}
+  virtual bool operator==(const SecondaryMessage& other) const override { return SecondaryMessage::operator==(other); }
+
   friend asn1::Serializer& operator<<(asn1::Serializer& ser, const SecondaryManifestReq& data);
   friend asn1::Deserializer& operator>>(asn1::Deserializer& des, SecondaryManifestReq& data);
   virtual void serialize(asn1::Serializer& ser) const { ser << *this; }
@@ -63,71 +77,119 @@ struct SecondaryManifestReq : public SecondaryMessage {
 
 struct SecondaryManifestResp : public SecondaryMessage {
   SecondaryManifestResp() { mes_type = kSecondaryMesManifestRespTag; }
+  virtual ~SecondaryManifestResp() {}
   virtual void serialize(asn1::Serializer& ser) const { ser << *this; }
+  virtual bool operator==(const SecondaryMessage& other) const override {
+    const SecondaryManifestResp& other_ = dynamic_cast<const SecondaryManifestResp&>(other);
+    return SecondaryMessage::operator==(other) && format == other_.format && manifest == other_.manifest;
+  }
+
   friend asn1::Serializer& operator<<(asn1::Serializer& ser, const SecondaryManifestResp& data);
   friend asn1::Deserializer& operator>>(asn1::Deserializer& des, SecondaryManifestResp& data);
-  SerializationFormat format;
+  SerializationFormat format{kSerializationJson};
   std::string manifest;
 };
 
 struct SecondaryPutMetaReq : public SecondaryMessage {
   SecondaryPutMetaReq() { mes_type = kSecondaryMesPutMetaReqTag; }
+  virtual ~SecondaryPutMetaReq() {}
   virtual void serialize(asn1::Serializer& ser) const { ser << *this; }
+  virtual bool operator==(const SecondaryMessage& other) const override {
+    const SecondaryPutMetaReq& other_ = dynamic_cast<const SecondaryPutMetaReq&>(other);
+    return SecondaryMessage::operator==(other) && director_targets_format == other_.director_targets_format &&
+           director_targets == other_.director_targets && image_meta_present == other_.image_meta_present &&
+           (!image_meta_present ||
+            (image_snapshot_format == other_.image_snapshot_format && image_snapshot == other_.image_snapshot &&
+             image_timestamp_format == other_.image_timestamp_format && image_timestamp == other_.image_timestamp &&
+             image_targets_format == other_.image_targets_format && image_targets == other_.image_targets));
+  }
+
   friend asn1::Serializer& operator<<(asn1::Serializer& ser, const SecondaryPutMetaReq& data);
   friend asn1::Deserializer& operator>>(asn1::Deserializer& des, SecondaryPutMetaReq& data);
-  SerializationFormat director_targets_format;
+  SerializationFormat director_targets_format{kSerializationJson};
   std::string director_targets;
 
-  bool image_meta_present;
-  SerializationFormat image_snapshot_format;
+  bool image_meta_present{true};
+  SerializationFormat image_snapshot_format{kSerializationJson};
   std::string image_snapshot;
-  SerializationFormat image_timestamp_format;
+  SerializationFormat image_timestamp_format{kSerializationJson};
   std::string image_timestamp;
-  SerializationFormat image_targets_format;
+  SerializationFormat image_targets_format{kSerializationJson};
   std::string image_targets;
 };
 
 struct SecondaryPutMetaResp : public SecondaryMessage {
   SecondaryPutMetaResp() { mes_type = kSecondaryMesPutMetaRespTag; }
+  virtual ~SecondaryPutMetaResp() {}
   virtual void serialize(asn1::Serializer& ser) const { ser << *this; }
+  virtual bool operator==(const SecondaryMessage& other) const override {
+    const SecondaryPutMetaResp& other_ = dynamic_cast<const SecondaryPutMetaResp&>(other);
+    return SecondaryMessage::operator==(other) && result == other_.result;
+  }
+
   friend asn1::Serializer& operator<<(asn1::Serializer& ser, const SecondaryPutMetaResp& data);
   friend asn1::Deserializer& operator>>(asn1::Deserializer& des, SecondaryManifestResp& data);
-  bool result = true;
+  bool result{true};
 };
 
 struct SecondaryRootVersionReq : public SecondaryMessage {
   SecondaryRootVersionReq() { mes_type = kSecondaryMesRootVersionReqTag; }
+  virtual ~SecondaryRootVersionReq() {}
   virtual void serialize(asn1::Serializer& ser) const { ser << *this; }
+  virtual bool operator==(const SecondaryMessage& other) const override {
+    const SecondaryRootVersionReq& other_ = dynamic_cast<const SecondaryRootVersionReq&>(other);
+    return SecondaryMessage::operator==(other) && director == other_.director;
+  }
+
   friend asn1::Serializer& operator<<(asn1::Serializer& ser, const SecondaryRootVersionReq& data);
   friend asn1::Deserializer& operator>>(asn1::Deserializer& des, SecondaryRootVersionReq& data);
-  bool director;
+  bool director{true};
 };
 
 struct SecondaryRootVersionResp : public SecondaryMessage {
   SecondaryRootVersionResp() { mes_type = kSecondaryMesRootVersionRespTag; }
+  virtual ~SecondaryRootVersionResp() {}
   virtual void serialize(asn1::Serializer& ser) const { ser << *this; }
+  virtual bool operator==(const SecondaryMessage& other) const override {
+    const SecondaryRootVersionResp& other_ = dynamic_cast<const SecondaryRootVersionResp&>(other);
+    return SecondaryMessage::operator==(other) && version == other_.version;
+  }
+
   friend asn1::Serializer& operator<<(asn1::Serializer& ser, const SecondaryRootVersionResp& data);
   friend asn1::Deserializer& operator>>(asn1::Deserializer& des, SecondaryRootVersionResp& data);
-  int32_t version;
+  int32_t version{-1};
 };
 
 struct SecondaryPutRootReq : public SecondaryMessage {
   SecondaryPutRootReq() { mes_type = kSecondaryMesPutRootReqTag; }
+  virtual ~SecondaryPutRootReq() {}
   virtual void serialize(asn1::Serializer& ser) const { ser << *this; }
+  virtual bool operator==(const SecondaryMessage& other) const override {
+    const SecondaryPutRootReq& other_ = dynamic_cast<const SecondaryPutRootReq&>(other);
+    return SecondaryMessage::operator==(other) && director == other_.director && root_format == other_.root_format &&
+           root == other_.root;
+  }
+
   friend asn1::Serializer& operator<<(asn1::Serializer& ser, const SecondaryPutRootReq& data);
   friend asn1::Deserializer& operator>>(asn1::Deserializer& des, SecondaryPutRootReq& data);
-  bool director;
+  bool director{true};
 
-  SerializationFormat root_format;
+  SerializationFormat root_format{kSerializationJson};
   std::string root;
 };
 
 struct SecondaryPutRootResp : public SecondaryMessage {
   SecondaryPutRootResp() { mes_type = kSecondaryMesPutRootRespTag; }
+  virtual ~SecondaryPutRootResp() {}
   virtual void serialize(asn1::Serializer& ser) const { ser << *this; }
+  virtual bool operator==(const SecondaryMessage& other) const override {
+    const SecondaryPutRootResp& other_ = dynamic_cast<const SecondaryPutRootResp&>(other);
+    return SecondaryMessage::operator==(other) && result == other_.result;
+  }
+
   friend asn1::Serializer& operator<<(asn1::Serializer& ser, const SecondaryPutRootResp& data);
   friend asn1::Deserializer& operator>>(asn1::Deserializer& des, SecondaryPutRootResp& data);
-  bool result = true;
+  bool result{true};
 };
 
 struct SecondarySendFirmwareOstreeReq : public SecondaryMessage {
@@ -143,7 +205,13 @@ struct SecondarySendFirmwareOstreeReq : public SecondaryMessage {
 
 struct SecondarySendFirmwareReq : public SecondaryMessage {
   SecondarySendFirmwareReq() { mes_type = kSecondaryMesSendFirmwareReqTag; }
+  virtual ~SecondarySendFirmwareReq() {}
   virtual void serialize(asn1::Serializer& ser) const { ser << *this; }
+  virtual bool operator==(const SecondaryMessage& other) const override {
+    const SecondarySendFirmwareReq& other_ = dynamic_cast<const SecondarySendFirmwareReq&>(other);
+    return SecondaryMessage::operator==(other) && firmware == other_.firmware;
+  }
+
   friend asn1::Serializer& operator<<(asn1::Serializer& ser, const SecondarySendFirmwareReq& data);
   friend asn1::Deserializer& operator>>(asn1::Deserializer& des, SecondarySendFirmwareReq& data);
 
@@ -152,10 +220,16 @@ struct SecondarySendFirmwareReq : public SecondaryMessage {
 
 struct SecondarySendFirmwareResp : public SecondaryMessage {
   SecondarySendFirmwareResp() { mes_type = kSecondaryMesSendFirmwareRespTag; }
+  virtual ~SecondarySendFirmwareResp() {}
   virtual void serialize(asn1::Serializer& ser) const { ser << *this; }
+  virtual bool operator==(const SecondaryMessage& other) const override {
+    const SecondarySendFirmwareResp& other_ = dynamic_cast<const SecondarySendFirmwareResp&>(other);
+    return SecondaryMessage::operator==(other) && result == other_.result;
+  }
+
   friend asn1::Serializer& operator<<(asn1::Serializer& ser, const SecondarySendFirmwareResp& data);
   friend asn1::Deserializer& operator>>(asn1::Deserializer& des, SecondarySendFirmwareResp& data);
-  bool result = true;
+  bool result{true};
 };
 
 struct SecondaryPacket {

--- a/src/asn1-cer.cc
+++ b/src/asn1-cer.cc
@@ -132,6 +132,7 @@ uint8_t cer_decode_token(const std::string& ber, int32_t* endpos, int32_t* int_p
           return kAsn1EndSequence;
 
       case kAsn1Integer:
+      case kAsn1Boolean:
       case kAsn1Enum: {
         if (constructed || token_len == -1) return kUnknown;
 

--- a/src/asn1-cerstream.cc
+++ b/src/asn1-cerstream.cc
@@ -1,6 +1,4 @@
 #include "asn1-cerstream.h"
-#include <iomanip>
-#include <iostream>
 
 namespace asn1 {
 
@@ -122,8 +120,6 @@ Deserializer& Deserializer::operator>>(const Token& tok) {
       int32_t cons_len = seq_consumed.top();
       seq_lengths.pop();
       seq_consumed.pop();
-      std::cout << "ENDSEQ LEN: " << std::dec << len << std::endl;
-      std::cout << "EXPECTED LEN: " << std::dec << cons_len << std::endl;
       if (len >= 0) {
         if (cons_len != len) throw deserialization_error();
       } else {
@@ -188,16 +184,14 @@ Deserializer& Deserializer::operator>>(const Token& tok) {
     }
 
     case Token::peekexpl_tok: {
-      std::cout << "BEFORE DECODE" << std::endl;
       uint8_t full_tag = cer_decode_token(data, &endpos, &seq_len, nullptr);
-      std::cout << "AFTER DECODE " << std::setfill('0') << std::setw(2) << std::hex << (((int)full_tag) & 0xFF)
-                << std::dec << std::endl;
-      std::cout << "SEQ_LEN " << seq_len << std::endl;
       if (full_tag == kUnknown) throw deserialization_error();
+
       uint8_t* out_tag = dynamic_cast<const PeekExplicitToken&>(tok).tag;
       ASN1_Class* out_tag_class = dynamic_cast<const PeekExplicitToken&>(tok).tag_class;
       if (out_tag) *out_tag = full_tag & 0x1F;
       if (out_tag_class) *out_tag_class = (ASN1_Class)(full_tag & 0xC0);
+
       data = data.substr(endpos);
       seq_lengths.push(seq_len);
       seq_consumed.push(0);

--- a/src/asn1-cerstream.cc
+++ b/src/asn1-cerstream.cc
@@ -70,12 +70,13 @@ Deserializer& Deserializer::operator>>(std::string& val) {
 
 Deserializer& Deserializer::operator>>(ASN1_UniversalTag tag) {
   int32_t endpos = 0;
-  if (opt_count && !opt_present) return *this;
+  if (opt_count && !opt_present && !opt_first) return *this;
 
   if (tag != cer_decode_token(data, &endpos, &int_param, &string_param)) {
     // failed to read first tag from OPTIONAL => OPTIONAL not present
     if (opt_count && opt_first) {
       opt_present = false;
+      opt_first = false;
       return *this;
     }
 
@@ -97,7 +98,7 @@ Deserializer& Deserializer::operator>>(const Token& tok) {
   int32_t endpos;
   int32_t seq_len;
 
-  if (opt_count && !opt_present) {
+  if (opt_count && !opt_present && !opt_first) {
     if (tok.type == Token::endopt_tok) {
       --opt_count;
       bool* result = dynamic_cast<const EndoptToken&>(tok).result_p;
@@ -108,7 +109,20 @@ Deserializer& Deserializer::operator>>(const Token& tok) {
 
   switch (tok.type) {
     case Token::seq_tok:
-      if (kAsn1Sequence != cer_decode_token(data, &endpos, &seq_len, nullptr)) throw deserialization_error();
+      if (kAsn1Sequence != cer_decode_token(data, &endpos, &seq_len, nullptr)) {
+        if (opt_count && opt_first) {
+          opt_present = false;
+          opt_first = false;
+          break;
+        }
+
+        throw deserialization_error();
+      }
+      if (opt_count && opt_first) {
+        opt_present = true;
+        opt_first = false;
+      }
+
       data = data.substr(endpos);
       seq_lengths.push(seq_len);
       seq_consumed.push(0);
@@ -176,7 +190,19 @@ Deserializer& Deserializer::operator>>(const Token& tok) {
     case Token::expl_tok: {
       uint8_t full_tag =
           dynamic_cast<const ExplicitToken&>(tok).tag | dynamic_cast<const ExplicitToken&>(tok).tag_class;
-      if (full_tag != cer_decode_token(data, &endpos, &seq_len, nullptr)) throw deserialization_error();
+      if (full_tag != cer_decode_token(data, &endpos, &seq_len, nullptr)) {
+        if (opt_count && opt_first) {
+          opt_present = false;
+          opt_first = false;
+          break;
+        }
+        throw deserialization_error();
+      }
+      if (opt_count && opt_first) {
+        opt_present = true;
+        opt_first = false;
+      }
+
       data = data.substr(endpos);
       seq_lengths.push(seq_len);
       seq_consumed.push(0);
@@ -186,6 +212,10 @@ Deserializer& Deserializer::operator>>(const Token& tok) {
     case Token::peekexpl_tok: {
       uint8_t full_tag = cer_decode_token(data, &endpos, &seq_len, nullptr);
       if (full_tag == kUnknown) throw deserialization_error();
+      if (opt_count && opt_first) {
+        opt_present = true;
+        opt_first = false;
+      }
 
       uint8_t* out_tag = dynamic_cast<const PeekExplicitToken&>(tok).tag;
       ASN1_Class* out_tag_class = dynamic_cast<const PeekExplicitToken&>(tok).tag_class;

--- a/src/asn1-cerstream.h
+++ b/src/asn1-cerstream.h
@@ -122,11 +122,7 @@ Serializer& operator<<(Serializer& ser, ImplicitC<Tag, T> imp) {
 
 class Deserializer {
  public:
-  Deserializer(const std::string& d) {
-    data = d;
-    opt_count = 0;
-    opt_first = opt_present = false;
-  };
+  Deserializer(const std::string& d) : data(d){};
 
   Deserializer& operator>>(int32_t& val);
   Deserializer& operator>>(bool& val);
@@ -140,12 +136,12 @@ class Deserializer {
   std::string data;
   std::stack<int32_t> seq_lengths;
   std::stack<int32_t> seq_consumed;
-  int32_t int_param;
+  int32_t int_param{0};
   std::string string_param;
 
-  int32_t opt_count;  // counter of tested asn1::optional
-  bool opt_first;
-  bool opt_present;
+  int32_t opt_count{0};  // counter of tested asn1::optional
+  bool opt_first{false};
+  bool opt_present{false};
 };
 
 template <ASN1_UniversalTag Tag, typename T>

--- a/src/config.cc
+++ b/src/config.cc
@@ -93,7 +93,7 @@ void NetworkConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt
   CopyFromConfig(ipdiscovery_host, "ipdiscovery_host", boost::log::trivial::trace, pt);
   CopyFromConfig(ipdiscovery_port, "ipdiscovery_port", boost::log::trivial::trace, pt);
   CopyFromConfig(ipdiscovery_wait_seconds, "ipdiscovery_wait_seconds", boost::log::trivial::trace, pt);
-  CopyFromConfig(network.ipuptane_port, "network.ipuptane_port", boost::log::trivial::trace, pt);
+  CopyFromConfig(ipuptane_port, "network.ipuptane_port", boost::log::trivial::trace, pt);
 }
 
 void NetworkConfig::writeToStream(std::ostream& out_stream) const {
@@ -110,7 +110,7 @@ void NetworkConfig::writeToStream(std::ostream& out_stream) const {
   writeOption(out_stream, ipdiscovery_host, "ipdiscovery_host");
   writeOption(out_stream, ipdiscovery_port, "ipdiscovery_port");
   writeOption(out_stream, ipdiscovery_wait_seconds, "ipdiscovery_wait_seconds");
-  writeOption(sink, network.ipuptane_port, "ipuptane_port");
+  writeOption(out_stream, ipuptane_port, "ipuptane_port");
 }
 
 void TlsConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt) {

--- a/src/config.cc
+++ b/src/config.cc
@@ -205,6 +205,12 @@ void UptaneConfig::writeToStream(std::ostream& out_stream) const {
   writeOption(out_stream, key_type, "key_type");
 }
 
+void DiscoveryConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt) {
+  CopyFromConfig(ipuptane, "ipuptane", boost::log::trivial::trace, pt);
+}
+
+void DiscoveryConfig::writeToStream(std::ostream& out_stream) const { writeOption(out_stream, ipuptane, "ipuptane"); }
+
 void PackageConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt) {
   std::string pm_type = "ostree";
   CopyFromConfig(pm_type, "type", boost::log::trivial::warning, pt);
@@ -306,6 +312,7 @@ void Config::updateFromPropertyTree(const boost::property_tree::ptree& pt) {
   CopySubtreeFromConfig(tls, "tls", pt);
   CopySubtreeFromConfig(provision, "provision", pt);
   CopySubtreeFromConfig(uptane, "uptane", pt);
+  CopySubtreeFromConfig(discovery, "discovery", pt);
   CopySubtreeFromConfig(pacman, "pacman", pt);
   CopySubtreeFromConfig(storage, "storage", pt);
   CopySubtreeFromConfig(import, "import", pt);
@@ -477,6 +484,7 @@ void Config::writeToFile(const boost::filesystem::path& filename) const {
   WriteSectionToStream(tls, "tls", sink);
   WriteSectionToStream(provision, "provision", sink);
   WriteSectionToStream(uptane, "uptane", sink);
+  WriteSectionToStream(discovery, "discovery", sink);
   WriteSectionToStream(pacman, "pacman", sink);
   WriteSectionToStream(storage, "storage", sink);
   WriteSectionToStream(import, "import", sink);

--- a/src/config.cc
+++ b/src/config.cc
@@ -93,6 +93,7 @@ void NetworkConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt
   CopyFromConfig(ipdiscovery_host, "ipdiscovery_host", boost::log::trivial::trace, pt);
   CopyFromConfig(ipdiscovery_port, "ipdiscovery_port", boost::log::trivial::trace, pt);
   CopyFromConfig(ipdiscovery_wait_seconds, "ipdiscovery_wait_seconds", boost::log::trivial::trace, pt);
+  CopyFromConfig(network.ipuptane_port, "network.ipuptane_port", boost::log::trivial::trace, pt);
 }
 
 void NetworkConfig::writeToStream(std::ostream& out_stream) const {
@@ -109,6 +110,7 @@ void NetworkConfig::writeToStream(std::ostream& out_stream) const {
   writeOption(out_stream, ipdiscovery_host, "ipdiscovery_host");
   writeOption(out_stream, ipdiscovery_port, "ipdiscovery_port");
   writeOption(out_stream, ipdiscovery_wait_seconds, "ipdiscovery_wait_seconds");
+  writeOption(sink, network.ipuptane_port, "ipuptane_port");
 }
 
 void TlsConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt) {
@@ -362,8 +364,8 @@ void Config::readSecondaryConfigs(const std::vector<boost::filesystem::path>& sc
     } else if (stype == "legacy") {
       LOG_ERROR << "Legacy secondaries should be initialized with --legacy-interface.";
       continue;
-    } else if (stype == "uptane") {
-      sconfig.secondary_type = Uptane::kUptane;
+    } else if (stype == "ip_uptane") {
+      sconfig.secondary_type = Uptane::kIpUptane;
     } else {
       LOG_ERROR << "Unrecognized secondary type: " << stype;
       continue;

--- a/src/config.h
+++ b/src/config.h
@@ -42,6 +42,7 @@ struct NetworkConfig {
   std::string ipdiscovery_host{"127.0.0.1"};
   unsigned int ipdiscovery_port{12345};
   unsigned int ipdiscovery_wait_seconds{10};
+  unsigned int ipuptane_port{12345};
 
   void updateFromPropertyTree(const boost::property_tree::ptree& pt);
   void writeToStream(std::ostream& out_stream) const;

--- a/src/config.h
+++ b/src/config.h
@@ -40,9 +40,9 @@ struct NetworkConfig {
   std::vector<std::string> socket_events{"DownloadComplete", "DownloadFailed"};
 
   std::string ipdiscovery_host{"127.0.0.1"};
-  unsigned int ipdiscovery_port{12345};
-  unsigned int ipdiscovery_wait_seconds{10};
-  unsigned int ipuptane_port{12345};
+  in_port_t ipdiscovery_port{12345};
+  uint32_t ipdiscovery_wait_seconds{10};
+  in_port_t ipuptane_port{12345};
 
   void updateFromPropertyTree(const boost::property_tree::ptree& pt);
   void writeToStream(std::ostream& out_stream) const;
@@ -91,6 +91,13 @@ struct UptaneConfig {
   void writeToStream(std::ostream& out_stream) const;
 };
 
+struct DiscoveryConfig {
+  bool ipuptane{false};
+
+  void updateFromPropertyTree(const boost::property_tree::ptree& pt);
+  void writeToStream(std::ostream& out_stream) const;
+};
+
 struct PackageConfig {
   PackageManager type{kOstree};
   std::string os;
@@ -121,6 +128,7 @@ class Config {
   TlsConfig tls;
   ProvisionConfig provision;
   UptaneConfig uptane;
+  DiscoveryConfig discovery;
   PackageConfig pacman;
   StorageConfig storage;
   ImportConfig import;

--- a/src/ipsecondarydiscovery.h
+++ b/src/ipsecondarydiscovery.h
@@ -5,6 +5,7 @@
 
 #include "config.h"
 #include "uptane/secondaryconfig.h"
+#include "utils.h"
 
 const int AKT_DISCOVERY_REQ = 0x00;
 const int AKT_DISCOVERY_RESP = 0x01;
@@ -12,14 +13,13 @@ const int AKT_DISCOVERY_RESP = 0x01;
 class IpSecondaryDiscovery {
  public:
   IpSecondaryDiscovery(const NetworkConfig &config) : config_(config){};
-  ~IpSecondaryDiscovery() { close(socket_fd); }
   std::vector<Uptane::SecondaryConfig> discover();
   std::vector<Uptane::SecondaryConfig> waitDevices();
   bool sendRequest();
 
  private:
   NetworkConfig config_;
-  int socket_fd;
+  SocketHandle socket_hdl;
 };
 
 #endif  // IPSECONDARYDISCOVERY_H_

--- a/src/ipuptaneconnection.cc
+++ b/src/ipuptaneconnection.cc
@@ -55,7 +55,7 @@ void IpUptaneConnection::open_socket() {
   LOG_INFO << "Listening on port " << listening_port();
 }
 
-IpUptaneConnection::IpUptaneConnection(int in_port) : in_port_(in_port) {
+IpUptaneConnection::IpUptaneConnection(in_port_t in_port) : in_port_(in_port) {
   open_socket();
 
   in_thread_ = std::thread([this]() {

--- a/src/ipuptaneconnection.h
+++ b/src/ipuptaneconnection.h
@@ -17,7 +17,8 @@ class IpUptaneConnection {
 
   SecondaryPacket::ChanType in_channel_;
   SecondaryPacket::ChanType out_channel_;
-  int listening_port() const;
+  in_port_t listening_port() const;
+  sockaddr_storage listening_address() const;
   void stop();
 
  private:
@@ -25,7 +26,8 @@ class IpUptaneConnection {
   void open_socket();
   SocketHandle socket_hdl_;
   std::thread in_thread_;
-  int in_port_;
+  std::thread out_thread_;
+  in_port_t in_port_;
 };
 
 #endif  // IP_UPTANE_CONNECTION_H_

--- a/src/ipuptaneconnection.h
+++ b/src/ipuptaneconnection.h
@@ -10,7 +10,7 @@
 
 class IpUptaneConnection {
  public:
-  IpUptaneConnection(int in_port);
+  IpUptaneConnection(in_port_t in_port);
   ~IpUptaneConnection();
   IpUptaneConnection(const IpUptaneConnection&) = delete;
   IpUptaneConnection& operator=(const IpUptaneConnection&) = delete;

--- a/src/ipuptaneconnection.h
+++ b/src/ipuptaneconnection.h
@@ -10,7 +10,7 @@
 
 class IpUptaneConnection {
  public:
-  IpUptaneConnection(in_port_t in_port);
+  IpUptaneConnection(in_port_t in_port, struct in6_addr = IN6ADDR_ANY_INIT);
   ~IpUptaneConnection();
   IpUptaneConnection(const IpUptaneConnection&) = delete;
   IpUptaneConnection& operator=(const IpUptaneConnection&) = delete;
@@ -28,6 +28,7 @@ class IpUptaneConnection {
   std::thread in_thread_;
   std::thread out_thread_;
   in_port_t in_port_;
+  struct in6_addr in_addr_;
 };
 
 #endif  // IP_UPTANE_CONNECTION_H_

--- a/src/ipuptaneconnectionsplitter.cc
+++ b/src/ipuptaneconnectionsplitter.cc
@@ -1,0 +1,22 @@
+#include "ipuptaneconnectionsplitter.h"
+#include "uptane/ipuptanesecondary.h"
+
+IpUptaneConnectionSplitter::IpUptaneConnectionSplitter(IpUptaneConnection& conn) : connection(conn) {
+  split_thread = std::thread([this]() {
+    std::shared_ptr<SecondaryPacket> pack;
+    while (connection.in_channel_ >> pack) {
+      auto sec = secondaries.find(pack->peer_addr);
+      if (sec != secondaries.end()) sec->second->pushMessage(pack);
+    }
+  });
+}
+
+void IpUptaneConnectionSplitter::registerSecondary(Uptane::IpUptaneSecondary& sec) {
+  secondaries[sec.getAddr()] = &sec;
+}
+
+void IpUptaneConnectionSplitter::send(std::shared_ptr<SecondaryPacket> pack) { connection.out_channel_ << pack; }
+
+bool operator<(const sockaddr_storage& left, const sockaddr_storage right) {
+  return memcmp(&left, &right, sizeof(sockaddr_storage)) < 0;
+}

--- a/src/ipuptaneconnectionsplitter.cc
+++ b/src/ipuptaneconnectionsplitter.cc
@@ -4,19 +4,30 @@
 IpUptaneConnectionSplitter::IpUptaneConnectionSplitter(IpUptaneConnection& conn) : connection(conn) {
   split_thread = std::thread([this]() {
     std::shared_ptr<SecondaryPacket> pack;
-    while (connection.in_channel_ >> pack) {
+    while (!stopped && connection.in_channel_ >> pack) {
       auto sec = secondaries.find(pack->peer_addr);
-      if (sec != secondaries.end()) sec->second->pushMessage(pack);
+      if (sec != secondaries.end()) {
+        sec->second->pushMessage(pack);
+      }
     }
   });
 }
 
 void IpUptaneConnectionSplitter::registerSecondary(Uptane::IpUptaneSecondary& sec) {
   secondaries[sec.getAddr()] = &sec;
+  sec.connect(this);
 }
 
 void IpUptaneConnectionSplitter::send(std::shared_ptr<SecondaryPacket> pack) { connection.out_channel_ << pack; }
 
-bool operator<(const sockaddr_storage& left, const sockaddr_storage right) {
-  return memcmp(&left, &right, sizeof(sockaddr_storage)) < 0;
+bool operator<(const sockaddr_storage& left, const sockaddr_storage& right) {
+  if (left.ss_family == AF_INET) {
+    throw std::runtime_error("IPv4 addresses are not supported");
+  } else {
+    const unsigned char* left_addr = reinterpret_cast<const sockaddr_in6*>(&left)->sin6_addr.s6_addr;
+    const unsigned char* right_addr = reinterpret_cast<const sockaddr_in6*>(&right)->sin6_addr.s6_addr;
+    int res = memcmp(left_addr, right_addr, 16);
+
+    return (res < 0);
+  }
 }

--- a/src/ipuptaneconnectionsplitter.h
+++ b/src/ipuptaneconnectionsplitter.h
@@ -1,0 +1,26 @@
+#ifndef IP_UPTANE_CONNECTION_SPLITTER_H_
+#define IP_UPTANE_CONNECTION_SPLITTER_H_
+
+#include <map>
+#include <thread>
+#include "ipuptaneconnection.h"
+
+namespace Uptane {
+class IpUptaneSecondary;
+}
+
+bool operator<(const sockaddr_storage& left, const sockaddr_storage right);
+
+class IpUptaneConnectionSplitter {
+ public:
+  IpUptaneConnectionSplitter(IpUptaneConnection& conn);
+  void registerSecondary(Uptane::IpUptaneSecondary& sec);
+  void send(std::shared_ptr<SecondaryPacket> pack);
+
+ private:
+  std::map<sockaddr_storage, Uptane::IpUptaneSecondary*> secondaries;
+  IpUptaneConnection& connection;
+
+  std::thread split_thread;
+};
+#endif  // IP_UPTANE_CONNECTION_SPLITTER_H_

--- a/src/ipuptaneconnectionsplitter.h
+++ b/src/ipuptaneconnectionsplitter.h
@@ -9,11 +9,15 @@ namespace Uptane {
 class IpUptaneSecondary;
 }
 
-bool operator<(const sockaddr_storage& left, const sockaddr_storage right);
+bool operator<(const sockaddr_storage& left, const sockaddr_storage& right);
 
 class IpUptaneConnectionSplitter {
  public:
   IpUptaneConnectionSplitter(IpUptaneConnection& conn);
+  ~IpUptaneConnectionSplitter() {
+    stopped = true;
+    split_thread.join();
+  }
   void registerSecondary(Uptane::IpUptaneSecondary& sec);
   void send(std::shared_ptr<SecondaryPacket> pack);
 
@@ -22,5 +26,6 @@ class IpUptaneConnectionSplitter {
   IpUptaneConnection& connection;
 
   std::thread split_thread;
+  bool stopped{false};
 };
 #endif  // IP_UPTANE_CONNECTION_SPLITTER_H_

--- a/src/sotauptaneclient.h
+++ b/src/sotauptaneclient.h
@@ -47,9 +47,8 @@ class SotaUptaneClient {
   HttpInterface &http;
   int last_targets_version;
   Json::Value operation_result;
-  IpSecondaryDiscovery ip_uptane_discovery;
-  IpUptaneConnection ip_uptane_connection;
-  IpUptaneConnectionSplitter ip_uptane_splitter;
+  std::unique_ptr<IpUptaneConnection> ip_uptane_connection;
+  std::unique_ptr<IpUptaneConnectionSplitter> ip_uptane_splitter;
 };
 
 class SerialCompare {

--- a/src/sotauptaneclient.h
+++ b/src/sotauptaneclient.h
@@ -1,4 +1,5 @@
 #include <map>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -9,13 +10,16 @@
 #include "events.h"
 #include "httpclient.h"
 #include "invstorage.h"
+#include "ipsecondarydiscovery.h"
+#include "ipuptaneconnection.h"
+#include "ipuptaneconnectionsplitter.h"
 #include "packagemanagerinterface.h"
 #include "uptane/secondaryinterface.h"
 #include "uptane/uptanerepository.h"
 
 class SotaUptaneClient {
  public:
-  SotaUptaneClient(const Config &config_in, event::Channel *events_channel_in, Uptane::Repository &repo,
+  SotaUptaneClient(Config &config_in, event::Channel *events_channel_in, Uptane::Repository &repo,
                    const boost::shared_ptr<INvStorage> storage_in, HttpInterface &http_client);
   void runForever(command::Channel *commands_channel);
   Json::Value AssembleManifest();
@@ -35,7 +39,7 @@ class SotaUptaneClient {
   void verifySecondaries();
   void sendMetadataToEcus(std::vector<Uptane::Target> targets);
   void sendImagesToEcus(std::vector<Uptane::Target> targets);
-  const Config &config;
+  Config &config;
   event::Channel *events_channel;
   Uptane::Repository &uptane_repo;
   const boost::shared_ptr<INvStorage> storage;
@@ -43,6 +47,9 @@ class SotaUptaneClient {
   HttpInterface &http;
   int last_targets_version;
   Json::Value operation_result;
+  IpSecondaryDiscovery ip_uptane_discovery;
+  IpUptaneConnection ip_uptane_connection;
+  IpUptaneConnectionSplitter ip_uptane_splitter;
 };
 
 class SerialCompare {

--- a/src/uptane/ipuptanesecondary.cc
+++ b/src/uptane/ipuptanesecondary.cc
@@ -1,0 +1,91 @@
+#include "ipuptanesecondary.h"
+
+namespace Uptane {
+
+bool IpUptaneSecondary::sendRecv(std::unique_ptr<SecondaryMessage> mes, std::shared_ptr<SecondaryPacket>& resp,
+                                 std::chrono::milliseconds to) {
+  pending_messages.clear();
+  std::shared_ptr<SecondaryPacket> pkt{new SecondaryPacket{sconfig.ip_addr, std::move(mes)}};
+  connection->send(pkt);
+
+  pending_messages.setTimeout(to);
+
+  return pending_messages >> resp;
+}
+
+std::pair<KeyType, std::string> IpUptaneSecondary::getPublicKey() {
+  std::shared_ptr<SecondaryPacket> resp;
+
+  if (!sendRecv(std::unique_ptr<SecondaryPublicKeyReq>(new SecondaryPublicKeyReq{}), resp) ||
+      (resp->msg->mes_type != kSecondaryMesPublicKeyRespTag))
+    return std::make_pair(kUnknownKey, "");
+
+  SecondaryPublicKeyResp& pkey_resp = dynamic_cast<SecondaryPublicKeyResp&>(*resp->msg);
+
+  return std::make_pair(pkey_resp.type, pkey_resp.key);
+}
+
+bool IpUptaneSecondary::putMetadata(const MetaPack& meta_pack) {
+  std::shared_ptr<SecondaryPacket> resp;
+  std::unique_ptr<SecondaryPutMetaReq> req{new SecondaryPutMetaReq()};
+
+  req->image_meta_present = true;
+  req->director_targets_format = kSerializationJson;
+  req->director_targets = Utils::jsonToStr(meta_pack.director_targets.original());
+  req->image_snapshot_format = kSerializationJson;
+  req->image_snapshot = Utils::jsonToStr(meta_pack.image_snapshot.original());
+  req->image_timestamp_format = kSerializationJson;
+  req->image_timestamp = Utils::jsonToStr(meta_pack.image_timestamp.original());
+  req->image_targets_format = kSerializationJson;
+  req->image_targets = Utils::jsonToStr(meta_pack.image_targets.original());
+
+  return sendRecv(std::move(req), resp) && (resp->msg->mes_type != kSecondaryMesPutMetaRespTag) &&
+         dynamic_cast<SecondaryPutMetaResp&>(*resp->msg).result;
+}
+
+int32_t IpUptaneSecondary::getRootVersion(const bool director) {
+  std::unique_ptr<SecondaryRootVersionReq> req{new SecondaryRootVersionReq()};
+  req->director = director;
+
+  std::shared_ptr<SecondaryPacket> resp;
+
+  if (!sendRecv(std::move(req), resp) || (resp->msg->mes_type != kSecondaryMesRootVersionRespTag)) return -1;
+
+  return dynamic_cast<SecondaryRootVersionResp&>(*resp->msg).version;
+}
+
+bool IpUptaneSecondary::putRoot(Uptane::Root root, const bool director) {
+  std::shared_ptr<SecondaryPacket> resp;
+
+  std::unique_ptr<SecondaryPutRootReq> req{new SecondaryPutRootReq()};
+  req->root_format = kSerializationJson;
+  req->root = Utils::jsonToStr(root.toJson());
+  req->director = director;
+
+  return sendRecv(std::move(req), resp) && (resp->msg->mes_type != kSecondaryMesPutRootRespTag) &&
+         dynamic_cast<SecondaryPutRootResp&>(*resp->msg).result;
+}
+
+bool IpUptaneSecondary::sendFirmware(const std::string& data) {
+  std::shared_ptr<SecondaryPacket> resp;
+  std::unique_ptr<SecondarySendFirmwareReq> req{new SecondarySendFirmwareReq()};
+  req->firmware = data;
+
+  return sendRecv(std::move(req), resp) && (resp->msg->mes_type != kSecondaryMesSendFirmwareRespTag) &&
+         dynamic_cast<SecondarySendFirmwareResp&>(*resp->msg).result;
+}
+
+Json::Value IpUptaneSecondary::getManifest() {
+  std::shared_ptr<SecondaryPacket> resp;
+
+  if (!sendRecv(std::unique_ptr<SecondaryManifestReq>(new SecondaryManifestReq{}), resp) ||
+      (resp->msg->mes_type != kSecondaryMesManifestRespTag))
+    return Json::Value();
+
+  SecondaryManifestResp& man_resp = dynamic_cast<SecondaryManifestResp&>(*resp->msg);
+
+  if (man_resp.format != kSerializationJson) return Json::Value();
+
+  return Utils::parseJSON(man_resp.manifest);
+}
+}  // namespace Uptane

--- a/src/uptane/ipuptanesecondary.h
+++ b/src/uptane/ipuptanesecondary.h
@@ -1,0 +1,36 @@
+#ifndef UPTANE_IPUPTANESECONDARY_H_
+#define UPTANE_IPUPTANESECONDARY_H_
+
+#include <chrono>
+#include "aktualizr_secondary_ipc.h"
+#include "ipuptaneconnectionsplitter.h"
+#include "uptane/secondaryinterface.h"
+
+namespace Uptane {
+class IpUptaneSecondary : public SecondaryInterface {
+ public:
+  IpUptaneSecondary(const SecondaryConfig& conf) : SecondaryInterface(conf), connection(nullptr) {}
+
+  // SecondaryInterface implementation
+  std::pair<KeyType, std::string> getPublicKey() override;
+  bool putMetadata(const MetaPack& meta_pack) override;
+  int32_t getRootVersion(const bool director) override;
+  bool putRoot(Uptane::Root root, const bool director) override;
+  bool sendFirmware(const std::string& data) override;
+  Json::Value getManifest() override;
+
+  // extra methods
+  void pushMessage(std::shared_ptr<SecondaryPacket> pack) { pending_messages << pack; }
+  sockaddr_storage getAddr() { return sconfig.ip_addr; }
+  void connect(IpUptaneConnectionSplitter* conn) { connection = conn; }
+
+ private:
+  bool sendRecv(std::unique_ptr<SecondaryMessage> mes, std::shared_ptr<SecondaryPacket>& resp,
+                std::chrono::milliseconds to = std::chrono::milliseconds(1000));
+  SecondaryPacket::ChanType pending_messages;
+  IpUptaneConnectionSplitter* connection;
+};
+
+}  // namespace Uptane
+
+#endif  // UPTANE_IPUPTANESECONDARY_H_

--- a/src/uptane/secondaryconfig.h
+++ b/src/uptane/secondaryconfig.h
@@ -3,17 +3,19 @@
 
 #include <string>
 
+#include <sys/socket.h>
 #include <boost/filesystem.hpp>
 #include "types.h"
 
 namespace Uptane {
 
 enum SecondaryType {
-  kVirtual,  // Virtual secondary (in-process fake implementation).
-  kLegacy,   // legacy non-UPTANE secondary. All the UPTANE metadata is managed locally. All commands are sent to an
-             // external firmware loader via shell.
+  kVirtual,   // Virtual secondary (in-process fake implementation).
+  kLegacy,    // legacy non-UPTANE secondary. All the UPTANE metadata is managed locally. All commands are sent to an
+              // external firmware loader via shell.
   kOpcua,    // Use OPC-UA protocol to interact with secondary
-  kUptane,   // UPTANE-compliant secondary (UDS, DoIP, et cetera).
+  kIpUptane,  // Custom Uptane protocol over TCP/IP network
+  kVirtualUptane,  // Partial UPTANE secondary implemented inside primary
 };
 
 class SecondaryConfig {
@@ -34,6 +36,8 @@ class SecondaryConfig {
   boost::filesystem::path target_name_path;  // kVirtual, kLegacy
 
   boost::filesystem::path flasher;  // kLegacy
+
+  sockaddr_storage ip_addr;  // kIpUptane
 };
 }  // namespace Uptane
 

--- a/src/uptane/secondaryconfig.h
+++ b/src/uptane/secondaryconfig.h
@@ -13,7 +13,7 @@ enum SecondaryType {
   kVirtual,   // Virtual secondary (in-process fake implementation).
   kLegacy,    // legacy non-UPTANE secondary. All the UPTANE metadata is managed locally. All commands are sent to an
               // external firmware loader via shell.
-  kOpcua,    // Use OPC-UA protocol to interact with secondary
+  kOpcua,     // Use OPC-UA protocol to interact with secondary
   kIpUptane,  // Custom Uptane protocol over TCP/IP network
   kVirtualUptane,  // Partial UPTANE secondary implemented inside primary
 };

--- a/src/uptane/secondaryfactory.h
+++ b/src/uptane/secondaryfactory.h
@@ -5,6 +5,7 @@
 #include <boost/shared_ptr.hpp>
 
 #include "logging.h"
+#include "uptane/ipuptanesecondary.h"
 #include "uptane/legacysecondary.h"
 #include "uptane/opcuasecondary.h"
 #include "uptane/secondaryconfig.h"
@@ -23,9 +24,8 @@ class SecondaryFactory {
       case kLegacy:
         return boost::make_shared<LegacySecondary>(sconfig);
         break;
-      case kUptane:
-        LOG_ERROR << "Uptane secondaries are not currently supported.";
-        return boost::shared_ptr<SecondaryInterface>();  // NULL-equivalent
+      case kIpUptane:
+        return boost::make_shared<IpUptaneSecondary>(sconfig);
       case kOpcua:
 #ifdef OPCUA_SECONDARY_ENABLED
         return boost::make_shared<OpcuaSecondary>(sconfig);
@@ -33,7 +33,6 @@ class SecondaryFactory {
         LOG_ERROR << "Built with no OPC-UA secondary support";
         return boost::shared_ptr<SecondaryInterface>();  // NULL-equivalent
 #endif
-        break;
       default:
         LOG_ERROR << "Unrecognized secondary type: " << sconfig.secondary_type;
         return boost::shared_ptr<SecondaryInterface>();  // NULL-equivalent

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -536,3 +536,10 @@ boost::filesystem::path TemporaryDirectory::operator/(const boost::filesystem::p
 }
 
 std::string TemporaryDirectory::PathString() const { return Path().string(); }
+
+void Utils::setSocketPort(sockaddr_storage *addr, in_port_t port) {
+  if (addr->ss_family == AF_INET)
+    reinterpret_cast<sockaddr_in *>(addr)->sin_port = port;
+  else if (addr->ss_family == AF_INET6)
+    reinterpret_cast<sockaddr_in6 *>(addr)->sin6_port = port;
+}

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -357,9 +357,13 @@ void Utils::writeFile(const boost::filesystem::path &filename, const std::string
 }
 
 void Utils::writeFile(const boost::filesystem::path &filename, const Json::Value &content, bool create_directories) {
+  Utils::writeFile(filename, jsonToStr(content), create_directories);
+}
+
+std::string Utils::jsonToStr(const Json::Value &json) {
   std::stringstream ss;
-  ss << content;
-  Utils::writeFile(filename, ss.str(), create_directories);
+  ss << json;
+  return ss.str();
 }
 
 Json::Value Utils::getHardwareInfo() {

--- a/src/utils.h
+++ b/src/utils.h
@@ -34,6 +34,7 @@ struct Utils {
   static int ipPort(const sockaddr_storage &saddr);
   static int shell(const std::string &command, std::string *output, bool include_stderr = false);
   static boost::filesystem::path absolutePath(const boost::filesystem::path &root, const boost::filesystem::path &file);
+  static void setSocketPort(sockaddr_storage *addr, in_port_t port);
 };
 
 /**

--- a/src/utils.h
+++ b/src/utils.h
@@ -17,6 +17,7 @@ struct Utils {
   static std::string addQuotes(const std::string &value);
   static Json::Value parseJSON(const std::string &json_str);
   static Json::Value parseJSONFile(const boost::filesystem::path &filename);
+  static std::string jsonToStr(const Json::Value &json);
   static std::string genPrettyName();
   static std::string readFile(const boost::filesystem::path &filename);
   static std::string readFileFromArchive(std::istream &as, const std::string &filename);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -167,6 +167,7 @@ add_aktualizr_test(NAME uptane_serial SOURCES uptane_serial_test.cc ARGS ${PROJE
                    PROJECT_WORKING_DIRECTORY)
 
 add_aktualizr_test(NAME uptane_secondary SOURCES uptane_secondary_test.cc PROJECT_WORKING_DIRECTORY)
+add_aktualizr_test(NAME ipuptane_connection SOURCES ipuptane_connection_test.cc PROJECT_WORKING_DIRECTORY)
 
 add_aktualizr_test(NAME asn1 SOURCES asn1_test.cc ARGS ${PROJECT_BINARY_DIR} PROJECT_WORKING_DIRECTORY)
 

--- a/tests/ipuptane_connection_test.cc
+++ b/tests/ipuptane_connection_test.cc
@@ -6,9 +6,12 @@
 
 #include <arpa/inet.h>
 #include <memory>
+#include <utility>
 
 #include "ipuptaneconnection.h"
 #include "ipuptaneconnectionsplitter.h"
+#include "uptane/ipuptanesecondary.h"
+#include "uptane/secondaryconfig.h"
 
 #include "logging.h"
 
@@ -27,7 +30,9 @@ bool test_message(sockaddr_storage addr, SecondaryPacket::ChanType& out_channel,
 }
 
 TEST(IpUptaneConnection, SendRecv) {
-  IpUptaneConnection sender{0};
+  struct in6_addr receiver_addr;
+  inet_pton(AF_INET6, "::ffff:127.0.0.1", &receiver_addr);
+  IpUptaneConnection sender{0, receiver_addr};
   IpUptaneConnection receiver{0};
 
   EXPECT_FALSE(sender.in_channel_.hasValues());
@@ -38,9 +43,9 @@ TEST(IpUptaneConnection, SendRecv) {
   // for this to run in Docker IPv4 should be used
   sockaddr_storage addr;
   memset(&addr, 0, sizeof(sockaddr_storage));
-  addr.ss_family = AF_INET;
-  reinterpret_cast<sockaddr_in*>(&addr)->sin_addr.s_addr = inet_addr("127.0.0.1");
-  reinterpret_cast<sockaddr_in*>(&addr)->sin_port = htons(receiver.listening_port());
+  addr.ss_family = AF_INET6;
+  reinterpret_cast<sockaddr_in6*>(&addr)->sin6_addr = receiver_addr;
+  reinterpret_cast<sockaddr_in6*>(&addr)->sin6_port = htons(receiver.listening_port());
 
   EXPECT_TRUE(test_message<SecondaryPublicKeyReq>(addr, sender.out_channel_, receiver.in_channel_));
   EXPECT_TRUE(test_message<SecondaryPublicKeyResp>(addr, sender.out_channel_, receiver.in_channel_));
@@ -54,6 +59,97 @@ TEST(IpUptaneConnection, SendRecv) {
   EXPECT_TRUE(test_message<SecondaryPutRootResp>(addr, sender.out_channel_, receiver.in_channel_));
   EXPECT_TRUE(test_message<SecondarySendFirmwareReq>(addr, sender.out_channel_, receiver.in_channel_));
   EXPECT_TRUE(test_message<SecondarySendFirmwareResp>(addr, sender.out_channel_, receiver.in_channel_));
+  sender.stop();
+  receiver.stop();
+}
+
+TEST(IpUptaneConnection, Splitter) {
+  struct in6_addr secondary_addr_0;
+  inet_pton(AF_INET6, "::ffff:127.0.0.1", &secondary_addr_0);
+
+  IpUptaneConnection secondary_conn_0{0, secondary_addr_0};
+
+  struct in6_addr secondary_addr_1;
+  inet_pton(AF_INET6, "::ffff:127.0.0.2", &secondary_addr_1);
+  IpUptaneConnection secondary_conn_1{0, secondary_addr_1};
+
+  Uptane::SecondaryConfig secondary_conf_0;
+  Uptane::SecondaryConfig secondary_conf_1;
+
+  memset(&secondary_conf_0.ip_addr, 0, sizeof(sockaddr_storage));
+  secondary_conf_0.ip_addr.ss_family = AF_INET6;
+  reinterpret_cast<sockaddr_in6*>(&secondary_conf_0.ip_addr)->sin6_addr = secondary_addr_0;
+  reinterpret_cast<sockaddr_in6*>(&secondary_conf_0.ip_addr)->sin6_port = htons(secondary_conn_0.listening_port());
+
+  memset(&secondary_conf_1.ip_addr, 0, sizeof(sockaddr_storage));
+  secondary_conf_1.ip_addr.ss_family = AF_INET6;
+  reinterpret_cast<sockaddr_in6*>(&secondary_conf_1.ip_addr)->sin6_addr = secondary_addr_1;
+  reinterpret_cast<sockaddr_in6*>(&secondary_conf_1.ip_addr)->sin6_port = htons(secondary_conn_1.listening_port());
+
+  Uptane::IpUptaneSecondary secondary_0{secondary_conf_0};
+  Uptane::IpUptaneSecondary secondary_1{secondary_conf_1};
+
+  struct in6_addr primary_addr_in;
+  inet_pton(AF_INET6, "::ffff:127.0.0.3", &primary_addr_in);
+  IpUptaneConnection primary_conn{0, primary_addr_in};
+  IpUptaneConnectionSplitter primary_splitter{primary_conn};
+
+  primary_splitter.registerSecondary(secondary_0);
+  primary_splitter.registerSecondary(secondary_1);
+
+  sockaddr_storage primary_addr;
+  memset(&primary_addr, 0, sizeof(sockaddr_storage));
+  primary_addr.ss_family = AF_INET6;
+  reinterpret_cast<sockaddr_in6*>(&primary_addr)->sin6_addr = primary_addr_in;
+  reinterpret_cast<sockaddr_in6*>(&primary_addr)->sin6_port = htons(primary_conn.listening_port());
+
+  std::thread secondary_0_thread = std::thread([&]() {
+    std::shared_ptr<SecondaryPacket> pack;
+    while (secondary_conn_0.in_channel_ >> pack) {
+      std::unique_ptr<SecondaryMessage> out_msg;
+      if (pack->msg->mes_type == kSecondaryMesPublicKeyReqTag) {
+        SecondaryPublicKeyResp* out_msg_pkey = new SecondaryPublicKeyResp;
+        out_msg_pkey->type = kRSA2048;
+        out_msg_pkey->key = "imakey0";
+
+        out_msg = std::unique_ptr<SecondaryMessage>{out_msg_pkey};
+
+        std::shared_ptr<SecondaryPacket> out_pack{new SecondaryPacket{primary_addr, std::move(out_msg)}};
+        secondary_conn_0.out_channel_ << out_pack;
+      }
+    }
+  });
+
+  std::thread secondary_1_thread = std::thread([&]() {
+    std::shared_ptr<SecondaryPacket> pack;
+    while (secondary_conn_1.in_channel_ >> pack) {
+      std::unique_ptr<SecondaryMessage> out_msg;
+      if (pack->msg->mes_type == kSecondaryMesPublicKeyReqTag) {
+        SecondaryPublicKeyResp* out_msg_pkey = new SecondaryPublicKeyResp;
+        out_msg_pkey->type = kRSA2048;
+        out_msg_pkey->key = "imakey1";
+
+        out_msg = std::unique_ptr<SecondaryMessage>{out_msg_pkey};
+
+        std::shared_ptr<SecondaryPacket> out_pack{new SecondaryPacket{primary_addr, std::move(out_msg)}};
+        secondary_conn_1.out_channel_ << out_pack;
+      }
+    }
+  });
+
+  auto res_0 = secondary_0.getPublicKey();
+  EXPECT_EQ(res_0.first, kRSA2048);
+  EXPECT_EQ(res_0.second, "imakey0");
+  auto res_1 = secondary_1.getPublicKey();
+  EXPECT_EQ(res_1.first, kRSA2048);
+  EXPECT_EQ(res_1.second, "imakey1");
+
+  secondary_conn_0.stop();
+  secondary_conn_1.stop();
+  primary_conn.stop();
+
+  secondary_0_thread.join();
+  secondary_1_thread.join();
 }
 
 #ifndef __NO_MAIN__

--- a/tests/ipuptane_connection_test.cc
+++ b/tests/ipuptane_connection_test.cc
@@ -1,0 +1,72 @@
+/**
+ * \file
+ */
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "ipuptaneconnection.h"
+#include "ipuptaneconnectionsplitter.h"
+
+#include "logging.h"
+
+template <typename Mes>
+bool test_message(sockaddr_storage addr, SecondaryPacket::ChanType& out_channel,
+                  SecondaryPacket::ChanType& in_channel) {
+  std::unique_ptr<SecondaryMessage> msg = std::unique_ptr<SecondaryMessage>{new Mes};
+  std::shared_ptr<SecondaryPacket> out_pack =
+      std::shared_ptr<SecondaryPacket>{new SecondaryPacket{addr, std::move(msg)}};
+
+  out_channel << out_pack;
+
+  std::shared_ptr<SecondaryPacket> in_pack;
+  in_channel.setTimeout(std::chrono::milliseconds(1000));
+  return (in_channel >> in_pack) && (*in_pack->msg == *out_pack->msg);
+}
+
+TEST(IpUptaneConnection, SendRecv) {
+  IpUptaneConnection sender{0};
+  IpUptaneConnection receiver{0};
+
+  EXPECT_FALSE(sender.in_channel_.hasValues());
+  EXPECT_FALSE(sender.out_channel_.hasValues());
+  EXPECT_FALSE(receiver.in_channel_.hasValues());
+  EXPECT_FALSE(receiver.out_channel_.hasValues());
+
+  EXPECT_TRUE(
+      test_message<SecondaryPublicKeyReq>(receiver.listening_address(), sender.out_channel_, receiver.in_channel_));
+  EXPECT_TRUE(
+      test_message<SecondaryPublicKeyResp>(receiver.listening_address(), sender.out_channel_, receiver.in_channel_));
+  EXPECT_TRUE(
+      test_message<SecondaryManifestReq>(receiver.listening_address(), sender.out_channel_, receiver.in_channel_));
+  EXPECT_TRUE(
+      test_message<SecondaryManifestResp>(receiver.listening_address(), sender.out_channel_, receiver.in_channel_));
+  EXPECT_TRUE(
+      test_message<SecondaryPutMetaReq>(receiver.listening_address(), sender.out_channel_, receiver.in_channel_));
+  EXPECT_TRUE(
+      test_message<SecondaryPutMetaResp>(receiver.listening_address(), sender.out_channel_, receiver.in_channel_));
+  EXPECT_TRUE(
+      test_message<SecondaryRootVersionReq>(receiver.listening_address(), sender.out_channel_, receiver.in_channel_));
+  EXPECT_TRUE(
+      test_message<SecondaryRootVersionResp>(receiver.listening_address(), sender.out_channel_, receiver.in_channel_));
+  EXPECT_TRUE(
+      test_message<SecondaryPutRootReq>(receiver.listening_address(), sender.out_channel_, receiver.in_channel_));
+  EXPECT_TRUE(
+      test_message<SecondaryPutRootResp>(receiver.listening_address(), sender.out_channel_, receiver.in_channel_));
+  EXPECT_TRUE(
+      test_message<SecondarySendFirmwareReq>(receiver.listening_address(), sender.out_channel_, receiver.in_channel_));
+  EXPECT_TRUE(
+      test_message<SecondarySendFirmwareResp>(receiver.listening_address(), sender.out_channel_, receiver.in_channel_));
+}
+
+#ifndef __NO_MAIN__
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+  logger_init();
+  logger_set_threshold(boost::log::trivial::trace);
+
+  return RUN_ALL_TESTS();
+}
+#endif

--- a/tests/ipuptane_connection_test.cc
+++ b/tests/ipuptane_connection_test.cc
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include <arpa/inet.h>
 #include <memory>
 
 #include "ipuptaneconnection.h"
@@ -34,30 +35,25 @@ TEST(IpUptaneConnection, SendRecv) {
   EXPECT_FALSE(receiver.in_channel_.hasValues());
   EXPECT_FALSE(receiver.out_channel_.hasValues());
 
-  EXPECT_TRUE(
-      test_message<SecondaryPublicKeyReq>(receiver.listening_address(), sender.out_channel_, receiver.in_channel_));
-  EXPECT_TRUE(
-      test_message<SecondaryPublicKeyResp>(receiver.listening_address(), sender.out_channel_, receiver.in_channel_));
-  EXPECT_TRUE(
-      test_message<SecondaryManifestReq>(receiver.listening_address(), sender.out_channel_, receiver.in_channel_));
-  EXPECT_TRUE(
-      test_message<SecondaryManifestResp>(receiver.listening_address(), sender.out_channel_, receiver.in_channel_));
-  EXPECT_TRUE(
-      test_message<SecondaryPutMetaReq>(receiver.listening_address(), sender.out_channel_, receiver.in_channel_));
-  EXPECT_TRUE(
-      test_message<SecondaryPutMetaResp>(receiver.listening_address(), sender.out_channel_, receiver.in_channel_));
-  EXPECT_TRUE(
-      test_message<SecondaryRootVersionReq>(receiver.listening_address(), sender.out_channel_, receiver.in_channel_));
-  EXPECT_TRUE(
-      test_message<SecondaryRootVersionResp>(receiver.listening_address(), sender.out_channel_, receiver.in_channel_));
-  EXPECT_TRUE(
-      test_message<SecondaryPutRootReq>(receiver.listening_address(), sender.out_channel_, receiver.in_channel_));
-  EXPECT_TRUE(
-      test_message<SecondaryPutRootResp>(receiver.listening_address(), sender.out_channel_, receiver.in_channel_));
-  EXPECT_TRUE(
-      test_message<SecondarySendFirmwareReq>(receiver.listening_address(), sender.out_channel_, receiver.in_channel_));
-  EXPECT_TRUE(
-      test_message<SecondarySendFirmwareResp>(receiver.listening_address(), sender.out_channel_, receiver.in_channel_));
+  // for this to run in Docker IPv4 should be used
+  sockaddr_storage addr;
+  memset(&addr, 0, sizeof(sockaddr_storage));
+  addr.ss_family = AF_INET;
+  reinterpret_cast<sockaddr_in*>(&addr)->sin_addr.s_addr = inet_addr("127.0.0.1");
+  reinterpret_cast<sockaddr_in*>(&addr)->sin_port = htons(receiver.listening_port());
+
+  EXPECT_TRUE(test_message<SecondaryPublicKeyReq>(addr, sender.out_channel_, receiver.in_channel_));
+  EXPECT_TRUE(test_message<SecondaryPublicKeyResp>(addr, sender.out_channel_, receiver.in_channel_));
+  EXPECT_TRUE(test_message<SecondaryManifestReq>(addr, sender.out_channel_, receiver.in_channel_));
+  EXPECT_TRUE(test_message<SecondaryManifestResp>(addr, sender.out_channel_, receiver.in_channel_));
+  EXPECT_TRUE(test_message<SecondaryPutMetaReq>(addr, sender.out_channel_, receiver.in_channel_));
+  EXPECT_TRUE(test_message<SecondaryPutMetaResp>(addr, sender.out_channel_, receiver.in_channel_));
+  EXPECT_TRUE(test_message<SecondaryRootVersionReq>(addr, sender.out_channel_, receiver.in_channel_));
+  EXPECT_TRUE(test_message<SecondaryRootVersionResp>(addr, sender.out_channel_, receiver.in_channel_));
+  EXPECT_TRUE(test_message<SecondaryPutRootReq>(addr, sender.out_channel_, receiver.in_channel_));
+  EXPECT_TRUE(test_message<SecondaryPutRootResp>(addr, sender.out_channel_, receiver.in_channel_));
+  EXPECT_TRUE(test_message<SecondarySendFirmwareReq>(addr, sender.out_channel_, receiver.in_channel_));
+  EXPECT_TRUE(test_message<SecondarySendFirmwareResp>(addr, sender.out_channel_, receiver.in_channel_));
 }
 
 #ifndef __NO_MAIN__

--- a/tests/uptane_secondary_test.cc
+++ b/tests/uptane_secondary_test.cc
@@ -44,7 +44,7 @@ TEST(SecondaryFactory, Legacy) {
 TEST(SecondaryFactory, Uptane_get_key) {
   TemporaryDirectory temp_dir;
   Uptane::SecondaryConfig sconfig;
-  sconfig.secondary_type = Uptane::kUptane;
+  sconfig.secondary_type = Uptane::kVirtualUptane;
   sconfig.partial_verifying = true;
   sconfig.full_client_dir = temp_dir.Path();
   sconfig.ecu_serial = "";
@@ -67,7 +67,7 @@ TEST(SecondaryFactory, Uptane_get_key) {
 TEST(SecondaryFactory, Uptane_putMetadata_good) {
   TemporaryDirectory temp_dir;
   Uptane::SecondaryConfig sconfig;
-  sconfig.secondary_type = Uptane::kUptane;
+  sconfig.secondary_type = Uptane::kVirtualUptane;
   sconfig.partial_verifying = true;
   sconfig.full_client_dir = temp_dir.Path();
   sconfig.ecu_serial = "";
@@ -91,7 +91,7 @@ TEST(SecondaryFactory, Uptane_putMetadata_good) {
 TEST(SecondaryFactory, Uptane_putMetadata_bad) {
   TemporaryDirectory temp_dir;
   Uptane::SecondaryConfig sconfig;
-  sconfig.secondary_type = Uptane::kUptane;
+  sconfig.secondary_type = Uptane::kVirtualUptane;
   sconfig.partial_verifying = true;
   sconfig.full_client_dir = temp_dir.Path();
   sconfig.ecu_serial = "";


### PR DESCRIPTION
I had to make Config non-const in order to be able to add data to secondary_configs. Alternatively we can move secondary_configs out of Config or declare it as mutable.

"not-ready" label is there until I'm done with the tests.