### PR TITLE
Fix linking issue with BUILD_ISOTP=ON

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,7 +4,7 @@ set -e
 (
 mkdir -p build-test
 cd build-test
-cmake -DBUILD_OSTREE=ON -DBUILD_SOTA_TOOLS=ON -DBUILD_DEB=ON -DCMAKE_BUILD_TYPE=Valgrind ../src
+cmake -DBUILD_OSTREE=ON -DBUILD_SOTA_TOOLS=ON -DBUILD_ISOTP=ON -DBUILD_DEB=ON -DCMAKE_BUILD_TYPE=Valgrind ../src
 
 make -j8
 
@@ -26,7 +26,7 @@ fi
 if [ -n "$STATIC_CHECKS" ]; then
   mkdir -p build-static-checks
   cd build-static-checks
-  cmake -DBUILD_OSTREE=ON -DBUILD_SOTA_TOOLS=ON -DBUILD_DEB=ON -DBUILD_P11=ON ../src
+  cmake -DBUILD_OSTREE=ON -DBUILD_SOTA_TOOLS=ON -DBUILD_ISOTP=ON -DBUILD_DEB=ON -DBUILD_P11=ON ../src
 
   make check-format -j8
   make clang-tidy -j8

--- a/src/external_secondaries/CMakeLists.txt
+++ b/src/external_secondaries/CMakeLists.txt
@@ -45,6 +45,7 @@ if(BUILD_ISOTP)
                           ${Boost_SYSTEM_LIBRARIES}
                           aktualizr_static_lib
                           ${Boost_LIBRARIES}
+                          ${LibArchive_LIBRARIES}
                           ${CMAKE_THREAD_LIBS_INIT})
     target_compile_options(isotp-test-interface PUBLIC -DECUFLASHER_TEST_ISOTP)
     target_include_directories(isotp-test-interface PUBLIC ${ISOTP_PATH_PREFIX} ${BITFIELD_PATH_PREFIX})

--- a/src/external_secondaries/test_isotp_interface.cc
+++ b/src/external_secondaries/test_isotp_interface.cc
@@ -28,7 +28,7 @@ TestIsotpInterface::TestIsotpInterface(const unsigned int loglevel, uint32_t can
   setsockopt(can_socket, SOL_CAN_RAW, CAN_RAW_FILTER, &filter, sizeof(filter));
 
   struct ifreq ifr;
-  strcpy(ifr.ifr_name, canIface.c_str());
+  strncpy(ifr.ifr_name, canIface.c_str(), IFNAMSIZ);
 
   if (ioctl(can_socket, SIOCGIFINDEX, &ifr)) {
     throw std::runtime_error("Unable to get interface index");


### PR DESCRIPTION
Also enable BUILD_ISOTP on CI builds so that we can catch problems faster.

(it is enabled in the yocto recipe but currently not on any CI configuration)