### PR TITLE
treehub: Fix logic for HTTP basic auth

### DIFF
--- a/src/sota_tools/authenticate.cc
+++ b/src/sota_tools/authenticate.cc
@@ -9,8 +9,7 @@ using std::string;
 int authenticate(const string &cacerts, const ServerCredentials &creds, TreehubServer &treehub) {
   switch (creds.GetMethod()) {
     case AUTH_BASIC: {
-      treehub.username(creds.GetAuthUser());
-      treehub.password(creds.GetAuthPassword());
+      treehub.SetAuthBasic(creds.GetAuthUser(), creds.GetAuthPassword());
       break;
     }
 

--- a/src/sota_tools/treehub_server.cc
+++ b/src/sota_tools/treehub_server.cc
@@ -34,6 +34,12 @@ void TreehubServer::SetCerts(const std::string& root_cert, const std::string& cl
   client_key_path_.PutContents(client_key);
 }
 
+void TreehubServer::SetAuthBasic(const std::string& username, const std::string& password) {
+  method_ = AUTH_BASIC;
+  username_ = username;
+  password_ = password;
+}
+
 // Note that this method creates a reference from curl_handle to this.  Keep
 // this TreehubServer object alive until the curl request has been completed
 void TreehubServer::InjectIntoCurl(const string& url_suffix, CURL* curl_handle, bool tufrepo) const {

--- a/src/sota_tools/treehub_server.h
+++ b/src/sota_tools/treehub_server.h
@@ -13,6 +13,7 @@ class TreehubServer {
   TreehubServer();
   void SetToken(const std::string &token);
   void SetCerts(const std::string &root_cert, const std::string &client_cert, const std::string &client_key);
+  void SetAuthBasic(const std::string &username, const std::string &password);
 
   void InjectIntoCurl(const std::string &url_suffix, CURL *curl_handle, bool tufrepo = false) const;
 
@@ -20,8 +21,6 @@ class TreehubServer {
   void root_url(const std::string &_root_url);
   void repo_url(const std::string &_repo_url);
   std::string root_url() { return root_url_; };
-  void username(const std::string &_username) { username_ = _username; }
-  void password(const std::string &_password) { password_ = _password; }
 
  private:
   std::string ca_certs_;


### PR DESCRIPTION
The username and password methods used by the authenticate function
don't tell the TreeHubServer to update its method_. This changes makes
this a single API to work more like the SetCerts and SetToken methods
work.

Signed-off-by: Andy Doan <andy@opensourcefoundries.com>