### PR TITLE
Latest garage-sign (134) and add libsystemd-dev to README.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -72,6 +72,7 @@ The following debian packages are used in the project:
 * libsodium-dev
 * libsqlite3-dev
 * libssl-dev
+* libsystemd-dev (when building with systemd support)
 * libyaml-cpp-dev (>=0.5.2)
 * python3-dev (when building tests)
 * python3-openssl (when building tests)

--- a/src/sota_tools/CMakeLists.txt
+++ b/src/sota_tools/CMakeLists.txt
@@ -93,8 +93,8 @@ if (BUILD_SOTA_TOOLS)
 
   include(ExternalProject)
   ExternalProject_Add(garage-sign DEPENDS garage-deploy
-                      URL https://ats-tuf-cli-releases.s3-eu-central-1.amazonaws.com/cli-0.2.0-106-g613f9ad.tgz
-                      URL_HASH SHA256=afd869c21e2a37918eef95e0ec778b54e86a2e725a0dc0ae982be46b9c790ff6
+                      URL https://ats-tuf-cli-releases.s3-eu-central-1.amazonaws.com/cli-0.2.0-134-ge27cd8a.tgz
+                      URL_HASH SHA256=6c00814dc49566dffb703ffe873a7e1d87a7bc345b7830737d0712bf88a85ffd
                       CONFIGURE_COMMAND "" BUILD_COMMAND "" INSTALL_COMMAND "")
   ExternalProject_Get_Property(garage-sign SOURCE_DIR)
 


### PR DESCRIPTION
I'd still like to work on the automatic garage-sign version management, but in the meantime, I'm hoping this will fix some of the garage-sign problems we've seen lately.