### PR TITLE
Fix clang-tidy header filter regex

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,6 @@
 ---
 Checks:          'clang-analyzer-*,modernize-use-override,readability-inconsistent-declaration-parameter-name'
 WarningsAsErrors: ''
-HeaderFilterRegex: '\.\./src/.*'
 AnalyzeTemporaryDtors: false
 User:            lbonn
 CheckOptions:    

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,9 @@ if(CLANG_TIDY)
         file(RELATIVE_PATH SUBDIR ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
         foreach(FILE ${ARGN})
             if(${FILE} MATCHES "\\.h")
+                # do not run clang-tidy directly on header files, since it
+                # ignores them. headers will be checked if they are included by
+                # a checked source file
                 continue()
             endif()
             string(REPLACE "/" "_" TARGETNAME "aktualizr_clang_tidy-${SUBDIR}-${FILE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,14 +171,15 @@ if(CLANG_TIDY)
     function(aktualizr_clang_tidy)
         file(RELATIVE_PATH SUBDIR ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
         foreach(FILE ${ARGN})
-            if(NOT ${FILE} MATCHES "\\.h")
-                string(REPLACE "/" "_" TARGETNAME "aktualizr_clang_tidy-${SUBDIR}-${FILE}")
-                add_custom_target(${TARGETNAME}
-                    COMMAND ${CLANG_TIDY} -quiet --extra-arg-before=-Wno-unknown-warning-option -format-style=file -warnings-as-errors=* -p ${CMAKE_BINARY_DIR} ${FILE}
-                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                    VERBATIM)
-                add_dependencies(clang-tidy ${TARGETNAME})
+            if(${FILE} MATCHES "\\.h")
+                continue()
             endif()
+            string(REPLACE "/" "_" TARGETNAME "aktualizr_clang_tidy-${SUBDIR}-${FILE}")
+            add_custom_target(${TARGETNAME}
+                COMMAND ${CLANG_TIDY} -quiet -header-filter=\(${CMAKE_SOURCE_DIR}|\\.\\.\)/src/.* --extra-arg-before=-Wno-unknown-warning-option -format-style=file -warnings-as-errors=* -p ${CMAKE_BINARY_DIR} ${FILE}
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                VERBATIM)
+            add_dependencies(clang-tidy ${TARGETNAME})
         endforeach()
     endfunction()
 else()

--- a/src/aktualizr_secondary/opcuaserver_secondary_delegate.h
+++ b/src/aktualizr_secondary/opcuaserver_secondary_delegate.h
@@ -5,10 +5,10 @@
 
 class OpcuaServerSecondaryDelegate : public opcuabridge::ServerDelegate {
  public:
-  virtual void handleServerInitialized(opcuabridge::ServerModel*) override;
-  virtual void handleVersionReportRequested(opcuabridge::ServerModel*) override;
-  virtual void handleMetaDataFilesReceived(opcuabridge::ServerModel*) override;
-  virtual void handleDirectoryFilesSynchronized(opcuabridge::ServerModel*) override;
+  void handleServerInitialized(opcuabridge::ServerModel*) override;
+  void handleVersionReportRequested(opcuabridge::ServerModel*) override;
+  void handleMetaDataFilesReceived(opcuabridge::ServerModel*) override;
+  void handleDirectoryFilesSynchronized(opcuabridge::ServerModel*) override;
 };
 
 #endif  // AKTUALIZR_SECONDARY_OPCUASERVER_SECONDARY_DELEGATE_H_

--- a/src/external_secondaries/example_flasher.h
+++ b/src/external_secondaries/example_flasher.h
@@ -5,12 +5,12 @@
 
 class ExampleFlasher : public ECUInterface {
  public:
-  virtual ~ExampleFlasher() {}
+  ~ExampleFlasher() override {}
   ExampleFlasher(const unsigned int loglevel);
-  virtual std::string apiVersion();
-  virtual std::string listEcus();
-  virtual InstallStatus installSoftware(const std::string &hardware_id, const std::string &ecu_id,
-                                        const std::string &firmware);
+  std::string apiVersion() override;
+  std::string listEcus() override;
+  InstallStatus installSoftware(const std::string &hardware_id, const std::string &ecu_id,
+                                const std::string &firmware) override;
 
  private:
   int loglevel_;

--- a/src/external_secondaries/test_isotp_interface.h
+++ b/src/external_secondaries/test_isotp_interface.h
@@ -15,9 +15,10 @@ const std::string kDefaultCanIf = "can0";
 class TestIsotpInterface : public ECUInterface {
  public:
   TestIsotpInterface(unsigned int loglevel, uint32_t canid = kDefaultCanId, const std::string& canif = kDefaultCanIf);
-  std::string apiVersion();
-  std::string listEcus();
-  InstallStatus installSoftware(const std::string& hardware_id, const std::string& ecu_id, const std::string& firmware);
+  std::string apiVersion() override;
+  std::string listEcus() override;
+  InstallStatus installSoftware(const std::string& hardware_id, const std::string& ecu_id,
+                                const std::string& firmware) override;
 
  private:
   // (hardware_id, ecu_serial) -> CAN address

--- a/src/fsstorage.cc
+++ b/src/fsstorage.cc
@@ -400,7 +400,7 @@ class FSTargetWHandle : public StorageTargetWHandle {
   ~FSTargetWHandle() override {
     if (!closed_) {
       LOG_WARNING << "Handle for file " << filename_ << " has not been committed or aborted, forcing abort";
-      this->wabort();
+      FSTargetWHandle::wabort();
     }
   }
 

--- a/src/opcuabridge/filedata.h
+++ b/src/opcuabridge/filedata.h
@@ -17,7 +17,7 @@ class FileData : public MessageFileData {
   const boost::filesystem::path& getFilePath() const { return file_path_; }
   void setFilePath(const boost::filesystem::path& file_path) { file_path_ = file_path; }
 
-  virtual std::string getFullFilePath() const override { return (getBasePath() / getFilePath()).native(); }
+  std::string getFullFilePath() const override { return (getBasePath() / getFilePath()).native(); }
 
   INITSERVERNODESET_FILE_FUNCTION_DEFINITION(FileData)  // InitServerNodeset(UA_Server*)
   CLIENTWRITE_FILE_FUNCTION_DEFINITION()                // ClientWrite(UA_Client*)

--- a/src/opcuabridge/metadatafiles.h
+++ b/src/opcuabridge/metadatafiles.h
@@ -23,8 +23,8 @@ class MetadataFiles {
   void setOnAfterWriteCallback(MessageOnAfterWriteCallback<MetadataFiles>::type cb) { on_after_write_cb_ = cb; }
 
  protected:
-  int GUID_;
-  std::size_t numberOfMetadataFiles_;
+  int GUID_{-1};
+  std::size_t numberOfMetadataFiles_{0};
 
   MessageOnBeforeReadCallback<MetadataFiles>::type on_before_read_cb_;
   MessageOnAfterWriteCallback<MetadataFiles>::type on_after_write_cb_;

--- a/src/sota_tools/accumulator.h
+++ b/src/sota_tools/accumulator.h
@@ -40,42 +40,42 @@ class accumulator_type : public boost::program_options::value_semantic {
     return this;
   }
 
-  virtual std::string name() const { return std::string(); }
+  virtual std::string name() const { return std::string(); }  // NOLINT
 
   /// There are no tokens for an accumulator_type
-  virtual unsigned min_tokens() const { return 0; }
-  virtual unsigned max_tokens() const { return 0; }
+  virtual unsigned min_tokens() const { return 0; }  // NOLINT
+  virtual unsigned max_tokens() const { return 0; }  // NOLINT
 
-  virtual bool adjacent_tokens_only() const { return false; }
+  virtual bool adjacent_tokens_only() const { return false; }  // NOLINT
 
   /// Accumulating from different sources is silly.
-  virtual bool is_composing() const { return false; }
+  virtual bool is_composing() const { return false; }  // NOLINT
 
   /// Requiring one or more appearances is unlikely.
-  virtual bool is_required() const { return false; }
+  virtual bool is_required() const { return false; }  // NOLINT
 
   /// Every appearance of the option simply increments the value
   //
   /// There should never be any tokens.
-  virtual void parse(boost::any& value_store, const std::vector<std::string>&, bool /*utf8*/) const {
+  virtual void parse(boost::any& value_store, const std::vector<std::string>&, bool /*utf8*/) const {  // NOLINT
     if (value_store.empty()) value_store = T();
     boost::any_cast<T&>(value_store) += _interval;
   }
 
   /// If the option doesn't appear, this is the default value.
-  virtual bool apply_default(boost::any& value_store) const {
+  virtual bool apply_default(boost::any& value_store) const {  // NOLINT
     value_store = _default;
     return true;
   }
 
   /// Notify the user function with the value of the value store.
-  virtual void notify(const boost::any& value_store) const {
+  virtual void notify(const boost::any& value_store) const {  // NOLINT
     const T* val = boost::any_cast<T>(&value_store);
     if (_store) *_store = *val;
     if (_notifier) _notifier(*val);
   }
 
-  virtual ~accumulator_type() {}
+  virtual ~accumulator_type() {}  // NOLINT
 
  private:
   T* _store;

--- a/src/sota_tools/ostree_dir_repo.h
+++ b/src/sota_tools/ostree_dir_repo.h
@@ -16,12 +16,12 @@ class OSTreeDirRepo : public OSTreeRepo {
  public:
   explicit OSTreeDirRepo(const boost::filesystem::path &root_path) : root_(root_path) {}
 
-  bool LooksValid() const;
-  OSTreeObject::ptr GetObject(const OSTreeHash hash) const;
-  OSTreeObject::ptr GetObject(const uint8_t sha256[32]) const;
-  OSTreeRef GetRef(const std::string &refname) const;
+  bool LooksValid() const override;
+  OSTreeObject::ptr GetObject(const OSTreeHash hash) const override;
+  OSTreeObject::ptr GetObject(const uint8_t sha256[32]) const override;
+  OSTreeRef GetRef(const std::string &refname) const override;
 
-  const boost::filesystem::path root() const { return root_; }
+  const boost::filesystem::path root() const override { return root_; }
 
  private:
   typedef std::map<OSTreeHash, OSTreeObject::ptr> otable;

--- a/src/sota_tools/ostree_hash.h
+++ b/src/sota_tools/ostree_hash.h
@@ -30,7 +30,7 @@ class OSTreeCommitParseError : std::exception {
  public:
   OSTreeCommitParseError(const std::string bad_hash) : bad_hash_(bad_hash) {}
 
-  virtual const char* what() const noexcept { return "Could not parse OSTree commit"; }
+  const char* what() const noexcept override { return "Could not parse OSTree commit"; }
 
   std::string bad_hash() const { return bad_hash_; }
 

--- a/src/sota_tools/ostree_http_repo.h
+++ b/src/sota_tools/ostree_http_repo.h
@@ -17,12 +17,12 @@ class OSTreeHttpRepo : public OSTreeRepo {
  public:
   explicit OSTreeHttpRepo(const TreehubServer* server) : server_(server) {}
 
-  bool LooksValid() const;
-  OSTreeObject::ptr GetObject(const OSTreeHash hash) const;
-  OSTreeObject::ptr GetObject(const uint8_t sha256[32]) const;
-  OSTreeRef GetRef(const std::string& refname) const;
+  bool LooksValid() const override;
+  OSTreeObject::ptr GetObject(const OSTreeHash hash) const override;
+  OSTreeObject::ptr GetObject(const uint8_t sha256[32]) const override;
+  OSTreeRef GetRef(const std::string& refname) const override;
 
-  const boost::filesystem::path root() const { return root_.PathString(); }
+  const boost::filesystem::path root() const override { return root_.PathString(); }
 
  private:
   bool Get(const boost::filesystem::path& path) const;

--- a/src/sota_tools/ostree_repo.h
+++ b/src/sota_tools/ostree_repo.h
@@ -34,7 +34,7 @@ class OSTreeObjectMissing : std::exception {
  public:
   OSTreeObjectMissing(const OSTreeHash _missing_object) : missing_object_(_missing_object) {}
 
-  virtual const char* what() const noexcept { return "OSTree repository is missing an object"; }
+  const char* what() const noexcept override { return "OSTree repository is missing an object"; }
 
   OSTreeHash missing_object() const { return missing_object_; }
 

--- a/src/sotauptaneclient.h
+++ b/src/sotauptaneclient.h
@@ -1,5 +1,4 @@
 #include <map>
-#include <map>
 #include <string>
 #include <vector>
 

--- a/src/sqlstorage.cc
+++ b/src/sqlstorage.cc
@@ -802,7 +802,7 @@ class SQLTargetWHandle : public StorageTargetWHandle {
   ~SQLTargetWHandle() override {
     if (!closed_) {
       LOG_WARNING << "Handle for file " << filename_ << " has not been committed or aborted, forcing abort";
-      this->wabort();
+      SQLTargetWHandle::wabort();
     }
   }
 

--- a/src/uptane/opcuasecondary.cc
+++ b/src/uptane/opcuasecondary.cc
@@ -22,20 +22,20 @@ OpcuaSecondary::OpcuaSecondary(const SecondaryConfig& sconfig) : SecondaryInterf
 OpcuaSecondary::~OpcuaSecondary() {}
 
 std::string OpcuaSecondary::getSerial() {
-  opcuabridge::Client client(opcuabridge::SelectEndPoint(SecondaryInterface::sconfig));
+  opcuabridge::Client client{opcuabridge::SelectEndPoint(SecondaryInterface::sconfig)};
   return client.recvConfiguration().getSerial();
 }
 std::string OpcuaSecondary::getHwId() {
-  opcuabridge::Client client(opcuabridge::SelectEndPoint(SecondaryInterface::sconfig));
+  opcuabridge::Client client{opcuabridge::SelectEndPoint(SecondaryInterface::sconfig)};
   return client.recvConfiguration().getHwId();
 }
 std::pair<KeyType, std::string> OpcuaSecondary::getPublicKey() {
-  opcuabridge::Client client(opcuabridge::SelectEndPoint(SecondaryInterface::sconfig));
+  opcuabridge::Client client{opcuabridge::SelectEndPoint(SecondaryInterface::sconfig)};
   return std::make_pair(client.recvConfiguration().getPublicKeyType(), client.recvConfiguration().getPublicKey());
 }
 
 Json::Value OpcuaSecondary::getManifest() {
-  opcuabridge::Client client(opcuabridge::SelectEndPoint(SecondaryInterface::sconfig));
+  opcuabridge::Client client{opcuabridge::SelectEndPoint(SecondaryInterface::sconfig)};
   return client.recvVersionReport().getEcuVersionManifest().wrapMessage();
 }
 
@@ -51,14 +51,14 @@ bool OpcuaSecondary::putMetadata(const MetaPack& meta_pack) {
   std::transform(director_targets.begin(), director_targets.end(), std::back_inserter(metadatafiles), makeMetadataFile);
   std::transform(image_targets.begin(), image_targets.end(), std::back_inserter(metadatafiles), makeMetadataFile);
 
-  opcuabridge::Client client(opcuabridge::SelectEndPoint(SecondaryInterface::sconfig));
+  opcuabridge::Client client{opcuabridge::SelectEndPoint(SecondaryInterface::sconfig)};
   return client.sendMetadataFiles(metadatafiles);
 }
 
 bool OpcuaSecondary::sendFirmware(const std::string& data) {
   const fs::path source_repo_dir_path(data);
 
-  opcuabridge::Client client(opcuabridge::SelectEndPoint(SecondaryInterface::sconfig));
+  opcuabridge::Client client{opcuabridge::SelectEndPoint(SecondaryInterface::sconfig)};
   if (!client) return false;
 
   bool retval = true;

--- a/src/uptane/opcuasecondary.h
+++ b/src/uptane/opcuasecondary.h
@@ -8,25 +8,25 @@
 
 namespace Uptane {
 
-class MetaPack;
+struct MetaPack;
 class SecondaryConfig;
 
 class OpcuaSecondary : public SecondaryInterface {
  public:
   OpcuaSecondary(const SecondaryConfig&);
-  virtual ~OpcuaSecondary();
+  ~OpcuaSecondary() override;
 
-  virtual std::string getSerial() override;
-  virtual std::string getHwId() override;
-  virtual std::pair<KeyType, std::string> getPublicKey() override;
+  std::string getSerial() override;
+  std::string getHwId() override;
+  std::pair<KeyType, std::string> getPublicKey() override;
 
-  virtual Json::Value getManifest() override;
-  virtual bool putMetadata(const MetaPack& meta_pack) override;
+  Json::Value getManifest() override;
+  bool putMetadata(const MetaPack& meta_pack) override;
 
-  virtual bool sendFirmware(const std::string& data) override;
+  bool sendFirmware(const std::string& data) override;
 
-  virtual int getRootVersion(bool director) override;
-  virtual bool putRoot(Uptane::Root root, bool director) override;
+  int getRootVersion(bool director) override;
+  bool putRoot(Uptane::Root root, bool director) override;
 };
 
 }  // namespace Uptane

--- a/tests/uptane_test.cc
+++ b/tests/uptane_test.cc
@@ -20,7 +20,6 @@
 #include "sotauptaneclient.h"
 #include "test_utils.h"
 #include "uptane/tuf.h"
-#include "uptane/tuf.h"
 #include "uptane/uptanerepository.h"
 #include "utils.h"
 


### PR DESCRIPTION
To also work when using a build directory outside the repository

Noticed the problem after #674. There was no problem in the option selection but only with the header controlling which header files to lint.

This is a bit ugly but looks like it now works in both cases.