### PR TITLE
Feat/garage sign auto version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN apt-get update && apt-get -y install \
   python3-gi \
   python3-openssl \
   python3-pip \
+  python3-requests \
   python3-venv \
   valgrind \
   wget

--- a/Dockerfile.deb-stable
+++ b/Dockerfile.deb-stable
@@ -51,6 +51,7 @@ RUN apt-get update && apt-get -y install \
   opensc \
   ostree \
   pkg-config \
+  python3-requests \
   psmisc \
   softhsm2 \
   wget

--- a/Dockerfile.deb-testing
+++ b/Dockerfile.deb-testing
@@ -59,6 +59,7 @@ RUN apt-get update && apt-get -y install \
   python3-dev \
   python3-gi \
   python3-openssl \
+  python3-requests \
   python3-venv \
   softhsm2 \
   valgrind \

--- a/Dockerfile.garage-deploy.deb-stable
+++ b/Dockerfile.garage-deploy.deb-stable
@@ -6,8 +6,15 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN echo "deb http://ftp.de.debian.org/debian stable main" > /etc/apt/sources.list
 RUN echo "deb http://ftp.de.debian.org/debian stable-updates main" >> /etc/apt/sources.list
 RUN echo "deb http://security.debian.org stable/updates main" >> /etc/apt/sources.list
-RUN apt-get update
 
-RUN apt-get install -y libarchive13 libcurl3 libglib2.0-0 libostree-1-1 libsodium18 opensc libengine-pkcs11-openssl openjdk-8-jre
+RUN apt-get update && apt-get install -y \
+  libarchive13 \
+  libcurl3 \
+  libengine-pkcs11-openssl \
+  libglib2.0-0 \
+  libostree-1-1 \
+  libsodium18 \
+  openjdk-8-jre \
+  opensc
 
 ENTRYPOINT dpkg -i /persistent/garage_deploy.deb && garage-deploy --version && garage-sign --help

--- a/Dockerfile.nop11
+++ b/Dockerfile.nop11
@@ -50,6 +50,7 @@ RUN apt-get update && apt-get -y install \
   python3-dev \
   python3-gi \
   python3-openssl \
+  python3-requests \
   python3-venv \
   valgrind \
   wget

--- a/README.adoc
+++ b/README.adoc
@@ -69,6 +69,7 @@ The following debian packages are used in the project:
 * libyaml-cpp-dev (>=0.5.2)
 * python3-dev (when building tests)
 * python3-openssl (when building tests)
+* python3-requests (when building sota_tools)
 * python3-venv (when building tests)
 * valgrind
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,9 @@
+:toc: macro
+:toc-title:
+
 https://opensource.org/licenses/MPL-2.0[image:https://img.shields.io/badge/License-MPL%202.0-brightgreen.svg[License: MPL 2.0]] https://travis-ci.org/advancedtelematic/aktualizr[image:https://travis-ci.org/advancedtelematic/aktualizr.svg?branch=master[TravisCI Build Status]] https://codecov.io/gh/advancedtelematic/aktualizr[image:https://codecov.io/gh/advancedtelematic/aktualizr/branch/master/graph/badge.svg[codecov]] https://bestpractices.coreinfrastructure.org/projects/674[image:https://bestpractices.coreinfrastructure.org/projects/674/badge[CII Best Practices]] https://github.com/RichardLitt/standard-readme[image:https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat[standard-readme compliant]]
 
+[discrete]
 = aktualizr
 
 ====
@@ -21,21 +25,10 @@ The client is responsible for:
 
 The client maintains the integrity and confidentiality of the OTA update in transit, communicating with the server over a TLS link. The client can run either as a system service, periodically checking for updates, or can by triggered by other system interactions (for example on user request, or on receipt of a wake-up message from the OTA server).
 
+[discrete]
 == Table of Contents
 
-* <<Security>>
-* <<Install>>
-** <<Dependencies>>
-** <<Building>>
-** <<Linting>>
-** <<Testing>>
-** <<Code Coverage>>
-** <<Building with Docker>>
-** <<Developing against an OpenEmbedded system>>
-* <<Usage>>
-* <<Maintainers>>
-* <<Contribute>>
-* <<License>>
+toc::[]
 
 == Security
 

--- a/scripts/get_garage_sign.py
+++ b/scripts/get_garage_sign.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import argparse
 import hashlib
 import os.path
 import requests
@@ -7,8 +8,18 @@ import shutil
 import sys
 import xml.etree.ElementTree as ET
 
+from pathlib import Path
+
 
 def main():
+    parser = argparse.ArgumentParser(description='Download a specific or the latest version of garage-sign')
+    parser.add_argument('-n', '--name', help='specific version to download')
+    parser.add_argument('-o', '--output', type=Path, default=Path('.'), help='download directory')
+    args = parser.parse_args()
+    if not args.output.exists():
+        print('Error: specified output directory ' + args.output + ' does not exist!')
+        return 1
+
     r = requests.get('https://ats-tuf-cli-releases.s3-eu-central-1.amazonaws.com')
     if r.status_code != 200:
         print('Error: unable to request index!')
@@ -20,13 +31,19 @@ def main():
     versions = dict()
     for i in (i for i in items if i.find(ns + 'Key').text[0:4] == 'cli-'):
         # ETag is md5sum.
-        versions[i.find(ns + 'LastModified').text] = (i.find(ns + 'Key').text, i.find(ns + 'ETag').text[1:-1])
-    latest = sorted(versions)[-1]
-    name = versions[latest][0]
-    md5_hash = versions[latest][1]
+        versions[i.find(ns + 'Key').text] = (i.find(ns + 'LastModified').text, i.find(ns + 'ETag').text[1:-1])
+    if args.name:
+        name = args.name
+        if name not in versions:
+            print('Error: ' + name + ' not found in tuf-cli releases.')
+            return 1
+    else:
+        name = sorted(versions)[-1]
+    path = args.output.joinpath(name)
+    md5_hash = versions[name][1]
     m = hashlib.md5()
-    if os.path.isfile(name):
-        if check_md5(name, m, md5_hash):
+    if os.path.isfile(path):
+        if check_md5(path, m, md5_hash):
             print(name + ' already present with valid md5 hash.')
             return 0
         else:
@@ -36,9 +53,9 @@ def main():
     if r2.status_code != 200:
         print('Error: unable to request file!')
         return 1
-    with open(name, mode='wb') as f:
+    with open(path, mode='wb') as f:
         shutil.copyfileobj(r2.raw, f)
-    if not check_md5(name, m, md5_hash):
+    if not check_md5(path, m, md5_hash):
         print('Error: md5 hash of ' + name + ' does not match expected value!')
         return 1
     else:
@@ -46,8 +63,8 @@ def main():
         return 0
 
 
-def check_md5(name, m, md5_hash):
-    with open(name, mode='rb') as f:
+def check_md5(path, m, md5_hash):
+    with open(path, mode='rb') as f:
         m.update(f.read())
     return m.hexdigest() == md5_hash
 

--- a/scripts/get_garage_sign.py
+++ b/scripts/get_garage_sign.py
@@ -43,7 +43,7 @@ def main():
     path = args.output.joinpath(name)
     md5_hash = versions[name][1]
     m = hashlib.md5()
-    if not os.path.isfile(path) or not check_md5(name, path, m, md5_hash):
+    if not path.is_file() or not check_md5(name, path, m, md5_hash):
         print('Downloading ' + name + ' from server...')
         if download(name, path, m, md5_hash):
             print(name + ' successfully downloaded and validated.')
@@ -55,11 +55,11 @@ def main():
     # Remove anything leftover inside the extracted directory.
     extract_path = args.output.joinpath('garage-sign')
     if extract_path.exists():
-        for f in os.listdir(extract_path):
-            shutil.rmtree(extract_path.joinpath(f))
+        for f in os.listdir(str(extract_path)):
+            shutil.rmtree(str(extract_path.joinpath(f)))
     # Always extract everything.
-    t = tarfile.open(path)
-    t.extractall(path=args.output)
+    t = tarfile.open(str(path))
+    t.extractall(path=str(args.output))
     return 0
 
 
@@ -68,16 +68,16 @@ def download(name, path, m, md5_hash):
     if r2.status_code != 200:
         print('Error: unable to request file!')
         return False
-    with open(path, mode='wb') as f:
+    with path.open(mode='wb') as f:
         shutil.copyfileobj(r2.raw, f)
     return check_md5(name, path, m, md5_hash)
 
 
 def check_md5(name, path, m, md5_hash):
-    if not tarfile.is_tarfile(path):
+    if not tarfile.is_tarfile(str(path)):
         print('Error: ' + name + ' is not a valid tar archive!')
         return False
-    with open(path, mode='rb') as f:
+    with path.open(mode='rb') as f:
         m.update(f.read())
     if m.hexdigest() == md5_hash:
         return True

--- a/scripts/get_garage_sign.py
+++ b/scripts/get_garage_sign.py
@@ -36,8 +36,13 @@ def main():
     if args.name:
         name = args.name
         if name not in versions:
-            print('Error: ' + name + ' not found in tuf-cli releases.')
-            return 1
+            # Try adding tgz in case it wasn't included.
+            name_ext = name + '.tgz'
+            if name_ext not in versions:
+                print('Error: ' + name + ' not found in tuf-cli releases.')
+                return 1
+            else:
+                name = name_ext
     else:
         name = sorted(versions)[-1]
     path = args.output.joinpath(name)

--- a/scripts/get_garage_sign.py
+++ b/scripts/get_garage_sign.py
@@ -15,11 +15,17 @@ from pathlib import Path
 def main():
     parser = argparse.ArgumentParser(description='Download a specific or the latest version of garage-sign')
     parser.add_argument('-n', '--name', help='specific version to download')
+    parser.add_argument('-s', '--sha256', help='expected hash of requested version')
     parser.add_argument('-o', '--output', type=Path, default=Path('.'), help='download directory')
     args = parser.parse_args()
     if not args.output.exists():
         print('Error: specified output directory ' + args.output + ' does not exist!')
         return 1
+    sha256_hash = args.sha256
+    if sha256_hash and not args.name:
+        print('Warning: sha256 hash specified without specifying a version.')
+    if args.name and not sha256_hash:
+        print('Warning: specific version requested without specifying the sha256 hash.')
 
     r = requests.get('https://ats-tuf-cli-releases.s3-eu-central-1.amazonaws.com')
     if r.status_code != 200:
@@ -47,15 +53,14 @@ def main():
         name = sorted(versions)[-1]
     path = args.output.joinpath(name)
     md5_hash = versions[name][1]
-    m = hashlib.md5()
-    if not path.is_file() or not check_md5(name, path, m, md5_hash):
+    if not path.is_file() or not check_hashes(name, path, md5_hash, sha256_hash):
         print('Downloading ' + name + ' from server...')
-        if download(name, path, m, md5_hash):
+        if download(name, path, md5_hash, sha256_hash):
             print(name + ' successfully downloaded and validated.')
         else:
             return 1
     else:
-        print(name + ' already present with valid md5 hash.')
+        print(name + ' already present and validated.')
 
     # Remove anything leftover inside the extracted directory.
     extract_path = args.output.joinpath('garage-sign')
@@ -68,27 +73,37 @@ def main():
     return 0
 
 
-def download(name, path, m, md5_hash):
+def download(name, path, md5_hash, sha256_hash):
     r2 = requests.get('https://ats-tuf-cli-releases.s3-eu-central-1.amazonaws.com/' + name, stream=True)
     if r2.status_code != 200:
         print('Error: unable to request file!')
         return False
     with path.open(mode='wb') as f:
         shutil.copyfileobj(r2.raw, f)
-    return check_md5(name, path, m, md5_hash)
+    return check_hashes(name, path, md5_hash, sha256_hash)
 
 
-def check_md5(name, path, m, md5_hash):
+def check_hashes(name, path, md5_hash, sha256_hash):
     if not tarfile.is_tarfile(str(path)):
         print('Error: ' + name + ' is not a valid tar archive!')
         return False
+    m = hashlib.md5()
+    if sha256_hash:
+        s = hashlib.sha256()
     with path.open(mode='rb') as f:
-        m.update(f.read())
-    if m.hexdigest() == md5_hash:
-        return True
-    else:
+        data = f.read()
+        m.update(data)
+        if sha256_hash:
+            s.update(data)
+    if m.hexdigest() != md5_hash:
         print('Error: md5 hash of ' + name + ' does not match expected value!')
+        print(m.hexdigest())
+        print(md5_hash)
         return False
+    if sha256_hash and s.hexdigest() != sha256_hash:
+        print('Error: sha256 hash of ' + name + ' does not match provided value!')
+        return False
+    return True
 
 
 if __name__ == '__main__':

--- a/scripts/get_garage_sign.py
+++ b/scripts/get_garage_sign.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+import hashlib
+import requests
+import shutil
+import sys
+import xml.etree.ElementTree as ET
+
+
+def main():
+    r = requests.get('https://ats-tuf-cli-releases.s3-eu-central-1.amazonaws.com')
+    if r.status_code != 200:
+        print('Error: unable to request index!')
+        return 1
+    tree = ET.fromstring(r.text)
+    # Assume namespace.
+    ns = '{http://s3.amazonaws.com/doc/2006-03-01/}'
+    items = tree.findall(ns + 'Contents')
+    versions = dict()
+    for i in (i for i in items if i.find(ns + 'Key').text[0:4] == 'cli-'):
+        # ETag is md5sum.
+        versions[i.find(ns + 'LastModified').text] = (i.find(ns + 'Key').text, i.find(ns + 'ETag').text[1:-1])
+    latest = sorted(versions)[-1]
+    name = versions[latest][0]
+    md5_hash = versions[latest][1]
+    r2 = requests.get('https://ats-tuf-cli-releases.s3-eu-central-1.amazonaws.com/' + name, stream=True)
+    if r2.status_code != 200:
+        print('Error: unable to request file!')
+        return 1
+    with open(name, mode='wb') as f:
+        shutil.copyfileobj(r2.raw, f)
+    m = hashlib.md5()
+    with open(name, mode='rb') as f:
+        m.update(f.read())
+    if m.hexdigest() != md5_hash:
+        print('Error: md5 hash does not match!')
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/get_garage_sign.py
+++ b/scripts/get_garage_sign.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import hashlib
+import os.path
 import requests
 import shutil
 import sys
@@ -23,19 +24,32 @@ def main():
     latest = sorted(versions)[-1]
     name = versions[latest][0]
     md5_hash = versions[latest][1]
+    m = hashlib.md5()
+    if os.path.isfile(name):
+        if check_md5(name, m, md5_hash):
+            print(name + ' already present with valid md5 hash.')
+            return 0
+        else:
+            print('md5 hash of local ' + name + ' doesn\'t match expected value, downloading from server...')
+
     r2 = requests.get('https://ats-tuf-cli-releases.s3-eu-central-1.amazonaws.com/' + name, stream=True)
     if r2.status_code != 200:
         print('Error: unable to request file!')
         return 1
     with open(name, mode='wb') as f:
         shutil.copyfileobj(r2.raw, f)
-    m = hashlib.md5()
+    if not check_md5(name, m, md5_hash):
+        print('Error: md5 hash of ' + name + ' does not match expected value!')
+        return 1
+    else:
+        print(name + ' successfully downloaded with valid md5 hash.')
+        return 0
+
+
+def check_md5(name, m, md5_hash):
     with open(name, mode='rb') as f:
         m.update(f.read())
-    if m.hexdigest() != md5_hash:
-        print('Error: md5 hash does not match!')
-        return 1
-    return 0
+    return m.hexdigest() == md5_hash
 
 
 if __name__ == '__main__':

--- a/scripts/get_garage_sign.py
+++ b/scripts/get_garage_sign.py
@@ -36,7 +36,8 @@ def main():
     ns = '{http://s3.amazonaws.com/doc/2006-03-01/}'
     items = tree.findall(ns + 'Contents')
     versions = dict()
-    for i in (i for i in items if i.find(ns + 'Key').text[0:4] == 'cli-'):
+    cli_items = [i for i in items if i.find(ns + 'Key').text.startswith('cli-')]
+    for i in cli_items:
         # ETag is md5sum.
         versions[i.find(ns + 'Key').text] = (i.find(ns + 'LastModified').text, i.find(ns + 'ETag').text[1:-1])
     if args.name:

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,11 +9,11 @@ cmake -DBUILD_OSTREE=ON -DBUILD_SOTA_TOOLS=ON -DBUILD_ISOTP=ON -DBUILD_DEB=ON -D
 make -j8
 
 # Check that 'make install' works
-DESTDIR=/tmp/aktualizr make install
+DESTDIR=/tmp/aktualizr make install -j8
 
 if [ -n "$BUILD_ONLY" ]; then
   if [ -n "$BUILD_DEB" ]; then
-    make package
+    make package -j8
     cp garage_deploy.deb /persistent/
   fi
   echo "Skipping test run because of BUILD_ONLY environment variable"

--- a/src/eventsinterpreter.cc
+++ b/src/eventsinterpreter.cc
@@ -34,7 +34,7 @@ void EventsInterpreter::run() {
     if (event->variant == "UptaneTimestampUpdated") {
       // These events indicates the end of pooling cycle
       if (!config.uptane.polling) {
-        // the option --pooling-once is set, so we need to exit now
+        // the option --poll-once is set, so we need to exit now
         *commands_channel << std::make_shared<command::Shutdown>();
       }
     }

--- a/src/sota_tools/CMakeLists.txt
+++ b/src/sota_tools/CMakeLists.txt
@@ -96,9 +96,13 @@ if (BUILD_SOTA_TOOLS)
   if(GARAGE_SIGN_VERSION)
     set(GARAGE_SIGN_VERSION_ARG "--name" ${GARAGE_SIGN_VERSION})
   endif(GARAGE_SIGN_VERSION)
+  if(GARAGE_SIGN_SHA256)
+    set(GARAGE_SIGN_SHA256_ARG "--sha256" ${GARAGE_SIGN_SHA256})
+  endif(GARAGE_SIGN_SHA256)
   add_custom_target(garage-sign
                     COMMAND ${PROJECT_SOURCE_DIR}/scripts/get_garage_sign.py
-                    --output ${CMAKE_CURRENT_BINARY_DIR} ${GARAGE_SIGN_VERSION_ARG})
+                    --output ${CMAKE_CURRENT_BINARY_DIR}
+                    ${GARAGE_SIGN_VERSION_ARG} ${GARAGE_SIGN_SHA256_ARG})
   add_dependencies(garage-deploy garage-sign)
 
   install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/garage-sign/bin/garage-sign DESTINATION bin COMPONENT garage_deploy)

--- a/src/sota_tools/CMakeLists.txt
+++ b/src/sota_tools/CMakeLists.txt
@@ -88,18 +88,21 @@ if (BUILD_SOTA_TOOLS)
 
   add_dependencies(build_tests garage-deploy)
 
-
   install(TARGETS garage-deploy RUNTIME DESTINATION bin COMPONENT garage_deploy)
 
-  include(ExternalProject)
-  ExternalProject_Add(garage-sign DEPENDS garage-deploy
-                      URL https://ats-tuf-cli-releases.s3-eu-central-1.amazonaws.com/cli-0.2.0-134-ge27cd8a.tgz
-                      URL_HASH SHA256=6c00814dc49566dffb703ffe873a7e1d87a7bc345b7830737d0712bf88a85ffd
-                      CONFIGURE_COMMAND "" BUILD_COMMAND "" INSTALL_COMMAND "")
-  ExternalProject_Get_Property(garage-sign SOURCE_DIR)
 
-  install(PROGRAMS ${SOURCE_DIR}/bin/garage-sign DESTINATION bin COMPONENT garage_deploy)
-  install(DIRECTORY ${SOURCE_DIR}/lib DESTINATION . COMPONENT garage_deploy)
+  ### garage-sign targets
+
+  if(GARAGE_SIGN_VERSION)
+    set(GARAGE_SIGN_VERSION_ARG "--name" ${GARAGE_SIGN_VERSION})
+  endif(GARAGE_SIGN_VERSION)
+  add_custom_target(garage-sign
+                    COMMAND ${PROJECT_SOURCE_DIR}/scripts/get_garage_sign.py
+                    --output ${CMAKE_CURRENT_BINARY_DIR} ${GARAGE_SIGN_VERSION_ARG})
+  add_dependencies(garage-deploy garage-sign)
+
+  install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/garage-sign/bin/garage-sign DESTINATION bin COMPONENT garage_deploy)
+  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/garage-sign/lib DESTINATION . COMPONENT garage_deploy)
 endif (BUILD_SOTA_TOOLS)
 
 


### PR DESCRIPTION
Use a script to fetch garage-sign instead of hardcoding a specific version.

Define `GARAGE_SIGN_VERSION` to control the version to download and package, e.g. `cmake ../ -DGARAGE_SIGN_VERSION=cli-0.3.0-5-g5908997.tgz`

Define `GARAGE_SIGN_SHA256` to provide a hash to check the downloaded file, e.g. `cmake ../ -DGARAGE_SIGN_SHA256=a24efff06bbe1617947d4a08a74f617af9a306d7013f0881407df9d630253b2b`
    
The default is the version whose name sorts highest, which should be the greatest version number. If the layout or content of the tuf-cli releases page changes substantially, this may break.