### PR TITLE
Update / re-enable vector tests

### DIFF
--- a/src/uptane/tuf.cc
+++ b/src/uptane/tuf.cc
@@ -101,9 +101,9 @@ std::ostream &Uptane::operator<<(std::ostream &os, const Hash &h) {
 Target::Target(const std::string &filename, const Json::Value &content) : filename_(filename), ecu_identifier_("") {
   if (content.isMember("custom")) {
     Json::Value custom = content["custom"];
-    // TODO: Hardware identifier?
     if (custom.isMember("ecuIdentifier")) ecu_identifier_ = custom["ecuIdentifier"].asString();
     if (custom.isMember("targetFormat")) type_ = custom["targetFormat"].asString();
+    if (custom.isMember("hardwareId")) hardware_id_ = custom["hardwareId"].asString();
   }
 
   length_ = content["length"].asInt64();

--- a/src/uptane/tuf.h
+++ b/src/uptane/tuf.h
@@ -108,12 +108,13 @@ class Target {
  public:
   Target(const std::string &filename, const Json::Value &content);
 
-  // TODO: ECU HW ID
   std::string ecu_identifier() const { return ecu_identifier_; }
   std::string filename() const { return filename_; }
   std::string format() const { return type_; }
   std::string sha256Hash() const;
   std::vector<Hash> hashes() const { return hashes_; };
+
+  bool IsForHardwareId(std::string hardware_id) const { return hardware_id == hardware_id_; }
 
   bool MatchWith(const Hash &hash) const;
 
@@ -128,6 +129,7 @@ class Target {
     // if (type_ != t2.type_) return false; // Director doesn't include targetFormat
     if (filename_ != t2.filename_) return false;
     if (length_ != t2.length_) return false;
+    if (hardware_id_ != t2.hardware_id_) return false;
 
     // requirements:
     // - all hashes of the same type should match
@@ -150,6 +152,8 @@ class Target {
   std::string ecu_identifier_;
   std::vector<Hash> hashes_;
   int64_t length_;
+
+  std::string hardware_id_;
 };
 
 std::ostream &operator<<(std::ostream &os, const Target &t);

--- a/tests/run_vector_tests.sh
+++ b/tests/run_vector_tests.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+: ${1:?'missing arg'}
+
 if [ ! -f venv/bin/activate ]; then
   python3 -m venv venv
 fi
@@ -12,9 +14,15 @@ pip install -r "$1/requirements.txt"
 
 PORT=`$1/../get_open_port.py`
 
-$1/generator.py -t uptane --signature-encoding base64 -o vectors --cjson json-subset
-$1/server.py -t uptane --signature-encoding base64 -P $PORT &
-sleep 3
+
+$1/server.py -t uptane --signature-encoding base64 -P $PORT \
+    --cjson json-subset \
+    --hardware-id FIXME --ecu-identifier FIXMETOO &
+
+while ! curl "localhost:$PORT"; do
+    sleep 0.1
+done
+
 trap 'kill %1' EXIT
 
 if [ "$2" == "valgrind" ]; then

--- a/tests/run_vector_tests.sh
+++ b/tests/run_vector_tests.sh
@@ -17,7 +17,7 @@ PORT=`$1/../get_open_port.py`
 
 $1/server.py -t uptane --signature-encoding base64 -P $PORT \
     --cjson json-subset \
-    --hardware-id FIXME --ecu-identifier FIXMETOO &
+    --hardware-id hardwareid1 --ecu-identifier serial1 &
 
 while ! curl "localhost:$PORT"; do
     sleep 0.1


### PR DESCRIPTION
Currently the tests fail because of unimplemented features in `aktualizr`. We need to abort on incorrect hardware IDs.

This PR is **not** ready for merge. There are two `FIXME`s in the runner script. We need to be able to init the `aktualizr` client in the test cases with a hardware ID and ECU ID so that tests that purposely violate that constraint can be correctly passed/failed.