### PR TITLE
Fix `git describe` on travis

### DIFF
--- a/scripts/build-ubuntu.sh
+++ b/scripts/build-ubuntu.sh
@@ -15,4 +15,5 @@ cp -f ../src/scripts/test_aktualizr_deb_and_update.sh /persistent/test_aktualizr
 cp -rf ../src/tests/test_data/fake_root /persistent/
 
 
+git -C ../src fetch --unshallow
 git -C ../src describe > /persistent/aktualizr-version


### PR DESCRIPTION
Travis uses a shallow clone to save time and bandwidth. We now have
reached a point where the last tagged commit is outside Travis' clone
range.

Solution: fetch the whole repo before running describe