### PR TITLE
Pull newer valgrind that understands C++11 instructions.

### DIFF
--- a/Dockerfile.nop11
+++ b/Dockerfile.nop11
@@ -51,8 +51,14 @@ RUN apt-get update && apt-get -y install \
   python3-gi \
   python3-openssl \
   python3-venv \
-  valgrind \
   wget
+
+# Workaround for this bug:
+# https://bugs.launchpad.net/ubuntu/+source/valgrind/+bug/1501545
+# https://stackoverflow.com/questions/37032339/valgrind-unrecognised-instruction
+RUN echo "deb http://mirrors.kernel.org/ubuntu/ artful main multiverse restricted universe" > /etc/apt/sources.list.d/artful.list
+RUN apt-get update && apt-get -y install \
+  valgrind
 
 RUN useradd testuser
 WORKDIR aktualizr

--- a/tests/aktualizr.supp
+++ b/tests/aktualizr.supp
@@ -52,7 +52,6 @@
    ...
    fun:_ZN5boost10filesystem11path_traits7convertEPKwS3_RNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKSt7codecvtIwc11__mbstate_tE
    fun:_ZN5boost10filesystem6detail11unique_pathERKNS0_4pathEPNS_6system10error_codeE
-   fun:_ZN5boost10filesystem11unique_pathERKNS0_4pathE
    ...
 }
 {
@@ -61,7 +60,6 @@
    ...
    fun:_ZN5boost10filesystem11path_traits7convertEPKwS3_RNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKSt7codecvtIwc11__mbstate_tE
    fun:_ZN5boost10filesystem6detail11unique_pathERKNS0_4pathEPNS_6system10error_codeE
-   fun:_ZN5boost10filesystem11unique_pathERKNS0_4pathE
    ...
 }
 {


### PR DESCRIPTION
This was causing an annoying tendency for our nop11 builds to fail in CI. More information:
https://bugs.launchpad.net/ubuntu/+source/valgrind/+bug/1501545
https://stackoverflow.com/questions/37032339/valgrind-unrecognised-instruction