### PR TITLE
Trigger poll event in poll event processor to avoid accumulation of events

### DIFF
--- a/src/aktualizr.cc
+++ b/src/aktualizr.cc
@@ -31,9 +31,9 @@ Aktualizr::Aktualizr(Config &config) : config_(config) {
 
 int Aktualizr::run() {
   std::shared_ptr<command::Channel> commands_channel{new command::Channel};
-  event::Channel events_channel;
+  std::shared_ptr<event::Channel> events_channel{new event::Channel};
 
-  EventsInterpreter events_interpreter(config_, &events_channel, commands_channel);
+  EventsInterpreter events_interpreter(config_, events_channel, commands_channel);
 
   // run events interpreter in background
   events_interpreter.interpret();
@@ -42,7 +42,7 @@ int Aktualizr::run() {
   storage->importData(config_.import);
   HttpClient http;
   Uptane::Repository repo(config_, storage, http);
-  SotaUptaneClient uptane_client(config_, &events_channel, repo, storage, http);
+  SotaUptaneClient uptane_client(config_, events_channel, repo, storage, http);
   uptane_client.runForever(commands_channel);
 
   return EXIT_SUCCESS;

--- a/src/aktualizr.cc
+++ b/src/aktualizr.cc
@@ -30,10 +30,10 @@ Aktualizr::Aktualizr(Config &config) : config_(config) {
 }
 
 int Aktualizr::run() {
-  command::Channel commands_channel;
+  std::shared_ptr<command::Channel> commands_channel{new command::Channel};
   event::Channel events_channel;
 
-  EventsInterpreter events_interpreter(config_, &events_channel, &commands_channel);
+  EventsInterpreter events_interpreter(config_, &events_channel, commands_channel);
 
   // run events interpreter in background
   events_interpreter.interpret();
@@ -43,7 +43,7 @@ int Aktualizr::run() {
   HttpClient http;
   Uptane::Repository repo(config_, storage, http);
   SotaUptaneClient uptane_client(config_, &events_channel, repo, storage, http);
-  uptane_client.runForever(&commands_channel);
+  uptane_client.runForever(commands_channel);
 
   return EXIT_SUCCESS;
 }

--- a/src/channel.h
+++ b/src/channel.h
@@ -36,7 +36,7 @@ class Channel {
    */
   void operator<<(const T &target) {
     std::unique_lock<std::mutex> lock(m);
-    if (closed) throw std::logic_error("Attempt to write to closed channel.");
+    if (closed) return;
     fill_cv.wait(lock, [this]() { return hasSpace(); });
     q.push(target);
     drain_cv.notify_one();

--- a/src/eventsinterpreter.cc
+++ b/src/eventsinterpreter.cc
@@ -4,7 +4,7 @@
 
 #include "config.h"
 
-EventsInterpreter::EventsInterpreter(const Config& config_in, event::Channel* events_channel_in,
+EventsInterpreter::EventsInterpreter(const Config& config_in, std::shared_ptr<event::Channel> events_channel_in,
                                      std::shared_ptr<command::Channel> commands_channel_in)
     : config(config_in),
       events_channel(events_channel_in),

--- a/src/eventsinterpreter.cc
+++ b/src/eventsinterpreter.cc
@@ -5,7 +5,7 @@
 #include "config.h"
 
 EventsInterpreter::EventsInterpreter(const Config& config_in, event::Channel* events_channel_in,
-                                     command::Channel* commands_channel_in)
+                                     std::shared_ptr<command::Channel> commands_channel_in)
     : config(config_in),
       events_channel(events_channel_in),
       commands_channel(commands_channel_in),

--- a/src/eventsinterpreter.h
+++ b/src/eventsinterpreter.h
@@ -10,7 +10,7 @@
 
 class EventsInterpreter {
  public:
-  EventsInterpreter(const Config &config_in, event::Channel *events_channel_in,
+  EventsInterpreter(const Config &config_in, std::shared_ptr<event::Channel> events_channel_in,
                     std::shared_ptr<command::Channel> commands_channel_in);
   ~EventsInterpreter();
   void interpret();
@@ -19,7 +19,7 @@ class EventsInterpreter {
  private:
   const Config &config;
   std::thread thread;
-  event::Channel *events_channel;
+  std::shared_ptr<event::Channel> events_channel;
   std::shared_ptr<command::Channel> commands_channel;
   GatewayManager gateway_manager;
 };

--- a/src/eventsinterpreter.h
+++ b/src/eventsinterpreter.h
@@ -10,7 +10,8 @@
 
 class EventsInterpreter {
  public:
-  EventsInterpreter(const Config &config_in, event::Channel *events_channel_in, command::Channel *commands_channel_in);
+  EventsInterpreter(const Config &config_in, event::Channel *events_channel_in,
+                    std::shared_ptr<command::Channel> commands_channel_in);
   ~EventsInterpreter();
   void interpret();
   void run();
@@ -19,7 +20,7 @@ class EventsInterpreter {
   const Config &config;
   std::thread thread;
   event::Channel *events_channel;
-  command::Channel *commands_channel;
+  std::shared_ptr<command::Channel> commands_channel;
   GatewayManager gateway_manager;
 };
 

--- a/src/gatewaymanager.cc
+++ b/src/gatewaymanager.cc
@@ -3,7 +3,7 @@
 #include "gatewaymanager.h"
 #include "socketgateway.h"
 
-GatewayManager::GatewayManager(const Config &config, command::Channel *commands_channel_in) {
+GatewayManager::GatewayManager(const Config &config, std::shared_ptr<command::Channel> commands_channel_in) {
   if (config.gateway.socket) {
     gateways.push_back(std::make_shared<SocketGateway>(config, commands_channel_in));
   }

--- a/src/gatewaymanager.h
+++ b/src/gatewaymanager.h
@@ -9,7 +9,7 @@
 
 class GatewayManager {
  public:
-  GatewayManager(const Config &config, command::Channel *commands_channel_in);
+  GatewayManager(const Config &config, std::shared_ptr<command::Channel> commands_channel_in);
   void processEvents(const std::shared_ptr<event::BaseEvent> &event);
 
  private:

--- a/src/socketgateway.cc
+++ b/src/socketgateway.cc
@@ -11,7 +11,7 @@
 using std::make_shared;
 using std::shared_ptr;
 
-SocketGateway::SocketGateway(const Config &config_in, command::Channel *commands_channel_in)
+SocketGateway::SocketGateway(const Config &config_in, std::shared_ptr<command::Channel> commands_channel_in)
     : config(config_in), commands_channel(commands_channel_in) {
   unlink(config.network.socket_events_path.c_str());
   unlink(config.network.socket_commands_path.c_str());
@@ -41,7 +41,7 @@ SocketGateway::~SocketGateway() {
   unlink(config.network.socket_commands_path.c_str());
 }
 
-void SocketGateway::commandsWorker(int socket, command::Channel *channel) {
+void SocketGateway::commandsWorker(int socket, std::shared_ptr<command::Channel> channel) {
   const int buff_size = 512;
   char buf[buff_size];
   std::string data;

--- a/src/socketgateway.h
+++ b/src/socketgateway.h
@@ -11,7 +11,7 @@
 
 class SocketGateway : public Gateway {
  public:
-  SocketGateway(const Config &config_in, command::Channel *commands_channel_in);
+  SocketGateway(const Config &config_in, std::shared_ptr<command::Channel> commands_channel_in);
   SocketGateway(const SocketGateway &) = delete;
   SocketGateway operator=(const SocketGateway &) = delete;
 
@@ -20,7 +20,7 @@ class SocketGateway : public Gateway {
 
  private:
   const Config &config;
-  command::Channel *commands_channel;
+  std::shared_ptr<command::Channel> commands_channel;
   std::vector<int> event_connections;
   std::vector<int> command_connections;
   std::vector<std::shared_ptr<std::thread> > command_workers;
@@ -31,7 +31,7 @@ class SocketGateway : public Gateway {
 
   void eventsServer();
   void commandsServer();
-  void commandsWorker(int socket, command::Channel *channel);
+  void commandsWorker(int socket, std::shared_ptr<command::Channel> channel);
   void broadcast_event(const std::shared_ptr<event::BaseEvent> &event);
 };
 

--- a/src/sotauptaneclient.cc
+++ b/src/sotauptaneclient.cc
@@ -13,8 +13,9 @@
 #include "utilities/keymanager.h"
 #include "utilities/utils.h"
 
-SotaUptaneClient::SotaUptaneClient(Config &config_in, event::Channel *events_channel_in, Uptane::Repository &repo,
-                                   const std::shared_ptr<INvStorage> storage_in, HttpInterface &http_client)
+SotaUptaneClient::SotaUptaneClient(Config &config_in, std::shared_ptr<event::Channel> events_channel_in,
+                                   Uptane::Repository &repo, const std::shared_ptr<INvStorage> storage_in,
+                                   HttpInterface &http_client)
     : config(config_in),
       events_channel(events_channel_in),
       uptane_repo(repo),

--- a/src/sotauptaneclient.h
+++ b/src/sotauptaneclient.h
@@ -33,7 +33,7 @@ class SotaUptaneClient {
   void PackageInstallSetResult(const Uptane::Target &target);
   void reportHwInfo();
   void reportInstalledPackages();
-  void run(command::Channel *commands_channel);
+  void schedulePoll(command::Channel *commands_channel);
   void initSecondaries();
   void verifySecondaries();
   void sendMetadataToEcus(std::vector<Uptane::Target> targets);

--- a/src/sotauptaneclient.h
+++ b/src/sotauptaneclient.h
@@ -19,7 +19,7 @@ class SotaUptaneClient {
  public:
   SotaUptaneClient(Config &config_in, event::Channel *events_channel_in, Uptane::Repository &repo,
                    const std::shared_ptr<INvStorage> storage_in, HttpInterface &http_client);
-  void runForever(command::Channel *commands_channel);
+  void runForever(std::shared_ptr<command::Channel> commands_channel);
   Json::Value AssembleManifest();
   std::string secondaryTreehubCredentials() const;
 
@@ -33,7 +33,7 @@ class SotaUptaneClient {
   void PackageInstallSetResult(const Uptane::Target &target);
   void reportHwInfo();
   void reportInstalledPackages();
-  void schedulePoll(command::Channel *commands_channel);
+  void schedulePoll(std::shared_ptr<command::Channel> commands_channel);
   void initSecondaries();
   void verifySecondaries();
   void sendMetadataToEcus(std::vector<Uptane::Target> targets);

--- a/src/sotauptaneclient.h
+++ b/src/sotauptaneclient.h
@@ -17,7 +17,7 @@
 
 class SotaUptaneClient {
  public:
-  SotaUptaneClient(Config &config_in, event::Channel *events_channel_in, Uptane::Repository &repo,
+  SotaUptaneClient(Config &config_in, std::shared_ptr<event::Channel> events_channel_in, Uptane::Repository &repo,
                    const std::shared_ptr<INvStorage> storage_in, HttpInterface &http_client);
   void runForever(std::shared_ptr<command::Channel> commands_channel);
   Json::Value AssembleManifest();
@@ -42,7 +42,7 @@ class SotaUptaneClient {
   bool putManifest();
 
   Config &config;
-  event::Channel *events_channel;
+  std::shared_ptr<event::Channel> events_channel;
   Uptane::Repository &uptane_repo;
   const std::shared_ptr<INvStorage> storage;
   std::shared_ptr<PackageManagerInterface> pacman;

--- a/tests/socketgateway_test.cc
+++ b/tests/socketgateway_test.cc
@@ -25,9 +25,9 @@ TEST(EventsTest, broadcasted) {
   Config conf;
   conf.network = network_conf;
 
-  command::Channel chan;
+  std::shared_ptr<command::Channel> chan{new command::Channel};
 
-  SocketGateway gateway(conf, &chan);
+  SocketGateway gateway(conf, chan);
   sleep(1);
   std::string cmd =
       (socket_path / "events.py").string() + " " + (temp_dir.Path() / "sota-events.socket").string() + " &";
@@ -50,9 +50,9 @@ TEST(EventsTest, not_broadcasted) {
   Config conf;
   conf.network = network_conf;
 
-  command::Channel chan;
+  std::shared_ptr<command::Channel> chan{new command::Channel};
 
-  SocketGateway gateway(conf, &chan);
+  SocketGateway gateway(conf, chan);
   std::string cmd =
       (socket_path / "events.py").string() + " " + (temp_dir.Path() / "sota-events.socket").string() + " &";
   EXPECT_EQ(system(cmd.c_str()), 0);
@@ -73,15 +73,15 @@ TEST(CommandsTest, recieved) {
   Config conf;
   conf.network = network_conf;
 
-  command::Channel chan;
+  std::shared_ptr<command::Channel> chan{new command::Channel};
 
-  SocketGateway gateway(conf, &chan);
+  SocketGateway gateway(conf, chan);
   std::string cmd =
       (socket_path / "commands.py").string() + " " + (temp_dir.Path() / "sota-commands.socket").string() + " &";
   EXPECT_EQ(system(cmd.c_str()), 0);
   sleep(1);
   std::shared_ptr<command::BaseCommand> command;
-  chan >> command;
+  *chan >> command;
 
   EXPECT_EQ(command->variant, "Shutdown");
 }

--- a/tests/uptane_key_test.cc
+++ b/tests/uptane_key_test.cc
@@ -118,8 +118,8 @@ TEST(UptaneKey, CheckAllKeys) {
 
   auto storage = INvStorage::newStorage(config.storage);
   Uptane::Repository uptane(config, storage, http);
-  event::Channel events_channel;
-  SotaUptaneClient sota_client(config, &events_channel, uptane, storage, http);
+  std::shared_ptr<event::Channel> events_channel{new event::Channel};
+  SotaUptaneClient sota_client(config, events_channel, uptane, storage, http);
   EXPECT_TRUE(uptane.initialize());
   checkKeyTests(storage, sota_client);
 }
@@ -139,8 +139,8 @@ TEST(UptaneKey, RecoverWithoutKeys) {
   {
     auto storage = INvStorage::newStorage(config.storage);
     Uptane::Repository uptane(config, storage, http);
-    event::Channel events_channel;
-    SotaUptaneClient sota_client(config, &events_channel, uptane, storage, http);
+    std::shared_ptr<event::Channel> events_channel{new event::Channel};
+    SotaUptaneClient sota_client(config, events_channel, uptane, storage, http);
 
     EXPECT_TRUE(uptane.initialize());
     checkKeyTests(storage, sota_client);
@@ -151,8 +151,8 @@ TEST(UptaneKey, RecoverWithoutKeys) {
   {
     auto storage = INvStorage::newStorage(config.storage);
     Uptane::Repository uptane(config, storage, http);
-    event::Channel events_channel;
-    SotaUptaneClient sota_client(config, &events_channel, uptane, storage, http);
+    std::shared_ptr<event::Channel> events_channel{new event::Channel};
+    SotaUptaneClient sota_client(config, events_channel, uptane, storage, http);
 
     EXPECT_TRUE(uptane.initialize());
     checkKeyTests(storage, sota_client);
@@ -169,8 +169,8 @@ TEST(UptaneKey, RecoverWithoutKeys) {
   {
     auto storage = INvStorage::newStorage(config.storage);
     Uptane::Repository uptane(config, storage, http);
-    event::Channel events_channel;
-    SotaUptaneClient sota_client(config, &events_channel, uptane, storage, http);
+    std::shared_ptr<event::Channel> events_channel{new event::Channel};
+    SotaUptaneClient sota_client(config, events_channel, uptane, storage, http);
 
     EXPECT_TRUE(uptane.initialize());
     checkKeyTests(storage, sota_client);

--- a/tests/uptane_test.cc
+++ b/tests/uptane_test.cc
@@ -597,17 +597,17 @@ TEST(Uptane, RunForeverNoUpdates) {
 
   conf.tls.server = http.tls_server;
   event::Channel events_channel;
-  command::Channel commands_channel;
+  std::shared_ptr<command::Channel> commands_channel{new command::Channel};
 
-  commands_channel << std::make_shared<command::GetUpdateRequests>();
-  commands_channel << std::make_shared<command::GetUpdateRequests>();
-  commands_channel << std::make_shared<command::GetUpdateRequests>();
-  commands_channel << std::make_shared<command::Shutdown>();
+  *commands_channel << std::make_shared<command::GetUpdateRequests>();
+  *commands_channel << std::make_shared<command::GetUpdateRequests>();
+  *commands_channel << std::make_shared<command::GetUpdateRequests>();
+  *commands_channel << std::make_shared<command::Shutdown>();
 
   auto storage = INvStorage::newStorage(conf.storage);
   Uptane::Repository repo(conf, storage, http);
   SotaUptaneClient up(conf, &events_channel, repo, storage, http);
-  up.runForever(&commands_channel);
+  up.runForever(commands_channel);
 
   std::shared_ptr<event::BaseEvent> event;
 
@@ -654,14 +654,14 @@ TEST(Uptane, RunForeverHasUpdates) {
 
   conf.tls.server = http.tls_server;
   event::Channel events_channel;
-  command::Channel commands_channel;
+  std::shared_ptr<command::Channel> commands_channel{new command::Channel};
 
-  commands_channel << std::make_shared<command::GetUpdateRequests>();
-  commands_channel << std::make_shared<command::Shutdown>();
+  *commands_channel << std::make_shared<command::GetUpdateRequests>();
+  *commands_channel << std::make_shared<command::Shutdown>();
   auto storage = INvStorage::newStorage(conf.storage);
   Uptane::Repository repo(conf, storage, http);
   SotaUptaneClient up(conf, &events_channel, repo, storage, http);
-  up.runForever(&commands_channel);
+  up.runForever(commands_channel);
 
   std::shared_ptr<event::BaseEvent> event;
   EXPECT_TRUE(events_channel.hasValues());
@@ -700,15 +700,15 @@ TEST(Uptane, RunForeverInstall) {
 
   conf.tls.server = http.tls_server;
   event::Channel events_channel;
-  command::Channel commands_channel;
+  std::shared_ptr<command::Channel> commands_channel{new command::Channel};
 
   std::vector<Uptane::Target> packages_to_install = makePackage("testostree");
-  commands_channel << std::make_shared<command::UptaneInstall>(packages_to_install);
-  commands_channel << std::make_shared<command::Shutdown>();
+  *commands_channel << std::make_shared<command::UptaneInstall>(packages_to_install);
+  *commands_channel << std::make_shared<command::Shutdown>();
   auto storage = INvStorage::newStorage(conf.storage);
   Uptane::Repository repo(conf, storage, http);
   SotaUptaneClient up(conf, &events_channel, repo, storage, http);
-  up.runForever(&commands_channel);
+  up.runForever(commands_channel);
 
   EXPECT_TRUE(boost::filesystem::exists(temp_dir.Path() / http.test_manifest));
 
@@ -785,16 +785,16 @@ TEST(Uptane, ProvisionOnServer) {
   config.storage.path = temp_dir.Path();
 
   event::Channel events_channel;
-  command::Channel commands_channel;
+  std::shared_ptr<command::Channel> commands_channel{new command::Channel};
   auto storage = INvStorage::newStorage(config.storage);
   HttpFake http(temp_dir.Path());
   std::vector<Uptane::Target> packages_to_install = makePackage(config.uptane.primary_ecu_serial);
-  commands_channel << std::make_shared<command::GetUpdateRequests>();
-  commands_channel << std::make_shared<command::UptaneInstall>(packages_to_install);
-  commands_channel << std::make_shared<command::Shutdown>();
+  *commands_channel << std::make_shared<command::GetUpdateRequests>();
+  *commands_channel << std::make_shared<command::UptaneInstall>(packages_to_install);
+  *commands_channel << std::make_shared<command::Shutdown>();
   Uptane::Repository repo(config, storage, http);
   SotaUptaneClient up(config, &events_channel, repo, storage, http);
-  up.runForever(&commands_channel);
+  up.runForever(commands_channel);
 }
 
 TEST(Uptane, CheckOldProvision) {


### PR DESCRIPTION
Accumulation gets especially annoying when debugging aktualizr, but can also slow everything down if network connection is slow/unstable.