### PR TITLE
Bugfix/pro 5337/fix config logging

### DIFF
--- a/src/aktualizr_secondary/aktualizr_secondary_config.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_config.cc
@@ -51,6 +51,12 @@ void AktualizrSecondaryUptaneConfig::writeToStream(std::ostream& out_stream) con
 
 AktualizrSecondaryConfig::AktualizrSecondaryConfig(const boost::filesystem::path& filename,
                                                    const boost::program_options::variables_map& cmd) {
+  // Redundantly check and set the loglevel from the commandline prematurely so
+  // that it is taken account while processing the config.
+  if (cmd.count("loglevel") != 0) {
+    logger.loglevel = static_cast<boost::log::trivial::severity_level>(cmd["loglevel"].as<int>());
+    logger.setLogLevel();
+  }
   updateFromToml(filename);
   updateFromCommandLine(cmd);
   postUpdateValues();
@@ -66,17 +72,7 @@ KeyManagerConfig AktualizrSecondaryConfig::keymanagerConfig() const {
   return KeyManagerConfig{p11, kFile, kFile, kFile, uptane.key_type, uptane.key_source};
 }
 
-void AktualizrSecondaryConfig::postUpdateValues() {
-  if (logger.loglevel < boost::log::trivial::trace) {
-    LOG_WARNING << "Invalid log level";
-    logger.loglevel = boost::log::trivial::trace;
-  }
-  if (boost::log::trivial::fatal < logger.loglevel) {
-    LOG_WARNING << "Invalid log level";
-    logger.loglevel = boost::log::trivial::fatal;
-  }
-  logger_set_threshold(logger.loglevel);
-}
+void AktualizrSecondaryConfig::postUpdateValues() { logger.setLogLevel(); }
 
 void AktualizrSecondaryConfig::updateFromCommandLine(const boost::program_options::variables_map& cmd) {
   if (cmd.count("loglevel") != 0) {

--- a/src/libaktualizr/config/config.h
+++ b/src/libaktualizr/config/config.h
@@ -116,7 +116,8 @@ class Config {
   void postUpdateValues();
   void writeToFile(const boost::filesystem::path& filename) const;
 
-  // config data structures
+  // Config data structures. Keep logger first so that it is taken into account
+  // while processing the others.
   LoggerConfig logger;
   GatewayConfig gateway;
   NetworkConfig network;

--- a/src/libaktualizr/logging/boost_logging.cc
+++ b/src/libaktualizr/logging/boost_logging.cc
@@ -25,6 +25,11 @@ int loggerGetSeverity() { return static_cast<int>(gLoggingThreshold); }
 
 void LoggerConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt) {
   CopyFromConfig(loglevel, "loglevel", boost::log::trivial::trace, pt);
+  // If not already set from the commandline, set the loglevel now so that it
+  // affects the rest of the config processing.
+  if (!initialized) {
+    setLogLevel();
+  }
 }
 
 void LoggerConfig::writeToStream(std::ostream& out_stream) const { writeOption(out_stream, loglevel, "loglevel"); }
@@ -39,6 +44,7 @@ void LoggerConfig::setLogLevel() {
     loglevel = boost::log::trivial::fatal;
   }
   logger_set_threshold(loglevel);
+  initialized = true;
 }
 
 // vim: set tabstop=2 shiftwidth=2 expandtab:

--- a/src/libaktualizr/logging/boost_logging.cc
+++ b/src/libaktualizr/logging/boost_logging.cc
@@ -29,4 +29,16 @@ void LoggerConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt)
 
 void LoggerConfig::writeToStream(std::ostream& out_stream) const { writeOption(out_stream, loglevel, "loglevel"); }
 
+void LoggerConfig::setLogLevel() {
+  if (loglevel < boost::log::trivial::trace) {
+    LOG_WARNING << "Invalid log level";
+    loglevel = boost::log::trivial::trace;
+  }
+  if (boost::log::trivial::fatal < loglevel) {
+    LOG_WARNING << "Invalid log level";
+    loglevel = boost::log::trivial::fatal;
+  }
+  logger_set_threshold(loglevel);
+}
+
 // vim: set tabstop=2 shiftwidth=2 expandtab:

--- a/src/libaktualizr/logging/logging.h
+++ b/src/libaktualizr/logging/logging.h
@@ -42,6 +42,9 @@ struct LoggerConfig {
   void writeToStream(std::ostream& out_stream) const;
 
   void setLogLevel();
+
+ private:
+  bool initialized{false};
 };
 
 #endif

--- a/src/libaktualizr/logging/logging.h
+++ b/src/libaktualizr/logging/logging.h
@@ -40,6 +40,8 @@ struct LoggerConfig {
 
   void updateFromPropertyTree(const boost::property_tree::ptree& pt);
   void writeToStream(std::ostream& out_stream) const;
+
+  void setLogLevel();
 };
 
 #endif


### PR DESCRIPTION
Now if loglevel is set on the commandline or in the config, it is taken into account while processing the rest of the config. This is a bit tedious, but I couldn't find a better way to make it work as expected.