### PR TITLE
Fix codecov ignore and rewrites

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,11 +1,5 @@
 ignore:
-  - "src/third_party"
-  - "src/tests"
-
-fixes:
-  - "src/::"     
-
-ignore:
-  - "tests"
   - "third_party"
+  - "tests"
   - "generated"
+  - "src/libaktualizr/third_party"


### PR DESCRIPTION
Since 434ee8487599ea6f1a44c635e49f99b5f8e3a3ce, no need to rewrite paths