### PR TITLE
Add explicit option for SOTA_PACKED_CREDENTIALS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ option(BUILD_OPCUA "Set to ON to compile with OPC-UA protocol support" OFF)
 option(BUILD_SYSTEMD "Set to ON to compile with systemd additional support" ON)
 option(BUILD_LOAD_TESTS "Set to ON to build load tests" ON)
 option(INSTALL_LIB "Set to ON to install library and headers" OFF)
+set(SOTA_PACKED_CREDENTIALS "" CACHE STRING "Credentials.zip for tests involving the server")
 
 set(TESTSUITE_ONLY "" CACHE STRING "Only run tests matching this list of labels")
 set(TESTSUITE_EXCLUDE "" CACHE STRING "Exclude tests matching this list of labels")


### PR DESCRIPTION
This makes it appear in the GUI, and should help avoid bugs like #741, where the tests are run without the option enabled

Change-Id: Id7b2aecd56a32004f1ed0141c27eabf97d44248e