### PR TITLE
Don't run clang-check on `make qa` and CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,6 @@ endif()
 
 if(CLANG_CHECK)
     add_custom_target(clang-check)
-    add_dependencies(qa clang-check)
     function(aktualizr_clang_check)
         file(RELATIVE_PATH SUBDIR ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
         foreach(FILE ${ARGN})

--- a/README.adoc
+++ b/README.adoc
@@ -113,7 +113,7 @@ Before checking in code, the code linting checks should be run:
 make qa
 ----
 
-This will reformat all the code with clang-format and run clang-check and the test suite. Please follow the https://google.github.io/styleguide/cppguide.html[Google C++ Style Guide] coding standard.
+This will reformat all the code with clang-format and run clang-tidy and the test suite. Please follow the https://google.github.io/styleguide/cppguide.html[Google C++ Style Guide] coding standard.
 
 By default, the compilation and tests run in sequence and the output of failing tests is suppressed. To run in parallel, for example with eight threads, and print the output of failing tests, run this:
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -98,7 +98,7 @@ if [[ $TEST_WITH_STATICTESTS = 1 ]]; then
     if [[ $TEST_DRYRUN != 1 ]]; then
         set -x
         make check-format -j8 || add_failure "formatting"
-        make clang-tidy clang-check -j8 || add_failure "static checks"
+        make clang-tidy -j8 || add_failure "static checks"
         set +x
     fi
 fi

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,7 +63,7 @@ add_asn1c_lib(asn1-reference/uptane/ipuptane_message)
 compile_asn1_lib()
 list(APPEND TEST_LIBS asn1_lib)
 
-# List of source files to run clang-format and clang-check on. Automatically
+# List of source files to run static analysis on. Automatically
 # appended to by add_aktualizr_test, but anything that doesn't use that must be
 # manually added to this list.
 set(TEST_SOURCES httpfake.h test_utils.cc test_utils.h)


### PR DESCRIPTION
I've become convinced that it's made redundant by clang-tidy.

Investigation: https://stackoverflow.com/questions/49943781/does-clang-tidy-make-clang-check-redundant/