### PR TITLE
Prevent aktualizr-info from probing legacy secondaries.

### DIFF
--- a/src/aktualizr_info/main.cc
+++ b/src/aktualizr_info/main.cc
@@ -36,7 +36,8 @@ int main(int argc, char **argv) {
       exit(EXIT_SUCCESS);
     }
 
-    Config config(vm);
+    bool process_legacy_interface = false;
+    Config config(vm, process_legacy_interface);
 
     std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
     std::cout << "Storage backend: " << ((storage->type() == kFileSystem) ? "Filesystem" : "Sqlite") << std::endl;

--- a/src/libaktualizr/config/config.cc
+++ b/src/libaktualizr/config/config.cc
@@ -219,7 +219,7 @@ Config::Config(const boost::filesystem::path& filename) {
   postUpdateValues();
 }
 
-Config::Config(const boost::program_options::variables_map& cmd) {
+Config::Config(const boost::program_options::variables_map& cmd, const bool process_legacy_interface_in) {
   // Redundantly check and set the loglevel from the commandline prematurely so
   // that it is taken account while processing the config.
   if (cmd.count("loglevel") != 0) {
@@ -227,6 +227,8 @@ Config::Config(const boost::program_options::variables_map& cmd) {
     logger_set_threshold(logger);
     loglevel_from_cmdline = true;
   }
+
+  process_legacy_interface = process_legacy_interface_in;
 
   if (cmd.count("config") > 0) {
     updateFromDirs(cmd["config"].as<std::vector<boost::filesystem::path>>());
@@ -284,8 +286,10 @@ void Config::postUpdateValues() {
     }
   }
 
-  checkLegacyVersion();
-  initLegacySecondaries();
+  if (process_legacy_interface) {
+    checkLegacyVersion();
+    initLegacySecondaries();
+  }
   LOG_TRACE << "Final configuration that will be used: \n" << (*this);
 }
 

--- a/src/libaktualizr/config/config.h
+++ b/src/libaktualizr/config/config.h
@@ -104,7 +104,7 @@ struct DiscoveryConfig {
 class Config {
  public:
   Config();
-  explicit Config(const boost::program_options::variables_map& cmd);
+  Config(const boost::program_options::variables_map& cmd, bool process_legacy_interface_in = true);
   explicit Config(const boost::filesystem::path& filename);
   explicit Config(const std::vector<boost::filesystem::path>& config_dirs) {
     updateFromDirs(config_dirs);
@@ -133,7 +133,6 @@ class Config {
   TelemetryConfig telemetry;
 
  private:
-  std::vector<boost::filesystem::path> config_dirs_ = {"/usr/lib/sota/conf.d", "/etc/sota/conf.d/"};
   void updateFromDirs(const std::vector<boost::filesystem::path>& configs);
   void updateFromPropertyTree(const boost::property_tree::ptree& pt);
   void updateFromToml(const boost::filesystem::path& filename);
@@ -141,7 +140,10 @@ class Config {
   void readSecondaryConfigs(const std::vector<boost::filesystem::path>& sconfigs);
   void checkLegacyVersion();
   void initLegacySecondaries();
+
+  std::vector<boost::filesystem::path> config_dirs_ = {"/usr/lib/sota/conf.d", "/etc/sota/conf.d/"};
   bool loglevel_from_cmdline{false};
+  bool process_legacy_interface{true};
 };
 
 #endif  // CONFIG_H_


### PR DESCRIPTION
That should only be done by aktualizr (the primary). aktualizr-info only
needs the config in order to read data out of storage. In the long term,
it may be better to give it its own config (much like
aktualizr-secondary) that basically only includes storage and maybe
logging.