### PR TITLE
Create new minimalist AktualizrInfoConfig.

### DIFF
--- a/src/aktualizr_info/CMakeLists.txt
+++ b/src/aktualizr_info/CMakeLists.txt
@@ -1,5 +1,7 @@
 
-set(AKTUALIZR_INFO_SRC main.cc )
+set(AKTUALIZR_INFO_SRC main.cc aktualizr_info_config.cc)
+
+set(AKTUALIZR_INFO_HEADERS aktualizr_info_config.h)
 
 add_executable(aktualizr-info ${AKTUALIZR_INFO_SRC})
 target_link_libraries(aktualizr-info aktualizr_static_lib
@@ -22,6 +24,6 @@ install(TARGETS aktualizr-info
         COMPONENT aktualizr
         RUNTIME DESTINATION bin)
 
-aktualizr_source_file_checks(${AKTUALIZR_INFO_SRC})
+aktualizr_source_file_checks(${AKTUALIZR_INFO_SRC} ${AKTUALIZR_INFO_HEADERS})
 
 # vim: set tabstop=4 shiftwidth=4 expandtab:

--- a/src/aktualizr_info/aktualizr_info_config.cc
+++ b/src/aktualizr_info/aktualizr_info_config.cc
@@ -1,0 +1,89 @@
+#include "aktualizr_info_config.h"
+
+#include "utilities/config_utils.h"
+
+AktualizrInfoConfig::AktualizrInfoConfig(const boost::program_options::variables_map& cmd) {
+  // Redundantly check and set the loglevel from the commandline prematurely so
+  // that it is taken account while processing the config.
+  if (cmd.count("loglevel") != 0) {
+    logger.loglevel = cmd["loglevel"].as<int>();
+    logger_set_threshold(logger);
+    loglevel_from_cmdline = true;
+  }
+
+  if (cmd.count("config") > 0) {
+    updateFromDirs(cmd["config"].as<std::vector<boost::filesystem::path>>());
+  } else {
+    updateFromDirs(config_dirs_);
+  }
+  updateFromCommandLine(cmd);
+  postUpdateValues();
+}
+
+AktualizrInfoConfig::AktualizrInfoConfig(const boost::filesystem::path& filename) {
+  updateFromToml(filename);
+  postUpdateValues();
+}
+
+void AktualizrInfoConfig::postUpdateValues() { logger_set_threshold(logger); }
+
+void AktualizrInfoConfig::updateFromDirs(const std::vector<boost::filesystem::path>& configs) {
+  std::map<std::string, boost::filesystem::path> configs_map;
+  for (const auto& config : configs) {
+    if (boost::filesystem::is_directory(config)) {
+      for (const auto& config_file : Utils::glob((config / "*.toml").string())) {
+        configs_map[config_file.filename().string()] = config_file;
+      }
+    } else {
+      configs_map[config.filename().string()] = config;
+    }
+  }
+  for (const auto& config_file : configs_map) {
+    updateFromToml(config_file.second);
+  }
+}
+
+void AktualizrInfoConfig::updateFromCommandLine(const boost::program_options::variables_map& cmd) {
+  if (cmd.count("loglevel") != 0) {
+    logger.loglevel = cmd["loglevel"].as<int>();
+  }
+}
+
+void AktualizrInfoConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt) {
+  // Keep this order the same as in aktualizr_info_config.h and
+  // AktualizrInfoConfig::writeToFile().
+
+  // from aktualizr config
+  if (!loglevel_from_cmdline) {
+    CopySubtreeFromConfig(logger, "logger", pt);
+    // If not already set from the commandline, set the loglevel now so that it
+    // affects the rest of the config processing.
+    logger_set_threshold(logger);
+  }
+
+  // from aktualizr config
+  CopySubtreeFromConfig(storage, "storage", pt);
+}
+
+std::ostream& operator<<(std::ostream& os, const AktualizrInfoConfig& cfg) {
+  (void)cfg;
+  return os;
+}
+
+void AktualizrInfoConfig::updateFromToml(const boost::filesystem::path& filename) {
+  boost::property_tree::ptree pt;
+  boost::property_tree::ini_parser::read_ini(filename.string(), pt);
+  updateFromPropertyTree(pt);
+  LOG_TRACE << "config read from " << filename << " :\n" << (*this);
+}
+
+void AktualizrInfoConfig::writeToFile(const boost::filesystem::path& filename) {
+  // Keep this order the same as in aktualizr_info_config.h and
+  // AktualizrInfoConfig::updateFromPropertyTree().
+  std::ofstream sink(filename.c_str(), std::ofstream::out);
+  sink << std::boolalpha;
+
+  // from aktualizr config
+  WriteSectionToStream(logger, "logger", sink);
+  WriteSectionToStream(storage, "storage", sink);
+}

--- a/src/aktualizr_info/aktualizr_info_config.h
+++ b/src/aktualizr_info/aktualizr_info_config.h
@@ -1,0 +1,38 @@
+#ifndef AKTUALIZR_INFO_CONFIG_H_
+#define AKTUALIZR_INFO_CONFIG_H_
+
+#include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
+#include <boost/property_tree/ini_parser.hpp>
+
+#include "config/config.h"
+#include "logging/logging.h"
+
+// Try to keep the order of config options the same as in
+// AktualizrInfoConfig::writeToFile() and
+// AktualizrInfoConfig::updateFromPropertyTree().
+
+class AktualizrInfoConfig {
+ public:
+  AktualizrInfoConfig() = default;
+  AktualizrInfoConfig(const boost::program_options::variables_map& cmd);
+  explicit AktualizrInfoConfig(const boost::filesystem::path& filename);
+
+  void postUpdateValues();
+  void writeToFile(const boost::filesystem::path& filename);
+
+  // from primary config
+  LoggerConfig logger;
+  StorageConfig storage;
+
+ private:
+  void updateFromDirs(const std::vector<boost::filesystem::path>& configs);
+  void updateFromCommandLine(const boost::program_options::variables_map& cmd);
+  void updateFromPropertyTree(const boost::property_tree::ptree& pt);
+  void updateFromToml(const boost::filesystem::path& filename);
+
+  std::vector<boost::filesystem::path> config_dirs_ = {"/usr/lib/sota/conf.d", "/etc/sota/conf.d/"};
+  bool loglevel_from_cmdline{false};
+};
+
+#endif  // AKTUALIZR_INFO_CONFIG_H_

--- a/src/aktualizr_info/main.cc
+++ b/src/aktualizr_info/main.cc
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 
-#include "config/config.h"
+#include "aktualizr_info_config.h"
 #include "logging/logging.h"
 #include "storage/invstorage.h"
 
@@ -16,6 +16,7 @@ int main(int argc, char **argv) {
   desc.add_options()
     ("help,h", "print usage")
     ("config,c", po::value<std::vector<boost::filesystem::path> >()->composing(), "configuration file or directory")
+    ("loglevel", po::value<int>(), "set log level 0-5 (trace, debug, info, warning, error, fatal)")
     ("tls-creds",  "Outputs TLS credentials")
     ("ecu-keys",  "Outputs UPTANE keys")
     ("images-root",  "Outputs root.json from images repo")
@@ -26,7 +27,7 @@ int main(int argc, char **argv) {
 
   try {
     logger_init();
-    logger_set_threshold(boost::log::trivial::error);
+    logger_set_threshold(boost::log::trivial::info);
     po::variables_map vm;
     po::basic_parsed_options<char> parsed_options = po::command_line_parser(argc, argv).options(desc).run();
     po::store(parsed_options, vm);
@@ -36,7 +37,7 @@ int main(int argc, char **argv) {
       exit(EXIT_SUCCESS);
     }
 
-    Config config(vm);
+    AktualizrInfoConfig config(vm);
 
     std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
     std::cout << "Storage backend: " << ((storage->type() == kFileSystem) ? "Filesystem" : "Sqlite") << std::endl;

--- a/src/libaktualizr/config/config.h
+++ b/src/libaktualizr/config/config.h
@@ -133,7 +133,6 @@ class Config {
   TelemetryConfig telemetry;
 
  private:
-  std::vector<boost::filesystem::path> config_dirs_ = {"/usr/lib/sota/conf.d", "/etc/sota/conf.d/"};
   void updateFromDirs(const std::vector<boost::filesystem::path>& configs);
   void updateFromPropertyTree(const boost::property_tree::ptree& pt);
   void updateFromToml(const boost::filesystem::path& filename);
@@ -141,6 +140,8 @@ class Config {
   void readSecondaryConfigs(const std::vector<boost::filesystem::path>& sconfigs);
   void checkLegacyVersion();
   void initLegacySecondaries();
+
+  std::vector<boost::filesystem::path> config_dirs_ = {"/usr/lib/sota/conf.d", "/etc/sota/conf.d/"};
   bool loglevel_from_cmdline{false};
 };
 


### PR DESCRIPTION
This should keep aktualizr-info simpler and prevent some potential
conflicts between aktualizr and aktualizr-info usage of the config.