### PR TITLE
garage-push: Honor the --cacerts option with HTTP Basic

### DIFF
--- a/src/sota_tools/authenticate.cc
+++ b/src/sota_tools/authenticate.cc
@@ -10,6 +10,7 @@ int authenticate(const string &cacerts, const ServerCredentials &creds, TreehubS
   switch (creds.GetMethod()) {
     case AUTH_BASIC: {
       treehub.SetAuthBasic(creds.GetAuthUser(), creds.GetAuthPassword());
+      treehub.ca_certs(cacerts);
       break;
     }
 


### PR DESCRIPTION
The --cacerts option is being ignored by the HTTP Basic code path in
authenticate.cc.

Signed-off-by: Andy Doan <andy@opensourcefoundries.com>