### PR TITLE
ostree: Log status updates of pull

### DIFF
--- a/src/libaktualizr/package_manager/ostreemanager.cc
+++ b/src/libaktualizr/package_manager/ostreemanager.cc
@@ -6,11 +6,11 @@
 
 #include <gio/gio.h>
 #include <json/json.h>
+#include <ostree-1/ostree-async-progress.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/filesystem.hpp>
-#include <ostree-1/ostree-async-progress.h>
 #include <utility>
 
 #include "logging/logging.h"
@@ -18,9 +18,8 @@
 
 using OstreeProgressPtr = std::unique_ptr<OstreeAsyncProgress, GObjectFinalizer<OstreeAsyncProgress>>;
 
-static void aktualizr_progress_cb(OstreeAsyncProgress *progress, gpointer data)
-{
-  auto *percent_complete = static_cast<guint*>(data);
+static void aktualizr_progress_cb(OstreeAsyncProgress *progress, gpointer data) {
+  auto *percent_complete = static_cast<guint *>(data);
 
   g_autofree char *status = ostree_async_progress_get_status(progress);
   guint scanning = ostree_async_progress_get_uint(progress, "scanning");
@@ -31,25 +30,23 @@ static void aktualizr_progress_cb(OstreeAsyncProgress *progress, gpointer data)
 
   if (status != nullptr && *status != '\0') {
     LOG_INFO << "ostree-pull: " << status;
-  }
-  else if (outstanding_fetches != 0) {
+  } else if (outstanding_fetches != 0) {
     float fetched = ostree_async_progress_get_uint(progress, "fetched");
     guint metadata_fetched = ostree_async_progress_get_uint(progress, "metadata-fetched");
     guint requested = ostree_async_progress_get_uint(progress, "requested");
     if (scanning != 0 || outstanding_metadata_fetches != 0) {
-      LOG_INFO << "ostree-pull: Receiving metadata objects: " << metadata_fetched << " outstanding: " << outstanding_metadata_fetches;
+      LOG_INFO << "ostree-pull: Receiving metadata objects: " << metadata_fetched
+               << " outstanding: " << outstanding_metadata_fetches;
     } else {
       guint calculated = round(((fetched) / requested) * 100);
       if (calculated != *percent_complete) {
         LOG_INFO << "ostree-pull: Receiving objects: " << calculated << "% ";
-	*percent_complete = calculated;
+        *percent_complete = calculated;
       }
     }
-  }
-  else if (outstanding_writes != 0) {
+  } else if (outstanding_writes != 0) {
     LOG_INFO << "ostree-pull: Writing objects: " << outstanding_writes;
-  }
-  else {
+  } else {
     LOG_INFO << "ostree-pull: Scanning metadata: " << n_scanned_metadata;
   }
 }


### PR DESCRIPTION
Fixes https://github.com/advancedtelematic/aktualizr/issues/670

The changes produce output at loglevel INFO like:

 ostree-pull: Receiving metadata objects: 3
 ostree-pull: Receiving metadata objects: 4
 ostree-pull: Receiving metadata objects: 6
 ostree-pull: Receiving metadata objects: 9
 ostree-pull: Receiving metadata objects: 11
 ostree-pull: Receiving objects: 44%
 ostree-pull: Receiving objects: 83%
 ostree-pull: Receiving objects: 90%
 ostree-pull: Receiving objects: 93%
 ostree-pull: Receiving objects: 97%
 ostree-pull: Writing objects: 1
 ostree-pull: 13 metadata, 16 content objects fetched; 44683 KiB transferred in 23 seconds

Signed-off-by: Andy Doan <andy@opensourcefoundries.com>