### PR TITLE
Fix typo that caused ipuptane_port to be ignored

### DIFF
--- a/src/libaktualizr/config/config.cc
+++ b/src/libaktualizr/config/config.cc
@@ -73,7 +73,7 @@ void NetworkConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt
   CopyFromConfig(ipdiscovery_host, "ipdiscovery_host", pt);
   CopyFromConfig(ipdiscovery_port, "ipdiscovery_port", pt);
   CopyFromConfig(ipdiscovery_wait_seconds, "ipdiscovery_wait_seconds", pt);
-  CopyFromConfig(ipuptane_port, "network.ipuptane_port", pt);
+  CopyFromConfig(ipuptane_port, "ipuptane_port", pt);
 }
 
 void NetworkConfig::writeToStream(std::ostream& out_stream) const {

--- a/src/libaktualizr/config/config_test.cc
+++ b/src/libaktualizr/config/config_test.cc
@@ -36,6 +36,19 @@ TEST(config, config_toml_parsing_empty_file) {
   EXPECT_EQ(conf.uptane.polling_sec, 10u);
 }
 
+TEST(config, config_toml_int) {
+  Config conf;
+  conf.updateFromTomlString("[uptane]\npolling = false\npolling_sec = 99\n");
+
+  EXPECT_EQ(conf.uptane.polling, false);
+  EXPECT_EQ(conf.uptane.polling_sec, 99u);
+}
+TEST(config, config_toml_netport) {
+  Config conf;
+  conf.updateFromTomlString("[network]\nipuptane_port = 9099\n\n");
+  EXPECT_EQ(conf.network.ipuptane_port, 9099);
+}
+
 TEST(config, config_cmdl_parsing) {
   constexpr int argc = 5;
   const char *argv[argc] = {"./aktualizr", "--gateway-socket", "on", "-c", "tests/config/minimal.toml"};


### PR DESCRIPTION
Change-Id: I6c3cd33078ac4d83b01c3e5bf08a0d96c9d75ed7