### PR TITLE
Make absence of asn1c non fatal

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -40,7 +40,7 @@ This client, and the https://github.com/advancedtelematic/rvi_sota_server[GENIVI
 
 The following debian packages are used in the project:
 
-* asn1c
+* asn1c (when building tests)
 * build-essential
 * clang (optional)
 * clang-format-3.8 (optional)

--- a/src/libaktualizr/asn1/CMakeLists.txt
+++ b/src/libaktualizr/asn1/CMakeLists.txt
@@ -8,11 +8,16 @@ add_library(asn1 OBJECT ${SOURCES})
 
 include(AddAktualizrTest)
 
-# Reference asn1c libraries
-add_asn1c_lib(${PROJECT_SOURCE_DIR}/tests/asn1-reference/common ${PROJECT_SOURCE_DIR}/tests/asn1-reference/config/cryptosource ${PROJECT_SOURCE_DIR}/tests/asn1-reference/config/tlsconfig)
-add_asn1c_lib(${PROJECT_SOURCE_DIR}/tests/asn1-reference/uptane/ipuptane_message)
-compile_asn1_lib()
-list(APPEND TEST_LIBS asn1_lib)
+if (ASN1C)
+    # Reference asn1c libraries
+    add_asn1c_lib(${PROJECT_SOURCE_DIR}/tests/asn1-reference/common ${PROJECT_SOURCE_DIR}/tests/asn1-reference/config/cryptosource ${PROJECT_SOURCE_DIR}/tests/asn1-reference/config/tlsconfig)
+    add_asn1c_lib(${PROJECT_SOURCE_DIR}/tests/asn1-reference/uptane/ipuptane_message)
+    compile_asn1_lib()
+    list(APPEND TEST_LIBS asn1_lib)
 
-add_aktualizr_test(NAME asn1 SOURCES asn1_test.cc ARGS ${PROJECT_SOURCE_DIR}/build5/tests PROJECT_WORKING_DIRECTORY)
-aktualizr_source_file_checks(${SOURCES} ${HEADERS} ${TEST_SOURCES} )
+    add_aktualizr_test(NAME asn1 SOURCES asn1_test.cc ARGS ${PROJECT_SOURCE_DIR}/build5/tests PROJECT_WORKING_DIRECTORY)
+else ()
+    list(APPEND TEST_SOURCES asn1_test.cc)
+endif ()
+
+aktualizr_source_file_checks(${SOURCES} ${HEADERS} ${TEST_SOURCES})


### PR DESCRIPTION
It's currently used only for a test, so we don't need to require it in all cases. Example: building with yocto.