### PR TITLE
Reenable `-Wshadow`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,20 +268,25 @@ include_directories(${LibArchive_INCLUDE_DIR})
 set_source_files_properties(third_party/jsoncpp/jsoncpp.cpp PROPERTIES COMPILE_FLAGS -w)
 add_library(jsoncpp OBJECT third_party/jsoncpp/jsoncpp.cpp)
 
-if (CMAKE_COMPILER_IS_GNUCXX)
+if (CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
     add_definitions(-fstack-protector-all)
     # Enable maximum set of warnings. -Wno-sign-compare is required because of
     # problems in gtest. -Wswitch-default and -Wconversion would be nice as
     # well, but they also cause problems in gtest.
-    add_definitions(-Wall -Wextra -Wformat-security -Wfloat-equal -Wcast-qual -Wlogical-op -Wno-sign-compare)
+    add_definitions(-Wall -Wextra -Wformat-security -Wfloat-equal -Wcast-qual -Wno-sign-compare)
+    if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        add_definitions(-Wlogical-op)
+    else ()
+        add_definitions(-Wno-unused-private-field)
+    endif ()
 
-    if (CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL "4.9" OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "4.9")
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL "4.9" OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "4.9")
         add_definitions(-Wshadow)
     endif ()
 
-    if(WARNING_AS_ERROR)
+    if (WARNING_AS_ERROR)
         add_definitions(-Werror)
-    endif()
+    endif ()
 
     if (PEDANTIC_WARNINGS)
         add_definitions(-Wpedantic -Wswitch-default -Wsign-compare -Wconversion)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,7 +275,7 @@ if (CMAKE_COMPILER_IS_GNUCXX)
     # well, but they also cause problems in gtest.
     add_definitions(-Wall -Wextra -Wformat-security -Wfloat-equal -Wcast-qual -Wlogical-op -Wno-sign-compare)
 
-    if (CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL "4.9" OR MAKE_CXX_COMPILER_VERSION VERSION_GREATER "4.9")
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL "4.9" OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "4.9")
         add_definitions(-Wshadow)
     endif ()
 

--- a/src/aktualizr_secondary/uptane_test.cc
+++ b/src/aktualizr_secondary/uptane_test.cc
@@ -6,27 +6,27 @@
 #include "config/config.h"
 #include "httpfake.h"
 
-std::shared_ptr<INvStorage> storage;
-AktualizrSecondaryConfig config;
-std::string sysroot;
+std::shared_ptr<INvStorage> test_storage;
+AktualizrSecondaryConfig test_config;
+std::string test_sysroot;
 
 TEST(aktualizr_secondary_uptane, getSerial) {
-  config.pacman.sysroot = sysroot;
-  AktualizrSecondary as(config, storage);
+  test_config.pacman.sysroot = test_sysroot;
+  AktualizrSecondary as(test_config, test_storage);
 
   EXPECT_NE(as.getSerialResp(), "");
 }
 
 TEST(aktualizr_secondary_uptane, getHwId) {
-  config.pacman.sysroot = sysroot;
-  AktualizrSecondary as(config, storage);
+  test_config.pacman.sysroot = test_sysroot;
+  AktualizrSecondary as(test_config, test_storage);
 
   EXPECT_NE(as.getHwIdResp(), Uptane::HardwareIdentifier(""));
 }
 
 TEST(aktualizr_secondary_uptane, getPublicKey) {
-  config.pacman.sysroot = sysroot;
-  AktualizrSecondary as(config, storage);
+  test_config.pacman.sysroot = test_sysroot;
+  AktualizrSecondary as(test_config, test_storage);
 
   KeyType type;
   std::string key;
@@ -54,7 +54,7 @@ TEST(aktualizr_secondary_uptane, credentialsPassing) {
 
   auto storage = INvStorage::newStorage(config.storage);
   Uptane::Repository uptane(config, storage, http);
-  SotaUptaneClient sota_client(config, NULL, uptane, storage, http);
+  SotaUptaneClient sota_client(config, nullptr, uptane, storage, http);
   EXPECT_TRUE(sota_client.initialize());
 
   std::string arch = sota_client.secondaryTreehubCredentials();
@@ -67,17 +67,17 @@ int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
 
   TemporaryDirectory temp_dir;
-  config.network.port = 0;  // random port
-  config.storage.type = kSqlite;
-  config.storage.sqldb_path = temp_dir.Path() / "sql.db";
+  test_config.network.port = 0;  // random port
+  test_config.storage.type = kSqlite;
+  test_config.storage.sqldb_path = temp_dir.Path() / "sql.db";
 
-  storage = INvStorage::newStorage(config.storage, temp_dir.Path());
+  test_storage = INvStorage::newStorage(test_config.storage, temp_dir.Path());
 
   if (argc != 2) {
     std::cerr << "Error: " << argv[0] << " requires the path to an OSTree sysroot as an input argument.\n";
     return EXIT_FAILURE;
   }
-  sysroot = argv[1];
+  test_sysroot = argv[1];
   return RUN_ALL_TESTS();
 }
 #endif

--- a/src/libaktualizr/asn1/asn1-cerstream.cc
+++ b/src/libaktualizr/asn1/asn1-cerstream.cc
@@ -177,13 +177,13 @@ Deserializer& Deserializer::operator>>(const Token& tok) {
         }
       } else {
         int nestedness = 0;
-        int32_t int_param = 0;
+        int32_t decoded_int = 0;
 
         for (;;) {
           if (data.empty()) {  // end of data before end of sequence
             throw deserialization_error();
           }
-          uint8_t ret = cer_decode_token(data, &endpos, &int_param, nullptr);
+          uint8_t ret = cer_decode_token(data, &endpos, &decoded_int, nullptr);
           data = data.substr(endpos);
           cons_len += endpos;
 
@@ -192,7 +192,7 @@ Deserializer& Deserializer::operator>>(const Token& tok) {
           }
           if (ret == kAsn1Sequence) {  // TODO: explicit tags (constructed tokens in general)
             // indefininte length, expect an end of sequence marker
-            if (int_param == -1) {
+            if (decoded_int == -1) {
               ++nestedness;
             }
           } else if (ret == kAsn1EndSequence) {

--- a/src/libaktualizr/asn1/asn1-cerstream.h
+++ b/src/libaktualizr/asn1/asn1-cerstream.h
@@ -26,8 +26,8 @@ class EndoptToken : public Token {
 
 class ExplicitToken : public Token {
  public:
-  explicit ExplicitToken(uint8_t tag, ASN1_Class tag_class = kAsn1Context)
-      : Token(expl_tok), tag(tag), tag_class(tag_class) {}
+  explicit ExplicitToken(uint8_t token_tag, ASN1_Class token_tag_class = kAsn1Context)
+      : Token(expl_tok), tag(token_tag), tag_class(token_tag_class) {}
   ~ExplicitToken() override = default;
   uint8_t tag;
   ASN1_Class tag_class;
@@ -35,8 +35,8 @@ class ExplicitToken : public Token {
 
 class PeekExplicitToken : public Token {
  public:
-  explicit PeekExplicitToken(uint8_t* tag = nullptr, ASN1_Class* tag_class = nullptr)
-      : Token(peekexpl_tok), tag(tag), tag_class(tag_class) {}
+  explicit PeekExplicitToken(uint8_t* token_tag = nullptr, ASN1_Class* token_tag_class = nullptr)
+      : Token(peekexpl_tok), tag(token_tag), tag_class(token_tag_class) {}
   ~PeekExplicitToken() override = default;
   uint8_t* tag;
   ASN1_Class* tag_class;

--- a/src/libaktualizr/opcuabridge/common.h
+++ b/src/libaktualizr/opcuabridge/common.h
@@ -277,7 +277,7 @@ inline UA_StatusCode ClientRead(UA_Client *client, const char *node_id, MessageT
     MessageT::unwrapMessage(obj, static_cast<const char *>(val->data), val->arrayLength);
     // read binary child node
     UA_Variant *bin_val = UA_Variant_new();
-    UA_StatusCode retval = UA_Client_readValueAttribute(
+    retval = UA_Client_readValueAttribute(
         client, UA_NODEID_STRING(kNSindex, const_cast<char *>(obj->bin_node_id_)), bin_val);
     if (retval == UA_STATUSCODE_GOOD && UA_Variant_hasArrayType(bin_val, &UA_TYPES[UA_TYPES_BYTE])) {
       bin_data->resize(bin_val->arrayLength);

--- a/src/libaktualizr/package_manager/ostreemanager_test.cc
+++ b/src/libaktualizr/package_manager/ostreemanager_test.cc
@@ -14,14 +14,14 @@
 #include "utilities/types.h"
 #include "utilities/utils.h"
 
-boost::filesystem::path sysroot;
+boost::filesystem::path test_sysroot;
 
 TEST(OstreeManager, PullBadUriNoCreds) {
   TemporaryDirectory temp_dir;
   Config config;
   config.pacman.ostree_server = "bad-url";
   config.pacman.type = kOstree;
-  config.pacman.sysroot = sysroot;
+  config.pacman.sysroot = test_sysroot;
   config.storage.path = temp_dir.Path();
   config.storage.uptane_metadata_path = "metadata";
   config.storage.uptane_private_key_path = "private.key";
@@ -41,7 +41,7 @@ TEST(OstreeManager, PullBadUriWithCreds) {
   Config config;
   config.pacman.ostree_server = "bad-url";
   config.pacman.type = kOstree;
-  config.pacman.sysroot = sysroot;
+  config.pacman.sysroot = test_sysroot;
   config.storage.path = temp_dir.Path();
   config.storage.uptane_metadata_path = "metadata";
   config.storage.uptane_private_key_path = "private.key";
@@ -70,7 +70,7 @@ TEST(OstreeManager, InstallBadUri) {
   TemporaryDirectory temp_dir;
   Config config;
   config.pacman.type = kOstree;
-  config.pacman.sysroot = sysroot;
+  config.pacman.sysroot = test_sysroot;
   config.storage.path = temp_dir.Path();
   config.storage.uptane_metadata_path = "metadata";
   config.storage.uptane_private_key_path = "private.key";
@@ -97,7 +97,7 @@ TEST(OstreeManager, ParseInstalledPackages) {
   TemporaryDirectory temp_dir;
   Config config;
   config.pacman.type = kOstree;
-  config.pacman.sysroot = sysroot;
+  config.pacman.sysroot = test_sysroot;
   config.pacman.packages_file = "tests/test_data/package.manifest";
   config.storage.path = temp_dir.Path();
 
@@ -116,36 +116,36 @@ TEST(OstreeManager, AddRemoteNoCreds) {
   TemporaryDirectory temp_dir;
   Config config;
   config.pacman.type = kOstree;
-  config.pacman.sysroot = sysroot;
+  config.pacman.sysroot = test_sysroot;
   config.storage.path = temp_dir.Path();
 
   std::shared_ptr<INvStorage> storage = std::make_shared<FSStorage>(config.storage);
   KeyManager keys(storage, config.keymanagerConfig());
   keys.loadKeys();
 
-  OstreeRepo *repo = NULL;
-  GError *error = NULL;
+  OstreeRepo *repo = nullptr;
+  GError *error = nullptr;
   std::shared_ptr<OstreeSysroot> sysroot = OstreeManager::LoadSysroot(config.pacman.sysroot);
-  EXPECT_TRUE(ostree_sysroot_get_repo(sysroot.get(), &repo, NULL, &error));
+  EXPECT_TRUE(ostree_sysroot_get_repo(sysroot.get(), &repo, nullptr, &error));
   EXPECT_TRUE(OstreeManager::addRemote(repo, config.pacman.ostree_server, keys));
 
-  g_autofree char *url = NULL;
-  EXPECT_TRUE(ostree_repo_get_remote_option(repo, remote, "url", NULL, &url, &error));
+  g_autofree char *url = nullptr;
+  EXPECT_TRUE(ostree_repo_get_remote_option(repo, remote, "url", nullptr, &url, &error));
   EXPECT_EQ(url, config.pacman.ostree_server);
 
   gboolean out_gpg_verify;
   EXPECT_TRUE(ostree_repo_get_remote_boolean_option(repo, remote, "gpg-verify", FALSE, &out_gpg_verify, &error));
 
-  g_autofree char *ostree_cert = NULL;
-  EXPECT_TRUE(ostree_repo_get_remote_option(repo, remote, "tls-client-cert-path", NULL, &ostree_cert, &error));
+  g_autofree char *ostree_cert = nullptr;
+  EXPECT_TRUE(ostree_repo_get_remote_option(repo, remote, "tls-client-cert-path", nullptr, &ostree_cert, &error));
   EXPECT_EQ(ostree_cert, nullptr);
 
-  g_autofree char *ostree_key = NULL;
-  EXPECT_TRUE(ostree_repo_get_remote_option(repo, remote, "tls-client-key-path", NULL, &ostree_key, &error));
+  g_autofree char *ostree_key = nullptr;
+  EXPECT_TRUE(ostree_repo_get_remote_option(repo, remote, "tls-client-key-path", nullptr, &ostree_key, &error));
   EXPECT_EQ(ostree_key, nullptr);
 
-  g_autofree char *ostree_ca = NULL;
-  EXPECT_TRUE(ostree_repo_get_remote_option(repo, remote, "tls-ca-path", NULL, &ostree_ca, &error));
+  g_autofree char *ostree_ca = nullptr;
+  EXPECT_TRUE(ostree_repo_get_remote_option(repo, remote, "tls-ca-path", nullptr, &ostree_ca, &error));
   EXPECT_EQ(ostree_ca, nullptr);
 
   g_object_unref(repo);
@@ -155,7 +155,7 @@ TEST(OstreeManager, AddRemoteWithCreds) {
   TemporaryDirectory temp_dir;
   Config config;
   config.pacman.type = kOstree;
-  config.pacman.sysroot = sysroot;
+  config.pacman.sysroot = test_sysroot;
   config.storage.path = temp_dir.Path();
 
   std::shared_ptr<INvStorage> storage = std::make_shared<FSStorage>(config.storage);
@@ -168,29 +168,29 @@ TEST(OstreeManager, AddRemoteWithCreds) {
   KeyManager keys(storage, config.keymanagerConfig());
   keys.loadKeys();
 
-  OstreeRepo *repo = NULL;
-  GError *error = NULL;
+  OstreeRepo *repo = nullptr;
+  GError *error = nullptr;
   std::shared_ptr<OstreeSysroot> sysroot = OstreeManager::LoadSysroot(config.pacman.sysroot);
-  EXPECT_TRUE(ostree_sysroot_get_repo(sysroot.get(), &repo, NULL, &error));
+  EXPECT_TRUE(ostree_sysroot_get_repo(sysroot.get(), &repo, nullptr, &error));
   EXPECT_TRUE(OstreeManager::addRemote(repo, config.pacman.ostree_server, keys));
 
-  g_autofree char *url = NULL;
-  EXPECT_TRUE(ostree_repo_get_remote_option(repo, remote, "url", NULL, &url, &error));
+  g_autofree char *url = nullptr;
+  EXPECT_TRUE(ostree_repo_get_remote_option(repo, remote, "url", nullptr, &url, &error));
   EXPECT_EQ(url, config.pacman.ostree_server);
 
   gboolean out_gpg_verify;
   EXPECT_TRUE(ostree_repo_get_remote_boolean_option(repo, remote, "gpg-verify", FALSE, &out_gpg_verify, &error));
 
-  g_autofree char *ostree_cert = NULL;
-  EXPECT_TRUE(ostree_repo_get_remote_option(repo, remote, "tls-client-cert-path", NULL, &ostree_cert, &error));
+  g_autofree char *ostree_cert = nullptr;
+  EXPECT_TRUE(ostree_repo_get_remote_option(repo, remote, "tls-client-cert-path", nullptr, &ostree_cert, &error));
   EXPECT_EQ(ostree_cert, keys.getCertFile());
 
-  g_autofree char *ostree_key = NULL;
-  EXPECT_TRUE(ostree_repo_get_remote_option(repo, remote, "tls-client-key-path", NULL, &ostree_key, &error));
+  g_autofree char *ostree_key = nullptr;
+  EXPECT_TRUE(ostree_repo_get_remote_option(repo, remote, "tls-client-key-path", nullptr, &ostree_key, &error));
   EXPECT_EQ(ostree_key, keys.getPkeyFile());
 
-  g_autofree char *ostree_ca = NULL;
-  EXPECT_TRUE(ostree_repo_get_remote_option(repo, remote, "tls-ca-path", NULL, &ostree_ca, &error));
+  g_autofree char *ostree_ca = nullptr;
+  EXPECT_TRUE(ostree_repo_get_remote_option(repo, remote, "tls-ca-path", nullptr, &ostree_ca, &error));
   EXPECT_EQ(ostree_ca, keys.getCaFile());
 
   g_object_unref(repo);
@@ -204,7 +204,7 @@ int main(int argc, char **argv) {
     std::cerr << "Error: " << argv[0] << " requires the path to an OSTree sysroot as an input argument.\n";
     return EXIT_FAILURE;
   }
-  sysroot = argv[1];
+  test_sysroot = argv[1];
   return RUN_ALL_TESTS();
 }
 #endif

--- a/src/libaktualizr/primary/initializer.h
+++ b/src/libaktualizr/primary/initializer.h
@@ -16,18 +16,18 @@ enum InitRetCode {
 
 class Initializer {
  public:
-  Initializer(const ProvisionConfig& config, const std::shared_ptr<INvStorage>& storage, HttpInterface& http_client,
+  Initializer(const ProvisionConfig& config, std::shared_ptr<INvStorage> storage, HttpInterface& http_client,
               KeyManager& keys,
               const std::map<std::string, std::shared_ptr<Uptane::SecondaryInterface> >& secondary_info);
-  bool isSuccessful() const { return success; }
+  bool isSuccessful() const { return success_; }
 
  private:
-  const ProvisionConfig& config;
-  std::shared_ptr<INvStorage> storage;
-  HttpInterface& http_client;
-  KeyManager& keys;
-  const std::map<std::string, std::shared_ptr<Uptane::SecondaryInterface> >& secondary_info;
-  bool success;
+  const ProvisionConfig& config_;
+  std::shared_ptr<INvStorage> storage_;
+  HttpInterface& http_client_;
+  KeyManager& keys_;
+  const std::map<std::string, std::shared_ptr<Uptane::SecondaryInterface> >& secondary_info_;
+  bool success_;
 
   bool initDeviceId();
   void resetDeviceId();

--- a/src/libaktualizr/storage/sqlstorage.cc
+++ b/src/libaktualizr/storage/sqlstorage.cc
@@ -597,11 +597,13 @@ void SQLStorage::storeEcuSerials(const EcuSerials& serials) {
 
     std::string serial = serials[0].first;
     std::string hwid = serials[0].second.ToString();
-    auto statement =
-        db.prepareStatement<std::string, std::string>("INSERT INTO ecu_serials VALUES (?,?,1);", serial, hwid);
-    if (statement.step() != SQLITE_DONE) {
-      LOG_ERROR << "Can't set ecu_serial: " << db.errmsg();
-      return;
+    {
+      auto statement =
+          db.prepareStatement<std::string, std::string>("INSERT INTO ecu_serials VALUES (?,?,1);", serial, hwid);
+      if (statement.step() != SQLITE_DONE) {
+        LOG_ERROR << "Can't set ecu_serial: " << db.errmsg();
+        return;
+      }
     }
 
     EcuSerials::const_iterator it;

--- a/src/libaktualizr/uptane/managedsecondary.cc
+++ b/src/libaktualizr/uptane/managedsecondary.cc
@@ -151,12 +151,12 @@ Json::Value ManagedSecondary::getManifest() {
   return signed_ecu_version;
 }
 
-void ManagedSecondary::storeKeys(const std::string &public_key, const std::string &private_key) {
-  Utils::writeFile((sconfig.full_client_dir / sconfig.ecu_private_key), private_key);
-  Utils::writeFile((sconfig.full_client_dir / sconfig.ecu_public_key), public_key);
+void ManagedSecondary::storeKeys(const std::string &pub_key, const std::string &priv_key) {
+  Utils::writeFile((sconfig.full_client_dir / sconfig.ecu_private_key), priv_key);
+  Utils::writeFile((sconfig.full_client_dir / sconfig.ecu_public_key), pub_key);
 }
 
-bool ManagedSecondary::loadKeys(std::string *public_key, std::string *private_key) {
+bool ManagedSecondary::loadKeys(std::string *pub_key, std::string *priv_key) {
   boost::filesystem::path public_key_path = sconfig.full_client_dir / sconfig.ecu_public_key;
   boost::filesystem::path private_key_path = sconfig.full_client_dir / sconfig.ecu_private_key;
 
@@ -164,8 +164,8 @@ bool ManagedSecondary::loadKeys(std::string *public_key, std::string *private_ke
     return false;
   }
 
-  *private_key = Utils::readFile(private_key_path.string());
-  *public_key = Utils::readFile(public_key_path.string());
+  *priv_key = Utils::readFile(private_key_path.string());
+  *pub_key = Utils::readFile(public_key_path.string());
   return true;
 }
 }  // namespace Uptane

--- a/src/libaktualizr/uptane/managedsecondary.h
+++ b/src/libaktualizr/uptane/managedsecondary.h
@@ -34,7 +34,7 @@ class ManagedSecondary : public SecondaryInterface {
   bool sendFirmware(const std::string& data) override;
   Json::Value getManifest() override;
 
-  bool loadKeys(std::string* public_key, std::string* private_key);
+  bool loadKeys(std::string* pub_key, std::string* priv_key);
 
  private:
   std::string public_key;
@@ -51,7 +51,7 @@ class ManagedSecondary : public SecondaryInterface {
   virtual bool storeFirmware(const std::string& target_name, const std::string& content) = 0;
   virtual bool getFirmwareInfo(std::string* target_name, size_t& target_len, std::string* sha256hash) = 0;
 
-  void storeKeys(const std::string& public_key, const std::string& private_key);
+  void storeKeys(const std::string& pub_key, const std::string& priv_key);
 
   // TODO: implement
   void storeMetadata(const MetaPack& meta_pack) { (void)meta_pack; }

--- a/src/sota_tools/garage_deploy.cc
+++ b/src/sota_tools/garage_deploy.cc
@@ -91,12 +91,11 @@ int main(int argc, char **argv) {
     OSTreeHash commit(OSTreeHash::Parse(ostree_commit));
     // Since the fetches happen on a single thread in OSTreeHttpRepo, there
     // isn't really any reason to upload in parallel
-    bool ok = UploadToTreehub(src_repo, push_credentials, commit, cacerts, false, 1);
-
-    if (!ok) {
+    if (!UploadToTreehub(src_repo, push_credentials, commit, cacerts, false, 1)) {
       LOG_FATAL << "Upload to treehub failed";
       return EXIT_FAILURE;
     }
+
     if (push_credentials.CanSignOffline()) {
       bool ok = OfflineSignRepo(ServerCredentials(push_credentials.GetPathOnDisk()), name, commit, hardwareids);
       return static_cast<int>(!ok);


### PR DESCRIPTION
There used to be a typo, so I fixed it + the warnings. Also, let's enable warnings when compiling with clang since it shares most of its compile options with gcc.