### PR TITLE
uptane: Change logging for unknown keys

### DIFF
--- a/src/libaktualizr/uptane/root.cc
+++ b/src/libaktualizr/uptane/root.cc
@@ -155,8 +155,7 @@ void Uptane::Root::UnpackSignedObject(const TimeStamp &now, const std::string &r
     }
     std::string keyid = (*sig)["keyid"].asString();
     if (keys_.count(keyid) == 0u) {
-      LOG_INFO << "Signed by unknown keyid, skipping";
-      LOG_TRACE << "Key ID: " << keyid;
+      LOG_DEBUG << "Signed by unknown keyid, " << keyid << ", skipping";
       continue;
     }
 


### PR DESCRIPTION
After doing a key rotation described here:

 https://docs.atsgarage.com/prod/rotating-signing-keys.html

We started seeing the LOG_INFO message. It seemed a bit concerning
to people until we dug into it more. I think this message is probably
more useful as a LOG_DEBUG. Additionally, if we are going to warn
about a key I think we ought to show it.

Signed-off-by: Andy Doan <andy@opensourcefoundries.com>