### PR TITLE
Fix finding the latest garage-sign version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN apt-get update && apt-get -y install \
   ostree \
   pkg-config \
   psmisc \
+  python3-dateutil \
   python3-dev \
   python3-gi \
   python3-openssl \

--- a/Dockerfile.deb-stable
+++ b/Dockerfile.deb-stable
@@ -52,6 +52,7 @@ RUN apt-get update && apt-get -y install \
   ostree \
   pkg-config \
   psmisc \
+  python3-dateutil \
   softhsm2 \
   wget
   

--- a/Dockerfile.deb-testing
+++ b/Dockerfile.deb-testing
@@ -57,6 +57,7 @@ RUN apt-get update && apt-get -y install \
   ostree \
   pkg-config \
   psmisc \
+  python3-dateutil \
   python3-dev \
   python3-gi \
   python3-openssl \

--- a/Dockerfile.noostree
+++ b/Dockerfile.noostree
@@ -46,6 +46,7 @@ RUN apt-get update && apt-get -y install \
   opensc \
   pkg-config \
   psmisc \
+  python3-dateutil \
   python3-dev \
   python3-gi \
   python3-openssl \

--- a/Dockerfile.nop11
+++ b/Dockerfile.nop11
@@ -47,6 +47,7 @@ RUN apt-get update && apt-get -y install \
   ostree \
   pkg-config \
   psmisc \
+  python3-dateutil \
   python3-dev \
   python3-gi \
   python3-openssl \

--- a/scripts/get_garage_sign.py
+++ b/scripts/get_garage_sign.py
@@ -8,6 +8,7 @@ import sys
 import tarfile
 import urllib.request
 import xml.etree.ElementTree as ET
+import dateutil.parser as dp
 
 from pathlib import Path
 
@@ -51,7 +52,8 @@ def main():
             else:
                 name = name_ext
     else:
-        name = sorted(versions)[-1]
+        name = sorted(versions, key=(lambda name: dp.parse(versions[name][0])))[-1]
+
     path = args.output.joinpath(name)
     md5_hash = versions[name][1]
     if not path.is_file() or not check_hashes(name, path, md5_hash, sha256_hash):


### PR DESCRIPTION
Plain `sorted()` sorts lexicographically