### PR TITLE
Fix errors on 'make qa' with all options turned on

### DIFF
--- a/src/external_secondaries/test_isotp_interface.cc
+++ b/src/external_secondaries/test_isotp_interface.cc
@@ -243,9 +243,9 @@ bool TestIsotpInterface::sendRecvUds(const std::string& out, std::string* in, ui
     return false;
   }
 
-  IsoTpMessage message =
+  IsoTpMessage message_tx =
       isotp_new_send_message(makeCanAf(sa, ta), reinterpret_cast<const uint8_t*>(out.c_str()), out.length());
-  IsoTpSendHandle send_handle = isotp_send(&isotp_shims, &message, nullptr);
+  IsoTpSendHandle send_handle = isotp_send(&isotp_shims, &message_tx, nullptr);
   if (send_handle.completed) {
     if (!send_handle.success) {
       std::cerr << "Message send failed" << std::endl;
@@ -322,13 +322,13 @@ bool TestIsotpInterface::sendRecvUds(const std::string& out, std::string* in, ui
           return false;
         }
 
-        IsoTpMessage message = isotp_continue_receive(&isotp_shims, &recv_handle, f.can_id, f.data, f.can_dlc);
-        if (message.completed && recv_handle.completed) {
+        IsoTpMessage message_rx = isotp_continue_receive(&isotp_shims, &recv_handle, f.can_id, f.data, f.can_dlc);
+        if (message_rx.completed && recv_handle.completed) {
           if (!recv_handle.success) {
             std::cerr << "IsoTp receiving error" << std::endl;
             return false;
           }
-          *in = std::string(reinterpret_cast<const char*>(message.payload), static_cast<size_t>(message.size));
+          *in = std::string(reinterpret_cast<const char*>(message_rx.payload), static_cast<size_t>(message_rx.size));
           return true;
         }
       } else {

--- a/src/libaktualizr/crypto/p11engine.cc
+++ b/src/libaktualizr/crypto/p11engine.cc
@@ -163,8 +163,11 @@ bool P11Engine::readUptanePublicKey(std::string* key_out) {
     boost::algorithm::unhex(config_.uptane_key_id, std::back_inserter(id_hex));
 
     for (int i = 0; i < nkeys; i++) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
       if ((keys[i].id_len == config_.uptane_key_id.length() / 2) &&
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
           (memcmp(keys[i].id, id_hex.data(), config_.uptane_key_id.length() / 2) == 0)) {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         key = &keys[i];
         break;
       }
@@ -238,7 +241,9 @@ bool P11Engine::readTlsCert(std::string* cert_out) const {
     boost::algorithm::unhex(id, std::back_inserter(id_hex));
 
     for (int i = 0; i < ncerts; i++) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
       if ((certs[i].id_len == id.length() / 2) && (memcmp(certs[i].id, id_hex.data(), id.length() / 2) == 0)) {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         cert = &certs[i];
         break;
       }

--- a/src/libaktualizr/opcuabridge/opcuabridge_ostree_repo_sync_server.cc
+++ b/src/libaktualizr/opcuabridge/opcuabridge_ostree_repo_sync_server.cc
@@ -74,13 +74,12 @@ int main(int argc, char* argv[]) {
   file_data.InitServerNodeset(server);
 
   file_list.setOnAfterWriteCallback([&src_repo_dir, &working_repo_dir]
-    (opcuabridge::FileList* file_list) {
-      if (!file_list->getBlock().empty() && file_list->getBlock()[0] == '\0')
+    (opcuabridge::FileList* file_list_cb) {
+      if (!file_list_cb->getBlock().empty() && file_list_cb->getBlock()[0] == '\0')
         if (!ostree_repo_sync::ArchiveModeRepo(src_repo_dir))
           if (!ostree_repo_sync::LocalPullRepo(working_repo_dir, src_repo_dir))
             LOG_ERROR << "OSTree: local pull to the source repo is failed";
     });
-
   // run server
   UA_StatusCode retval = UA_Server_run(server, &running);
   UA_Server_delete(server);

--- a/src/libaktualizr/uptane/opcuasecondary.cc
+++ b/src/libaktualizr/uptane/opcuasecondary.cc
@@ -17,7 +17,7 @@ namespace fs = boost::filesystem;
 
 namespace Uptane {
 
-OpcuaSecondary::OpcuaSecondary(const SecondaryConfig& sconfig) : SecondaryInterface(sconfig) {}
+OpcuaSecondary::OpcuaSecondary(const SecondaryConfig& sconfig_in) : SecondaryInterface(sconfig_in) {}
 
 OpcuaSecondary::~OpcuaSecondary() = default;
 


### PR DESCRIPTION
sconfig is a member variable of SecondaryInterface, and message was getting
shadowed.