### PR TITLE
Drop python dateutil

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,6 @@ RUN apt-get update && apt-get -y install \
   ostree \
   pkg-config \
   psmisc \
-  python3-dateutil \
   python3-dev \
   python3-gi \
   python3-openssl \

--- a/Dockerfile.deb-stable
+++ b/Dockerfile.deb-stable
@@ -52,7 +52,6 @@ RUN apt-get update && apt-get -y install \
   ostree \
   pkg-config \
   psmisc \
-  python3-dateutil \
   softhsm2 \
   wget
   

--- a/Dockerfile.deb-testing
+++ b/Dockerfile.deb-testing
@@ -57,7 +57,6 @@ RUN apt-get update && apt-get -y install \
   ostree \
   pkg-config \
   psmisc \
-  python3-dateutil \
   python3-dev \
   python3-gi \
   python3-openssl \

--- a/Dockerfile.noostree
+++ b/Dockerfile.noostree
@@ -46,7 +46,6 @@ RUN apt-get update && apt-get -y install \
   opensc \
   pkg-config \
   psmisc \
-  python3-dateutil \
   python3-dev \
   python3-gi \
   python3-openssl \

--- a/Dockerfile.nop11
+++ b/Dockerfile.nop11
@@ -47,7 +47,6 @@ RUN apt-get update && apt-get -y install \
   ostree \
   pkg-config \
   psmisc \
-  python3-dateutil \
   python3-dev \
   python3-gi \
   python3-openssl \

--- a/README.adoc
+++ b/README.adoc
@@ -67,7 +67,6 @@ The following debian packages are used in the project:
 * libsystemd-dev (when building with systemd support for secondaries)
 * libyaml-cpp-dev (>=0.5.2)
 * python3-dev (when building tests)
-* python3-dateutil
 * python3-openssl (when building tests)
 * python3-venv (when building tests)
 * valgrind (when building tests)

--- a/scripts/get_garage_sign.py
+++ b/scripts/get_garage_sign.py
@@ -8,7 +8,6 @@ import sys
 import tarfile
 import urllib.request
 import xml.etree.ElementTree as ET
-import dateutil.parser as dp
 
 from pathlib import Path
 
@@ -52,7 +51,7 @@ def main():
             else:
                 name = name_ext
     else:
-        name = sorted(versions, key=(lambda name: dp.parse(versions[name][0])))[-1]
+        name = sorted(versions, key=(lambda name: (versions[name][0])))[-1]
 
     path = args.output.joinpath(name)
     md5_hash = versions[name][1]

--- a/scripts/get_garage_sign.py
+++ b/scripts/get_garage_sign.py
@@ -51,7 +51,7 @@ def main():
             else:
                 name = name_ext
     else:
-        name = sorted(versions, key=(lambda name: (versions[name][0])))[-1]
+        name = max(versions, key=(lambda name: (versions[name][0])))
 
     path = args.output.joinpath(name)
     md5_hash = versions[name][1]


### PR DESCRIPTION
Python dateutil isn't packaged for Yocto, which makes this fail when built in meta-updater