### PR TITLE
Fix a potential comparison with uninitialized pointer

### DIFF
--- a/src/libaktualizr/package_manager/ostreemanager.cc
+++ b/src/libaktualizr/package_manager/ostreemanager.cc
@@ -240,7 +240,7 @@ bool OstreeManager::imageUpdated() {
 
   GPtrArray *deployments = ostree_sysroot_get_deployments(sysroot_smart.get());
 
-  OstreeDeployment *pending_deployment;
+  OstreeDeployment *pending_deployment = nullptr;
   ostree_sysroot_query_deployments_for(sysroot_smart.get(), nullptr, &pending_deployment, nullptr);
 
   bool pending_found = false;


### PR DESCRIPTION
`ostree_sysroot_query_deployments` could fail and not update the
pointer. In that case, the loop after that would compare uninitialized
memory with other pointers