### PR TITLE
Only wait 2s for discovery responses

### DIFF
--- a/src/libaktualizr/config/config.h
+++ b/src/libaktualizr/config/config.h
@@ -45,7 +45,7 @@ struct NetworkConfig {
 
   std::string ipdiscovery_host{"::ffff:127.0.0.1"};
   in_port_t ipdiscovery_port{9031};
-  uint32_t ipdiscovery_wait_seconds{10};
+  uint32_t ipdiscovery_wait_seconds{2};
   in_port_t ipuptane_port{9030};
 
   void updateFromPropertyTree(const boost::property_tree::ptree& pt);


### PR DESCRIPTION
We send the IP Uptane discovery packet once, and 2 seconds seems enough to have
aktualizr be started by systemd and respond.  We don't currently retry sending
the discovery packet, so this delay won't help if systemd hasn't started
listening on the UDP port of the secondary yet.