### PR TITLE
Move config dir checking to a common function.

### DIFF
--- a/src/aktualizr_info/aktualizr_info_config.cc
+++ b/src/aktualizr_info/aktualizr_info_config.cc
@@ -13,11 +13,7 @@ AktualizrInfoConfig::AktualizrInfoConfig(const boost::program_options::variables
 
   if (cmd.count("config") > 0) {
     const auto configs = cmd["config"].as<std::vector<boost::filesystem::path>>();
-    for (const auto& config : configs) {
-      if (!boost::filesystem::exists(config)) {
-        LOG_ERROR << "Provided config file or directory " << config << " does not exist!";
-      }
-    }
+    checkDirs(configs);
     updateFromDirs(configs);
   } else {
     updateFromDirs(config_dirs_);

--- a/src/aktualizr_info/aktualizr_info_config.h
+++ b/src/aktualizr_info/aktualizr_info_config.h
@@ -7,6 +7,7 @@
 
 #include "logging/logging_config.h"
 #include "storage/storage_config.h"
+#include "utilities/config_utils.h"
 
 // Try to keep the order of config options the same as in
 // AktualizrInfoConfig::writeToStream() and

--- a/src/aktualizr_secondary/CMakeLists.txt
+++ b/src/aktualizr_secondary/CMakeLists.txt
@@ -113,7 +113,7 @@ set_tests_properties(aktualizr_secondary_cmdline--something
 add_test(NAME aktualizr_secondary_no_config_check_message
          COMMAND aktualizr-secondary -c non-existent-config.toml)
 set_tests_properties(aktualizr_secondary_no_config_check_message
-                     PROPERTIES PASS_REGULAR_EXPRESSION "Provided config file or directory \"non-existent-config.toml\" does not exist!")
+                     PROPERTIES PASS_REGULAR_EXPRESSION "Config directory non-existent-config.toml does not exist.")
 
 add_test(NAME aktualizr_secondary_help_with_other_options
          COMMAND aktualizr-secondary --help -c someconfig.toml)

--- a/src/aktualizr_secondary/aktualizr_secondary_config.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_config.cc
@@ -59,11 +59,7 @@ AktualizrSecondaryConfig::AktualizrSecondaryConfig(const boost::program_options:
 
   if (cmd.count("config") > 0) {
     const auto configs = cmd["config"].as<std::vector<boost::filesystem::path>>();
-    for (const auto& config : configs) {
-      if (!boost::filesystem::exists(config)) {
-        LOG_ERROR << "Provided config file or directory " << config << " does not exist!";
-      }
-    }
+    checkDirs(configs);
     updateFromDirs(configs);
   } else {
     updateFromDirs(config_dirs_);

--- a/src/aktualizr_secondary/aktualizr_secondary_config.h
+++ b/src/aktualizr_secondary/aktualizr_secondary_config.h
@@ -10,6 +10,7 @@
 #include "logging/logging_config.h"
 #include "package_manager/packagemanagerconfig.h"
 #include "storage/storage_config.h"
+#include "utilities/config_utils.h"
 
 // Try to keep the order of config options the same as in
 // AktualizrSecondaryConfig::writeToStream() and

--- a/src/libaktualizr/config/config.cc
+++ b/src/libaktualizr/config/config.cc
@@ -181,6 +181,12 @@ Config::Config(const boost::filesystem::path& filename) {
   postUpdateValues();
 }
 
+Config::Config(const std::vector<boost::filesystem::path>& config_dirs) {
+  checkDirs(config_dirs);
+  updateFromDirs(config_dirs);
+  postUpdateValues();
+}
+
 Config::Config(const boost::program_options::variables_map& cmd) {
   // Redundantly check and set the loglevel from the commandline prematurely so
   // that it is taken account while processing the config.
@@ -192,11 +198,7 @@ Config::Config(const boost::program_options::variables_map& cmd) {
 
   if (cmd.count("config") > 0) {
     const auto configs = cmd["config"].as<std::vector<boost::filesystem::path>>();
-    for (const auto& config : configs) {
-      if (!boost::filesystem::exists(config)) {
-        LOG_ERROR << "Provided config file or directory " << config << " does not exist!";
-      }
-    }
+    checkDirs(configs);
     updateFromDirs(configs);
   } else {
     updateFromDirs(config_dirs_);

--- a/src/libaktualizr/config/config.h
+++ b/src/libaktualizr/config/config.h
@@ -14,9 +14,6 @@
 #include <boost/uuid/uuid_io.hpp>
 
 #include "asn1/asn1-cerstream.h"
-#include "utilities/config_utils.h"
-#include "utilities/types.h"
-
 #include "bootloader/bootloader.h"
 #include "crypto/keymanager_config.h"
 #include "crypto/p11_config.h"
@@ -25,6 +22,8 @@
 #include "storage/storage_config.h"
 #include "telemetry/telemetryconfig.h"
 #include "uptane/secondaryconfig.h"
+#include "utilities/config_utils.h"
+#include "utilities/types.h"
 
 enum class ProvisionMode { kAutomatic = 0, kImplicit };
 
@@ -107,10 +106,7 @@ class Config : public BaseConfig {
   Config();
   explicit Config(const boost::program_options::variables_map& cmd);
   explicit Config(const boost::filesystem::path& filename);
-  explicit Config(const std::vector<boost::filesystem::path>& config_dirs) {
-    updateFromDirs(config_dirs);
-    postUpdateValues();
-  }
+  explicit Config(const std::vector<boost::filesystem::path>& config_dirs);
 
   KeyManagerConfig keymanagerConfig() const;
 

--- a/src/libaktualizr/utilities/config_utils.h
+++ b/src/libaktualizr/utilities/config_utils.h
@@ -85,7 +85,7 @@ class BaseConfig {
   void updateFromToml(const boost::filesystem::path& filename) {
     LOG_INFO << "Reading config: " << filename;
     if (!boost::filesystem::exists(filename)) {
-      throw std::runtime_error(filename.string() + " does not exist.");
+      throw std::runtime_error("Config file " + filename.string() + " does not exist.");
     }
     boost::property_tree::ptree pt;
     boost::property_tree::ini_parser::read_ini(filename.string(), pt);
@@ -110,6 +110,14 @@ class BaseConfig {
     }
     for (const auto& config_file : configs_map) {
       updateFromToml(config_file.second);
+    }
+  }
+
+  void checkDirs(const std::vector<boost::filesystem::path>& configs) {
+    for (const auto& config : configs) {
+      if (!boost::filesystem::exists(config)) {
+        throw std::runtime_error("Config directory " + config.string() + " does not exist.");
+      }
     }
   }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -136,7 +136,7 @@ set_tests_properties(test_cmdline--something
 add_test(NAME test-no-config-check-message
          COMMAND aktualizr -c non-existent-config.toml)
 set_tests_properties(test-no-config-check-message
-                     PROPERTIES PASS_REGULAR_EXPRESSION "Provided config file or directory \"non-existent-config.toml\" does not exist!")
+                     PROPERTIES PASS_REGULAR_EXPRESSION "Config directory non-existent-config.toml does not exist.")
 
 add_test(NAME test-help-with-other-options
          COMMAND aktualizr --help -c someconfig.toml)


### PR DESCRIPTION
Also use it for the Config(vector<path>) constructor, which cert_provider uses. Previously, a nonexistent config would be silently ignored. Now it is as least not silent.

The idea is that if config files/dirs specified directly on the commandline do not exist, you should tell the user, because that probably matters.

This does mean that if you use this in meta-updater, the implicit prov test should fail just like the HSM test. This is intentional. It should fail if it can't find the config file. Currently it is sometimes using an empty config, which mostly works, but is maybe not a good idea.