### PR TITLE
Feat/manual installation result

### DIFF
--- a/config/sql/migration/migrate.07.sql
+++ b/config/sql/migration/migrate.07.sql
@@ -1,0 +1,9 @@
+-- Don't modify this! Create a new migration instead--see docs/schema-migrations.adoc
+BEGIN TRANSACTION;
+
+CREATE TABLE installation_result(result TEXT);
+
+DELETE FROM version;
+INSERT INTO version VALUES(7);
+
+COMMIT TRANSACTION;

--- a/config/sql/migration/migrate.07.sql
+++ b/config/sql/migration/migrate.07.sql
@@ -1,7 +1,7 @@
 -- Don't modify this! Create a new migration instead--see docs/schema-migrations.adoc
 BEGIN TRANSACTION;
 
-CREATE TABLE installation_result(id TEXT, result_code INTEGER NOT NULL DEFAULT 0, result_text TEXT);
+CREATE TABLE installation_result(unique_mark INTEGER PRIMARY KEY CHECK (unique_mark = 0), id TEXT, result_code INTEGER NOT NULL DEFAULT 0, result_text TEXT);
 
 DELETE FROM version;
 INSERT INTO version VALUES(7);

--- a/config/sql/migration/migrate.07.sql
+++ b/config/sql/migration/migrate.07.sql
@@ -1,7 +1,7 @@
 -- Don't modify this! Create a new migration instead--see docs/schema-migrations.adoc
 BEGIN TRANSACTION;
 
-CREATE TABLE installation_result(result TEXT);
+CREATE TABLE installation_result(id TEXT, result_code INTEGER NOT NULL DEFAULT 0, result_text TEXT);
 
 DELETE FROM version;
 INSERT INTO version VALUES(7);

--- a/config/sql/schema.sql
+++ b/config/sql/schema.sql
@@ -1,5 +1,5 @@
 CREATE TABLE version(version INTEGER);
-INSERT INTO version(rowid,version) VALUES(1,6);
+INSERT INTO version(rowid,version) VALUES(1,7);
 CREATE TABLE device_info(device_id TEXT, is_registered INTEGER NOT NULL DEFAULT 0 CHECK (is_registered IN (0,1)));
 CREATE TABLE ecu_serials(serial TEXT UNIQUE, hardware_id TEXT NOT NULL, is_primary INTEGER NOT NULL CHECK (is_primary IN (0,1)));
 CREATE TABLE misconfigured_ecus(serial TEXT UNIQUE, hardware_id TEXT NOT NULL, state INTEGER NOT NULL CHECK (state IN (0,1)));
@@ -19,3 +19,4 @@ INSERT INTO meta_types(rowid,meta,meta_string) VALUES(3,2,'targets');
 INSERT INTO meta_types(rowid,meta,meta_string) VALUES(4,3,'timestamp');
 INSERT INTO repo_types(rowid,repo,repo_string) VALUES(1,0,'images');
 INSERT INTO repo_types(rowid,repo,repo_string) VALUES(2,1,'director');
+CREATE TABLE installation_result(id TEXT, result_code INTEGER NOT NULL DEFAULT 0, result_text TEXT);

--- a/config/sql/schema.sql
+++ b/config/sql/schema.sql
@@ -19,4 +19,4 @@ INSERT INTO meta_types(rowid,meta,meta_string) VALUES(3,2,'targets');
 INSERT INTO meta_types(rowid,meta,meta_string) VALUES(4,3,'timestamp');
 INSERT INTO repo_types(rowid,repo,repo_string) VALUES(1,0,'images');
 INSERT INTO repo_types(rowid,repo,repo_string) VALUES(2,1,'director');
-CREATE TABLE installation_result(id TEXT, result_code INTEGER NOT NULL DEFAULT 0, result_text TEXT);
+CREATE TABLE installation_result(unique_mark INTEGER PRIMARY KEY CHECK (unique_mark = 0), id TEXT, result_code INTEGER NOT NULL DEFAULT 0, result_text TEXT);

--- a/src/external_secondaries/example_flasher.cc
+++ b/src/external_secondaries/example_flasher.cc
@@ -13,7 +13,7 @@ ExampleFlasher::ExampleFlasher(const unsigned int loglevel) : loglevel_(loglevel
   // Use /var/sota if it is available and accessible to the current user.
   // Generally this is true for devices but not hosts.
   if (boost::filesystem::exists("/var/sota")) {
-    if (access("/var/sota", R_OK & W_OK & X_OK) == 0) {
+    if (access("/var/sota", R_OK | W_OK | X_OK) != 0) {
       filename = "/tmp/example_serial";
     } else {
       filename = "/var/sota/example_serial";

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -76,7 +76,6 @@ class SotaUptaneClient {
   Uptane::Fetcher uptane_fetcher;
   const Bootloader &bootloader;
   ReportQueue &report_queue;
-  Json::Value operation_result;
   std::atomic<bool> shutdown = {false};
   Json::Value last_network_info_reported;
   std::map<Uptane::EcuSerial, Uptane::HardwareIdentifier> hw_ids;

--- a/src/libaktualizr/storage/fsstorage.cc
+++ b/src/libaktualizr/storage/fsstorage.cc
@@ -547,17 +547,18 @@ void FSStorage::clearInstalledVersions() {
   }
 }
 
-void FSStorage::storeInstallationResult(const std::string& installation_result) {
-  Utils::writeFile(Utils::absolutePath(config_.path, "installation_result"), installation_result);
+void FSStorage::storeInstallationResult(const data::OperationResult& result) {
+  Utils::writeFile(Utils::absolutePath(config_.path, "installation_result"), result.toJson());
 }
 
-bool FSStorage::loadInstallationResult(std::string* installation_result) {
+bool FSStorage::loadInstallationResult(data::OperationResult* result) {
   if (!boost::filesystem::exists(Utils::absolutePath(config_.path, "installation_result").string())) {
     return false;
   }
 
-  if (installation_result != nullptr) {
-    *installation_result = Utils::readFile(Utils::absolutePath(config_.path, "installation_result").string());
+  if (result != nullptr) {
+    *result = data::OperationResult::fromJson(
+        Utils::readFile(Utils::absolutePath(config_.path, "installation_result").string()));
   }
   return true;
 }

--- a/src/libaktualizr/storage/fsstorage.cc
+++ b/src/libaktualizr/storage/fsstorage.cc
@@ -1,14 +1,15 @@
 #include "fsstorage.h"
 
-#include <iostream>
-
-#include <boost/lexical_cast.hpp>
-#include <boost/scoped_array.hpp>
-#include <utility>
-
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+
+#include <iostream>
+#include <utility>
+
+#include <boost/lexical_cast.hpp>
+#include <boost/scoped_array.hpp>
+#include "json/json.h"
 
 #include "logging/logging.h"
 #include "utilities/utils.h"
@@ -544,6 +545,25 @@ void FSStorage::clearInstalledVersions() {
   if (boost::filesystem::exists(Utils::absolutePath(config_.path, "installed_versions"))) {
     boost::filesystem::remove(Utils::absolutePath(config_.path, "installed_versions"));
   }
+}
+
+void FSStorage::storeInstallationResult(const std::string& installation_result) {
+  Utils::writeFile(Utils::absolutePath(config_.path, "installation_result"), installation_result);
+}
+
+bool FSStorage::loadInstallationResult(std::string* installation_result) {
+  if (!boost::filesystem::exists(Utils::absolutePath(config_.path, "installation_result").string())) {
+    return false;
+  }
+
+  if (installation_result != nullptr) {
+    *installation_result = Utils::readFile(Utils::absolutePath(config_.path, "installation_result").string());
+  }
+  return true;
+}
+
+void FSStorage::clearInstallationResult() {
+  boost::filesystem::remove(Utils::absolutePath(config_.path, "installation_result"));
 }
 
 class FSTargetWHandle : public StorageTargetWHandle {

--- a/src/libaktualizr/storage/fsstorage.h
+++ b/src/libaktualizr/storage/fsstorage.h
@@ -47,8 +47,8 @@ class FSStorage : public INvStorage {
                               const std::string& current_hash) override;
   std::string loadInstalledVersions(std::vector<Uptane::Target>* installed_versions) override;
   void clearInstalledVersions() override;
-  void storeInstallationResult(const std::string& installation_result) override;
-  bool loadInstallationResult(std::string* installation_result) override;
+  void storeInstallationResult(const data::OperationResult& result) override;
+  bool loadInstallationResult(data::OperationResult* result) override;
   void clearInstallationResult() override;
 
   std::unique_ptr<StorageTargetWHandle> allocateTargetFile(bool from_director, const std::string& filename,

--- a/src/libaktualizr/storage/fsstorage.h
+++ b/src/libaktualizr/storage/fsstorage.h
@@ -47,6 +47,10 @@ class FSStorage : public INvStorage {
                               const std::string& current_hash) override;
   std::string loadInstalledVersions(std::vector<Uptane::Target>* installed_versions) override;
   void clearInstalledVersions() override;
+  void storeInstallationResult(const std::string& installation_result) override;
+  bool loadInstallationResult(std::string* installation_result) override;
+  void clearInstallationResult() override;
+
   std::unique_ptr<StorageTargetWHandle> allocateTargetFile(bool from_director, const std::string& filename,
                                                            size_t size) override;
   std::unique_ptr<StorageTargetRHandle> openTargetFile(const std::string& filename) override;

--- a/src/libaktualizr/storage/invstorage.h
+++ b/src/libaktualizr/storage/invstorage.h
@@ -133,6 +133,10 @@ class INvStorage {
   virtual std::string loadInstalledVersions(std::vector<Uptane::Target>* installed_versions) = 0;
   virtual void clearInstalledVersions() = 0;
 
+  virtual void storeInstallationResult(const std::string& installation_result) = 0;
+  virtual bool loadInstallationResult(std::string* installation_result) = 0;
+  virtual void clearInstallationResult() = 0;
+
   // Incremental file API
   virtual std::unique_ptr<StorageTargetWHandle> allocateTargetFile(bool from_director, const std::string& filename,
                                                                    size_t size) = 0;

--- a/src/libaktualizr/storage/invstorage.h
+++ b/src/libaktualizr/storage/invstorage.h
@@ -1,14 +1,15 @@
 #ifndef INVSTORAGE_H_
 #define INVSTORAGE_H_
 
-#include <boost/filesystem.hpp>
 #include <memory>
 #include <string>
 #include <utility>
 
-#include "uptane/tuf.h"
+#include <boost/filesystem.hpp>
 
 #include "storage_config.h"
+#include "uptane/tuf.h"
+#include "utilities/types.h"
 
 class INvStorage;
 class FSStorage;
@@ -133,8 +134,8 @@ class INvStorage {
   virtual std::string loadInstalledVersions(std::vector<Uptane::Target>* installed_versions) = 0;
   virtual void clearInstalledVersions() = 0;
 
-  virtual void storeInstallationResult(const std::string& installation_result) = 0;
-  virtual bool loadInstallationResult(std::string* installation_result) = 0;
+  virtual void storeInstallationResult(const data::OperationResult& result) = 0;
+  virtual bool loadInstallationResult(data::OperationResult* result) = 0;
   virtual void clearInstallationResult() = 0;
 
   // Incremental file API

--- a/src/libaktualizr/storage/sqlstorage.cc
+++ b/src/libaktualizr/storage/sqlstorage.cc
@@ -340,7 +340,7 @@ bool SQLStorage::loadTlsCa(std::string* ca) {
 
   auto statement = db.prepareStatement("SELECT ca_cert FROM tls_creds LIMIT 1;");
   if (statement.step() != SQLITE_ROW) {
-    LOG_ERROR << "Can't get device ID: " << db.errmsg();
+    LOG_ERROR << "Can't get tls_creds: " << db.errmsg();
     return false;
   }
 
@@ -366,7 +366,7 @@ bool SQLStorage::loadTlsCert(std::string* cert) {
 
   auto statement = db.prepareStatement("SELECT client_cert FROM tls_creds LIMIT 1;");
   if (statement.step() != SQLITE_ROW) {
-    LOG_ERROR << "Can't get device ID: " << db.errmsg();
+    LOG_ERROR << "Can't get tls_creds: " << db.errmsg();
     return false;
   }
 
@@ -953,6 +953,62 @@ void SQLStorage::clearInstalledVersions() {
   }
 }
 
+void SQLStorage::storeInstallationResult(const std::string& installation_result) {
+  SQLite3Guard db(config_.sqldb_path.c_str());
+
+  if (db.get_rc() != SQLITE_OK) {
+    LOG_ERROR << "Can't open database: " << db.errmsg();
+    return;
+  }
+
+  auto statement =
+      db.prepareStatement<std::string>("UPDATE OR REPLACE installation_result SET result = ?;", installation_result);
+  if (statement.step() != SQLITE_DONE) {
+    LOG_ERROR << "Can't set installation_result: " << db.errmsg();
+    return;
+  }
+}
+
+bool SQLStorage::loadInstallationResult(std::string* installation_result) {
+  SQLite3Guard db(config_.sqldb_path.c_str());
+
+  if (db.get_rc() != SQLITE_OK) {
+    LOG_ERROR << "Can't open database: " << db.errmsg();
+    return false;
+  }
+
+  auto statement = db.prepareStatement("SELECT result FROM installation_result LIMIT 1;");
+  if (statement.step() != SQLITE_ROW) {
+    LOG_ERROR << "Can't get installation_result: " << db.errmsg();
+    return false;
+  }
+
+  auto did = statement.get_result_col_str(0);
+  if (did == boost::none) {
+    return false;
+  }
+
+  if (installation_result != nullptr) {
+    *installation_result = std::move(did.value());
+  }
+
+  return true;
+}
+
+void SQLStorage::clearInstallationResult() {
+  SQLite3Guard db(config_.sqldb_path.c_str());
+
+  if (db.get_rc() != SQLITE_OK) {
+    LOG_ERROR << "Can't open database: " << db.errmsg();
+    return;
+  }
+
+  if (db.exec("UPDATE OR REPLACE installation_result SET result = NULL;", nullptr, nullptr) != SQLITE_OK) {
+    LOG_ERROR << "Can't clear installation_result: " << db.errmsg();
+    return;
+  }
+}
+
 class SQLTargetWHandle : public StorageTargetWHandle {
  public:
   SQLTargetWHandle(const SQLStorage& storage, std::string filename, size_t size)
@@ -1220,15 +1276,25 @@ bool SQLStorage::dbInit() {
   }
 
   auto statement = db.prepareStatement("SELECT count(*) FROM device_info;");
-
   if (statement.step() != SQLITE_ROW) {
     LOG_ERROR << "Can't get number of rows in device_info: " << db.errmsg();
     return false;
   }
-
   if (statement.get_result_col_int(0) < 1) {
     if (db.exec("INSERT INTO device_info DEFAULT VALUES;", nullptr, nullptr) != SQLITE_OK) {
       LOG_ERROR << "Can't set default values to device_info: " << db.errmsg();
+      return false;
+    }
+  }
+
+  auto statement2 = db.prepareStatement("SELECT count(*) FROM installation_result;");
+  if (statement2.step() != SQLITE_ROW) {
+    LOG_ERROR << "Can't get number of rows in installation_result: " << db.errmsg();
+    return false;
+  }
+  if (statement2.get_result_col_int(0) < 1) {
+    if (db.exec("INSERT INTO installation_result DEFAULT VALUES;", nullptr, nullptr) != SQLITE_OK) {
+      LOG_ERROR << "Can't set default values to installation_result: " << db.errmsg();
       return false;
     }
   }

--- a/src/libaktualizr/storage/sqlstorage.h
+++ b/src/libaktualizr/storage/sqlstorage.h
@@ -59,8 +59,8 @@ class SQLStorage : public INvStorage {
                               const std::string& current_hash) override;
   std::string loadInstalledVersions(std::vector<Uptane::Target>* installed_versions) override;
   void clearInstalledVersions() override;
-  void storeInstallationResult(const std::string& installation_result) override;
-  bool loadInstallationResult(std::string* installation_result) override;
+  void storeInstallationResult(const data::OperationResult& result) override;
+  bool loadInstallationResult(data::OperationResult* result) override;
   void clearInstallationResult() override;
 
   std::unique_ptr<StorageTargetWHandle> allocateTargetFile(bool from_director, const std::string& filename,

--- a/src/libaktualizr/storage/sqlstorage.h
+++ b/src/libaktualizr/storage/sqlstorage.h
@@ -59,6 +59,10 @@ class SQLStorage : public INvStorage {
                               const std::string& current_hash) override;
   std::string loadInstalledVersions(std::vector<Uptane::Target>* installed_versions) override;
   void clearInstalledVersions() override;
+  void storeInstallationResult(const std::string& installation_result) override;
+  bool loadInstallationResult(std::string* installation_result) override;
+  void clearInstallationResult() override;
+
   std::unique_ptr<StorageTargetWHandle> allocateTargetFile(bool from_director, const std::string& filename,
                                                            size_t size) override;
   std::unique_ptr<StorageTargetRHandle> openTargetFile(const std::string& filename) override;

--- a/src/libaktualizr/storage/storage_common_test.cc
+++ b/src/libaktualizr/storage/storage_common_test.cc
@@ -285,19 +285,14 @@ TEST(storage, load_store_installation_result) {
   mkdir(storage_test_dir.c_str(), S_IRWXU);
   std::unique_ptr<INvStorage> storage = Storage();
   data::InstallOutcome outcome(data::UpdateResultCode::kGeneralError, "some failure");
-  Json::Value operation_result;
-  operation_result["operation_result"] = data::OperationResult::fromOutcome("target_filename", outcome).toJson();
-  std::string result_str = Json::FastWriter().write(operation_result);
-  storage->storeInstallationResult(result_str);
+  data::OperationResult result("target_filename", outcome);
+  storage->storeInstallationResult(result);
 
-  std::string installation_result;
-  EXPECT_TRUE(storage->loadInstallationResult(&installation_result));
-  EXPECT_EQ(installation_result, result_str);
-  Json::Value read_result = Utils::parseJSON(installation_result);
-  EXPECT_EQ(read_result["operation_result"]["id"], "target_filename");
-  EXPECT_EQ(read_result["operation_result"]["result_code"], static_cast<int>(data::UpdateResultCode::kGeneralError));
-  EXPECT_EQ(read_result["operation_result"]["result_text"], "some failure");
-
+  data::OperationResult result_out;
+  EXPECT_TRUE(storage->loadInstallationResult(&result_out));
+  EXPECT_EQ(result.id, result_out.id);
+  EXPECT_EQ(result.result_code, result_out.result_code);
+  EXPECT_EQ(result.result_text, result_out.result_text);
   storage->clearInstallationResult();
   EXPECT_FALSE(storage->loadInstallationResult(NULL));
   boost::filesystem::remove_all(storage_test_dir);

--- a/src/libaktualizr/uptane/uptane_test.cc
+++ b/src/libaktualizr/uptane/uptane_test.cc
@@ -1086,7 +1086,7 @@ TEST(Uptane, krejectallTest) {
 
   config.provision.device_id = "device_id";
   config.postUpdateValues();
-  auto storage = INvStorage::newStorage(config.storage);
+  auto storage = INvStorage::newStorage(config.storage, "");
   Uptane::Manifest uptane_manifest{config, storage};
   Bootloader bootloader{config.bootloader};
   ReportQueue report_queue(config, http);

--- a/src/libaktualizr/uptane/uptane_test.cc
+++ b/src/libaktualizr/uptane/uptane_test.cc
@@ -573,6 +573,9 @@ TEST(Uptane, RunForeverNoUpdates) {
   EXPECT_TRUE(events_channel->hasValues());
   EXPECT_TRUE(*events_channel >> event);
   EXPECT_EQ(event->variant, "UptaneTimestampUpdated");
+
+  Json::Value manifest = up.AssembleManifest();
+  EXPECT_FALSE(manifest["testecuserial"]["signed"].isMember("custom"));
 }
 
 TEST(Uptane, RunForeverHasUpdates) {
@@ -628,6 +631,9 @@ TEST(Uptane, RunForeverHasUpdates) {
   EXPECT_EQ(targets_event->updates.size(), 2u);
   EXPECT_EQ(targets_event->updates[0].filename(), "primary_firmware.txt");
   EXPECT_EQ(targets_event->updates[1].filename(), "secondary_firmware.txt");
+
+  Json::Value manifest = up.AssembleManifest();
+  EXPECT_FALSE(manifest["testecuserial"]["signed"].isMember("custom"));
 }
 
 std::vector<Uptane::Target> makePackage(const std::string& serial, const std::string& hw_id) {
@@ -670,6 +676,14 @@ TEST(Uptane, RunForeverInstall) {
   up.runForever(commands_channel);
 
   EXPECT_FALSE(boost::filesystem::exists(temp_dir.Path() / http.test_manifest));
+
+  // Make sure operation_result was correctly written and formatted.
+  Json::Value manifest = up.AssembleManifest();
+  EXPECT_EQ(manifest["testecuserial"]["signed"]["custom"]["operation_result"]["id"], "testecuserial");
+  EXPECT_EQ(manifest["testecuserial"]["signed"]["custom"]["operation_result"]["result_code"],
+            static_cast<int>(data::UpdateResultCode::kOk));
+  EXPECT_EQ(manifest["testecuserial"]["signed"]["custom"]["operation_result"]["result_text"],
+            "Installing fake package was successful");
 }
 
 TEST(Uptane, UptaneSecondaryAdd) {

--- a/src/libaktualizr/utilities/types.cc
+++ b/src/libaktualizr/utilities/types.cc
@@ -24,9 +24,12 @@ Package Package::fromJson(const std::string& json_str) {
 OperationResult::OperationResult(std::string id_in, UpdateResultCode result_code_in, std::string result_text_in)
     : id(std::move(id_in)), result_code(result_code_in), result_text(std::move(result_text_in)) {}
 
-InstallOutcome OperationResult::toOutcome() { return InstallOutcome(result_code, result_text); }
+OperationResult::OperationResult(std::string id_in, InstallOutcome outcome_in)
+    : id(std::move(id_in)), result_code(outcome_in.first), result_text(outcome_in.second) {}
 
-Json::Value OperationResult::toJson() {
+InstallOutcome OperationResult::toOutcome() const { return InstallOutcome(result_code, result_text); }
+
+Json::Value OperationResult::toJson() const {
   Json::Value json;
   json["id"] = id;
   json["result_code"] = static_cast<int>(result_code);
@@ -46,10 +49,7 @@ OperationResult OperationResult::fromJson(const std::string& json_str) {
 }
 
 OperationResult OperationResult::fromOutcome(const std::string& id, const InstallOutcome& outcome) {
-  OperationResult operation_result;
-  operation_result.id = id;
-  operation_result.result_code = outcome.first;
-  operation_result.result_text = outcome.second;
+  OperationResult operation_result(id, outcome);
   return operation_result;
 }
 

--- a/src/libaktualizr/utilities/types.h
+++ b/src/libaktualizr/utilities/types.h
@@ -140,14 +140,15 @@ typedef std::pair<UpdateResultCode, std::string> InstallOutcome;
 struct OperationResult {
   OperationResult() : result_code(UpdateResultCode::kOk) {}
   OperationResult(std::string id_in, UpdateResultCode result_code_in, std::string result_text_in);
+  OperationResult(std::string id_in, InstallOutcome outcome_in);
   std::string id;
   UpdateResultCode result_code{};
   std::string result_text;
-  Json::Value toJson();
-  bool isSuccess() {
+  Json::Value toJson() const;
+  bool isSuccess() const {
     return result_code == UpdateResultCode::kOk || result_code == UpdateResultCode::kAlreadyProcessed;
   };
-  InstallOutcome toOutcome();
+  InstallOutcome toOutcome() const;
   static OperationResult fromJson(const std::string& json_str);
   static OperationResult fromOutcome(const std::string& id, const InstallOutcome& outcome);
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -148,13 +148,18 @@ add_test(NAME test-help-with-nonexistent-options
 set_tests_properties(test-help-with-nonexistent-options
                      PROPERTIES PASS_REGULAR_EXPRESSION "aktualizr command line options")
 
+# --tls-server is provided only to prevent the credentials file from getting
+# read before the desired error message is printed. This was a problem if
+# /var/sota existed but was owned by root, because aktualizr would crash.
 add_test(NAME test-legacy-interface-with-nonexistent-file
-         COMMAND aktualizr -c  ${PROJECT_SOURCE_DIR}/config/sota_autoprov.toml --legacy-interface nonexistentfile)
+         COMMAND aktualizr -c ${PROJECT_SOURCE_DIR}/config/sota_autoprov.toml
+         --tls-server fake --legacy-interface nonexistentfile)
 set_tests_properties(test-legacy-interface-with-nonexistent-file
                      PROPERTIES PASS_REGULAR_EXPRESSION "Legacy external flasher not found: nonexistentfile")
 
 add_test(NAME test-secondary-config-with-nonexistent-file
-         COMMAND aktualizr -c  ${PROJECT_SOURCE_DIR}/config/sota_autoprov.toml --secondary-config nonexistentfile)
+         COMMAND aktualizr -c ${PROJECT_SOURCE_DIR}/config/sota_autoprov.toml
+         --tls-server fake --secondary-config nonexistentfile)
 set_tests_properties(test-secondary-config-with-nonexistent-file
                      PROPERTIES PASS_REGULAR_EXPRESSION "nonexistentfile does not exist!")
 


### PR DESCRIPTION
This stores the operation_result that was previously just a member variable. This means that manual aktualizr control should still send it in the manifest after an install. @rdanitz can you please verify that this fixes the manual control e2e test?