### PR TITLE
SQLite coverage + fixes

### DIFF
--- a/config/sql/migration/migrate.08.sql
+++ b/config/sql/migration/migrate.08.sql
@@ -6,6 +6,11 @@ INSERT INTO primary_keys_migrate SELECT 0,private,public FROM primary_keys LIMIT
 DROP TABLE primary_keys;
 ALTER TABLE primary_keys_migrate RENAME TO primary_keys;
 
+CREATE TABLE device_info_migrate(unique_mark INTEGER PRIMARY KEY CHECK (unique_mark = 0), device_id TEXT, is_registered INTEGER NOT NULL DEFAULT 0 CHECK (is_registered IN (0,1)));
+INSERT INTO device_info_migrate SELECT 0,device_id,is_registered FROM device_info LIMIT 1;
+DROP TABLE device_info;
+ALTER TABLE device_info_migrate RENAME TO device_info;
+
 DELETE FROM version;
 INSERT INTO version VALUES(8);
 

--- a/config/sql/migration/migrate.08.sql
+++ b/config/sql/migration/migrate.08.sql
@@ -1,0 +1,12 @@
+-- Don't modify this! Create a new migration instead--see docs/schema-migrations.adoc
+BEGIN TRANSACTION;
+
+CREATE TABLE primary_keys_migrate(unique_mark INTEGER PRIMARY KEY CHECK (unique_mark = 0), private TEXT, public TEXT);
+INSERT INTO primary_keys_migrate SELECT 0,private,public FROM primary_keys LIMIT 1;
+DROP TABLE primary_keys;
+ALTER TABLE primary_keys_migrate RENAME TO primary_keys;
+
+DELETE FROM version;
+INSERT INTO version VALUES(8);
+
+COMMIT TRANSACTION;

--- a/config/sql/schema.sql
+++ b/config/sql/schema.sql
@@ -1,6 +1,6 @@
 CREATE TABLE version(version INTEGER);
 INSERT INTO version(rowid,version) VALUES(1,8);
-CREATE TABLE device_info(device_id TEXT, is_registered INTEGER NOT NULL DEFAULT 0 CHECK (is_registered IN (0,1)));
+CREATE TABLE device_info(unique_mark INTEGER PRIMARY KEY CHECK (unique_mark = 0), device_id TEXT, is_registered INTEGER NOT NULL DEFAULT 0 CHECK (is_registered IN (0,1)));
 CREATE TABLE ecu_serials(serial TEXT UNIQUE, hardware_id TEXT NOT NULL, is_primary INTEGER NOT NULL CHECK (is_primary IN (0,1)));
 CREATE TABLE misconfigured_ecus(serial TEXT UNIQUE, hardware_id TEXT NOT NULL, state INTEGER NOT NULL CHECK (state IN (0,1)));
 CREATE TABLE installed_versions(hash TEXT UNIQUE, name TEXT NOT NULL, is_current INTEGER NOT NULL CHECK (is_current IN (0,1)) DEFAULT 0,

--- a/config/sql/schema.sql
+++ b/config/sql/schema.sql
@@ -1,11 +1,11 @@
 CREATE TABLE version(version INTEGER);
-INSERT INTO version(rowid,version) VALUES(1,7);
+INSERT INTO version(rowid,version) VALUES(1,8);
 CREATE TABLE device_info(device_id TEXT, is_registered INTEGER NOT NULL DEFAULT 0 CHECK (is_registered IN (0,1)));
 CREATE TABLE ecu_serials(serial TEXT UNIQUE, hardware_id TEXT NOT NULL, is_primary INTEGER NOT NULL CHECK (is_primary IN (0,1)));
 CREATE TABLE misconfigured_ecus(serial TEXT UNIQUE, hardware_id TEXT NOT NULL, state INTEGER NOT NULL CHECK (state IN (0,1)));
 CREATE TABLE installed_versions(hash TEXT UNIQUE, name TEXT NOT NULL, is_current INTEGER NOT NULL CHECK (is_current IN (0,1)) DEFAULT 0,
                                 length INTEGER NOT NULL DEFAULT 0);
-CREATE TABLE primary_keys(private TEXT, public TEXT);
+CREATE TABLE primary_keys(unique_mark INTEGER PRIMARY KEY CHECK (unique_mark = 0), private TEXT, public TEXT);
 CREATE TABLE tls_creds(ca_cert BLOB, ca_cert_format TEXT,
                        client_cert BLOB, client_cert_format TEXT,
                        client_pkey BLOB, client_pkey_format TEXT);

--- a/src/libaktualizr/storage/fsstorage.cc
+++ b/src/libaktualizr/storage/fsstorage.cc
@@ -389,6 +389,9 @@ bool FSStorage::loadDeviceId(std::string* device_id) {
 void FSStorage::clearDeviceId() { boost::filesystem::remove(Utils::absolutePath(config_.path, "device_id")); }
 
 void FSStorage::storeEcuRegistered() {
+  if (!loadDeviceId(nullptr)) {
+    throw std::runtime_error("Cannot set ecu registered if no device_info set");
+  }
   Utils::writeFile(Utils::absolutePath(config_.path, "is_registered"), std::string("1"));
 }
 

--- a/src/libaktualizr/storage/fsstorage.cc
+++ b/src/libaktualizr/storage/fsstorage.cc
@@ -349,8 +349,9 @@ void FSStorage::clearNonRootMeta(Uptane::RepositoryType repo) {
         continue;
       }
       std::string role_name;
-      if (splitNameRoleVersion(it->path().native(), &role_name, nullptr) &&
-          (role_name == Uptane::Version().RoleFileName(role))) {
+      std::string fn = it->path().filename().native();
+      if (fn == Uptane::Version().RoleFileName(role) ||
+          (splitNameRoleVersion(fn, &role_name, nullptr) && (role_name == Uptane::Version().RoleFileName(role)))) {
         boost::filesystem::remove(it->path());
       }
     }

--- a/src/libaktualizr/storage/invstorage.h
+++ b/src/libaktualizr/storage/invstorage.h
@@ -125,7 +125,7 @@ class INvStorage {
   virtual bool loadMisconfiguredEcus(std::vector<MisconfiguredEcu>* ecus) = 0;
   virtual void clearMisconfiguredEcus() = 0;
 
-  virtual void storeEcuRegistered() = 0;
+  virtual void storeEcuRegistered() = 0;  // should be called after storeDeviceId
   virtual bool loadEcuRegistered() = 0;
   virtual void clearEcuRegistered() = 0;
 

--- a/src/libaktualizr/storage/sqlstorage.cc
+++ b/src/libaktualizr/storage/sqlstorage.cc
@@ -100,20 +100,8 @@ void SQLStorage::storePrimaryKeys(const std::string& public_key, const std::stri
     return;
   }
 
-  auto statement = db.prepareStatement("SELECT count(*) FROM primary_keys;");
-  if (statement.step() != SQLITE_ROW) {
-    LOG_ERROR << "Can't get count of keys table: " << db.errmsg();
-    return;
-  }
-
-  const char* req;
-  if (statement.get_result_col_int(0) != 0) {
-    req = "UPDATE OR REPLACE primary_keys SET (public, private) = (?,?);";
-  } else {
-    req = "INSERT INTO primary_keys(public,private) VALUES (?,?);";
-  }
-
-  statement = db.prepareStatement<std::string>(req, public_key, private_key);
+  auto statement = db.prepareStatement<std::string>(
+      "INSERT OR REPLACE INTO primary_keys(unique_mark,public,private) VALUES (0,?,?);", public_key, private_key);
   if (statement.step() != SQLITE_DONE) {
     LOG_ERROR << "Can't set primary keys: " << db.errmsg();
     return;

--- a/src/libaktualizr/storage/sqlstorage.cc
+++ b/src/libaktualizr/storage/sqlstorage.cc
@@ -1268,8 +1268,8 @@ bool SQLStorage::dbMigrate() {
   }
 
   for (int k = schema_num_version + 1; k <= current_schema_version; k++) {
-    if (db.exec(schema_migrations[k].c_str(), nullptr, nullptr) != SQLITE_OK) {
-      LOG_ERROR << "Can't migrate db from version" << (k - 1) << " to version " << k << ": " << db.errmsg();
+    if (db.exec(schema_migrations.at(k), nullptr, nullptr) != SQLITE_OK) {
+      LOG_ERROR << "Can't migrate db from version " << (k - 1) << " to version " << k << ": " << db.errmsg();
       return false;
     }
   }

--- a/src/libaktualizr/storage/sqlstorage.h
+++ b/src/libaktualizr/storage/sqlstorage.h
@@ -73,7 +73,6 @@ class SQLStorage : public INvStorage {
   std::string getTableSchemaFromDb(const std::string& tablename);
 
   bool dbMigrate();
-  bool dbInit();
   DbVersion getVersion();  // non-negative integer on success or -1 on error
 
  private:

--- a/src/libaktualizr/storage/sqlstorage_test.cc
+++ b/src/libaktualizr/storage/sqlstorage_test.cc
@@ -97,7 +97,7 @@ static bool dbSchemaCheck(SQLStorage& storage) {
     return false;
   }
 
-  for (std::map<std::string, std::string>::iterator it = tables.begin(); it != tables.end(); ++it) {
+  for (auto it = tables.begin(); it != tables.end(); ++it) {
     std::string schema_from_db = storage.getTableSchemaFromDb(it->first);
     if (!tableSchemasEqual(schema_from_db, it->second)) {
       LOG_ERROR << "Schemas don't match for " << it->first;

--- a/src/libaktualizr/storage/storage_common_test.cc
+++ b/src/libaktualizr/storage/storage_common_test.cc
@@ -282,6 +282,8 @@ TEST(storage, load_store_misconfigured_ecus) {
 TEST(storage, load_store_ecu_registered) {
   mkdir(storage_test_dir.c_str(), S_IRWXU);
   std::unique_ptr<INvStorage> storage = Storage();
+  EXPECT_THROW(storage->storeEcuRegistered(), std::runtime_error);
+  storage->storeDeviceId("test");
   storage->storeEcuRegistered();
   storage->storeEcuRegistered();
 


### PR DESCRIPTION
More tests (store data twice in tests, mostly) which uncovered two issues
  - one small bug in FSStorage
  - one use of some sql syntax unsupported on xenial's version

Also:

* generalize transactions when doing SELECT then modify
* uses unique_mark trick for two tables
* simplify `device_info` handling and remove `dbInit()`