### PR TITLE
Introduce Target::IsOstree()

### DIFF
--- a/src/aktualizr_secondary/aktualizr_secondary.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary.cc
@@ -133,7 +133,7 @@ bool AktualizrSecondary::sendFirmwareResp(const std::string& firmware) {
   data::UpdateResultCode res_code;
   std::string message;
 
-  if (target_->format().empty() || target_->format() == "OSTREE") {
+  if (target_->IsOstree()) {
 #ifdef BUILD_OSTREE
     std::tie(res_code, message) =
         OstreeManager::pull(config_.pacman.sysroot, treehub_server, keys_, target_->sha256Hash());

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -73,8 +73,7 @@ data::InstallOutcome SotaUptaneClient::PackageInstall(const Uptane::Target &targ
 
 void SotaUptaneClient::PackageInstallSetResult(const Uptane::Target &target) {
   data::OperationResult result;
-  if (((!target.format().empty() && target.format() != "OSTREE") || target.length() != 0) &&
-      config.pacman.type == PackageManager::kOstree) {
+  if (!target.IsOstree() && config.pacman.type == PackageManager::kOstree) {
     data::InstallOutcome outcome(data::UpdateResultCode::kValidationFailed,
                                  "Cannot install a non-OSTree package on an OSTree system");
     result = data::OperationResult::fromOutcome(target.filename(), outcome);
@@ -973,7 +972,7 @@ void SotaUptaneClient::sendImagesToEcus(std::vector<Uptane::Target> targets) {
         continue;
       }
 
-      if (targets_it->format().empty() || targets_it->format() == "OSTREE") {
+      if (targets_it->IsOstree()) {
         // empty firmware means OSTree secondaries: pack credentials instead
         std::string creds_archive = secondaryTreehubCredentials();
         if (creds_archive.empty()) {

--- a/src/libaktualizr/uptane/fetcher.cc
+++ b/src/libaktualizr/uptane/fetcher.cc
@@ -34,7 +34,7 @@ static size_t DownloadHandler(char* contents, size_t size, size_t nmemb, void* u
 
 bool Fetcher::fetchVerifyTarget(const Target& target) {
   try {
-    if (target.length() > 0) {
+    if (!target.IsOstree()) {
       DownloadMetaStruct ds;
       std::unique_ptr<StorageTargetWHandle> fhandle =
           storage->allocateTargetFile(false, target.filename(), target.length());
@@ -61,7 +61,7 @@ bool Fetcher::fetchVerifyTarget(const Target& target) {
       if (!target.MatchWith(Hash(ds.hash_type, ds.hasher().getHexDigest()))) {
         throw TargetHashMismatch(target.filename());
       }
-    } else if (target.format().empty() || target.format() == "OSTREE") {
+    } else {
 #ifdef BUILD_OSTREE
       KeyManager keys(storage, config.keymanagerConfig());
       keys.loadKeys();

--- a/src/libaktualizr/uptane/tuf.cc
+++ b/src/libaktualizr/uptane/tuf.cc
@@ -149,6 +149,21 @@ std::string Target::sha256Hash() const {
   return std::string();
 }
 
+bool Target::IsOstree() const {
+  if (type_ == "OSTREE") {
+    // Modern servers explicitly specify the type of the target
+    return true;
+  } else if (type_.empty() && length() == 0) {
+    // Older servers don't specify the type of the target. Assume that it is
+    // an OSTree target if the length is zero.
+    return true;
+  } else {
+    // If type is explicitly not OSTREE or the length is non-zero, then this
+    // is a firmware blob.
+    return false;
+  }
+}
+
 Json::Value Target::toDebugJson() const {
   Json::Value res;
   for (auto it = ecus_.begin(); it != ecus_.cend(); ++it) {

--- a/src/libaktualizr/uptane/tuf.h
+++ b/src/libaktualizr/uptane/tuf.h
@@ -184,7 +184,6 @@ class Target {
 
   const std::map<EcuSerial, HardwareIdentifier> &ecus() const { return ecus_; }
   std::string filename() const { return filename_; }
-  std::string format() const { return type_; }
   std::string sha256Hash() const;
   std::vector<Hash> hashes() const { return hashes_; };
 
@@ -197,6 +196,14 @@ class Target {
               return pair.first == ecuIdentifier;
             }) != ecus_.cend());
   };
+
+  /**
+   * Is this an OSTree target?
+   * OSTree targets need special treatment because the hash doesn't represent
+   * the contents of the update itself, instead it is the hash (name) of the
+   * root commit object.
+   */
+  bool IsOstree() const;
 
   bool operator==(const Target &t2) const {
     // if (type_ != t2.type_) return false; // Director doesn't include targetFormat


### PR DESCRIPTION
This replaces Target::format(), and brings the logic about the meaning of that
field inside the Target class itself.