### PR TITLE
SendDeviceData also for --running-mode=check.

### DIFF
--- a/src/libaktualizr/primary/eventsinterpreter.cc
+++ b/src/libaktualizr/primary/eventsinterpreter.cc
@@ -24,8 +24,6 @@ void EventsInterpreter::run() {
 
   if (config.uptane.running_mode == RunningMode::kDownload || config.uptane.running_mode == RunningMode::kInstall) {
     *commands_channel << std::make_shared<command::CheckUpdates>();
-  } else if (config.uptane.running_mode == RunningMode::kCheck) {
-    *commands_channel << std::make_shared<command::FetchMeta>();
   } else {
     *commands_channel << std::make_shared<command::SendDeviceData>();
   }

--- a/src/libaktualizr/primary/eventsinterpreter_test.cc
+++ b/src/libaktualizr/primary/eventsinterpreter_test.cc
@@ -111,6 +111,9 @@ TEST(event, RunningMode_check) {
   std::shared_ptr<command::BaseCommand> command;
 
   *commands_channel >> command;
+  EXPECT_EQ(command->variant, "SendDeviceData");
+  *events_channel << std::make_shared<event::SendDeviceDataComplete>();
+  *commands_channel >> command;
   EXPECT_EQ(command->variant, "FetchMeta");
   *events_channel << std::make_shared<event::FetchMetaComplete>();
   *commands_channel >> command;


### PR DESCRIPTION
This will send a lot of redundant data every time aktualizr runs with that flag, but that might be reasonable anyway if the data changed since the last run.

This probably isn't a perfect solution, but since there is no specific requirement at present, I'd rather keep it simple while sending the messages that were previously being skipped in manual runs.