### PR TITLE
Fix/prevent rel path misuse

### DIFF
--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -156,7 +156,7 @@ Options for how Aktualizr stores data locally.
 | `tls_cacert_path`         | `"root.crt"`              | Relative path to the TLS root CA certificate. Only used with `filesystem`.
 | `tls_pkey_path`           | `"pkey.pem"`              | Relative path to the client's TLS private key. Only used with `filesystem`.
 | `tls_clientcert_path`     | `"client.pem"`            | Relative path to the client's TLS certificate. Only used with `filesystem`.
-| `sqldb_path`              | `"/var/sota/sql.db"`      | Path to the database file. Only used with `sqlite`.
+| `sqldb_path`              | `"sql.db"`                | Relative path to the database file. Only used with `sqlite`.
 |==========================================================================================
 
 == `import`

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -166,6 +166,7 @@ Options for importing data from the filesystem into the storage. Most useful if 
 [options="header"]
 |==========================================================================================
 | Name                      | Default | Description
+| `base_path`               |         | Path to a common root directory to the subsequent files
 | `uptane_private_key_path` |         | Path to the device's private key.
 | `uptane_public_key_path`  |         | Path to the device's public key.
 | `tls_cacert_path`         |         | Path to the TLS root CA certificate.

--- a/src/aktualizr_info/aktualizr_info_config_test.cc
+++ b/src/aktualizr_info/aktualizr_info_config_test.cc
@@ -14,7 +14,7 @@ TEST(aktualizr_info_config, config_toml_parsing) {
   AktualizrInfoConfig conf("config/sota_autoprov.toml");
 
   EXPECT_EQ(conf.storage.type, StorageType::kSqlite);
-  EXPECT_EQ(conf.storage.sqldb_path, "/var/sota/sql.db");
+  EXPECT_EQ(conf.storage.sqldb_path.get(conf.storage.path), "/var/sota/sql.db");
 }
 
 /* We don't normally dump the config to file, but we do write it to the log. */

--- a/src/aktualizr_secondary/protocol_test.cc
+++ b/src/aktualizr_secondary/protocol_test.cc
@@ -13,8 +13,8 @@ TEST(aktualizr_secondary_protocol, run_and_stop) {
   TemporaryDirectory temp_dir;
   AktualizrSecondaryConfig config = conf;
   config.network.port = 0;  // random port
+  config.storage.path = temp_dir.Path();
   config.storage.type = StorageType::kSqlite;
-  config.storage.sqldb_path = temp_dir.Path() / "sql.db";
 
   config.pacman.sysroot = sysroot;
   auto storage = INvStorage::newStorage(config.storage, temp_dir.Path());

--- a/src/aktualizr_secondary/update_test.cc
+++ b/src/aktualizr_secondary/update_test.cc
@@ -36,7 +36,6 @@ TEST(aktualizr_secondary_protocol, DISABLED_manual_update) {
   AktualizrSecondaryConfig config;
   config.network.port = 0;
   config.storage.type = StorageType::kSqlite;
-  config.storage.sqldb_path = temp_dir_sec / "sql.db";
   config.pacman.sysroot = sysroot;
   auto storage = INvStorage::newStorage(config.storage, temp_dir_sec.Path());
 

--- a/src/aktualizr_secondary/update_test.cc
+++ b/src/aktualizr_secondary/update_test.cc
@@ -52,7 +52,7 @@ TEST(aktualizr_secondary_protocol, DISABLED_manual_update) {
   StorageConfig fs_config;
   fs_config.type = StorageType::kFileSystem;
   fs_config.path = temp_dir.Path();
-  fs_config.uptane_metadata_path = "metadata";
+  fs_config.uptane_metadata_path = BasedPath("metadata");
   FSStorage fs_storage(fs_config);
 
   Uptane::RawMetaPack metadata;

--- a/src/aktualizr_secondary/uptane_test.cc
+++ b/src/aktualizr_secondary/uptane_test.cc
@@ -66,8 +66,8 @@ int main(int argc, char **argv) {
 
   TemporaryDirectory temp_dir;
   test_config.network.port = 0;  // random port
+  test_config.storage.path = temp_dir.Path();
   test_config.storage.type = StorageType::kSqlite;
-  test_config.storage.sqldb_path = temp_dir.Path() / "sql.db";
 
   test_storage = INvStorage::newStorage(test_config.storage, temp_dir.Path());
 

--- a/src/aktualizr_secondary/uptane_test.cc
+++ b/src/aktualizr_secondary/uptane_test.cc
@@ -37,9 +37,9 @@ TEST(aktualizr_secondary_uptane, credentialsPassing) {
   HttpFake http(temp_dir.Path());
   Config config;
   config.storage.path = temp_dir.Path();
-  config.storage.uptane_metadata_path = "metadata";
-  config.storage.uptane_private_key_path = "private.key";
-  config.storage.uptane_public_key_path = "public.key";
+  config.storage.uptane_metadata_path = BasedPath("metadata");
+  config.storage.uptane_private_key_path = BasedPath("private.key");
+  config.storage.uptane_public_key_path = BasedPath("public.key");
   boost::filesystem::copy_file("tests/test_data/cred.zip", (temp_dir / "cred.zip").string());
   config.provision.provision_path = temp_dir / "cred.zip";
   config.provision.mode = ProvisionMode::kAutomatic;

--- a/src/cert_provider/main.cc
+++ b/src/cert_provider/main.cc
@@ -400,19 +400,19 @@ int main(int argc, char* argv[]) {
     if (!config.import.tls_pkey_path.empty()) {
       pkey_file = config.import.tls_pkey_path;
     } else {
-      pkey_file = config.storage.tls_pkey_path;
+      pkey_file = config.storage.tls_pkey_path.get("");
     }
 
     if (!config.import.tls_clientcert_path.empty()) {
       cert_file = config.import.tls_clientcert_path;
     } else {
-      cert_file = config.storage.tls_clientcert_path;
+      cert_file = config.storage.tls_clientcert_path.get("");
     }
     if (provide_ca) {
       if (!config.import.tls_cacert_path.empty()) {
         ca_file = config.import.tls_cacert_path;
       } else {
-        ca_file = config.storage.tls_cacert_path;
+        ca_file = config.storage.tls_cacert_path.get("");
       }
     }
     if (provide_url) {

--- a/src/cert_provider/main.cc
+++ b/src/cert_provider/main.cc
@@ -385,10 +385,10 @@ int main(int argc, char* argv[]) {
   }
 
   boost::filesystem::path directory = "/var/sota/token";
-  boost::filesystem::path pkey_file = "pkey.pem";
-  boost::filesystem::path cert_file = "client.pem";
-  boost::filesystem::path ca_file = "root.crt";
-  boost::filesystem::path url_file = "gateway.url";
+  BasedPath pkey_file = BasedPath("pkey.pem");
+  BasedPath cert_file = BasedPath("client.pem");
+  BasedPath ca_file = BasedPath("root.crt");
+  BasedPath url_file = BasedPath("gateway.url");
   if (!config_path.empty()) {
     Config config(config_path);
     // TODO: provide path to root directory in `--local` parameter
@@ -400,19 +400,19 @@ int main(int argc, char* argv[]) {
     if (!config.import.tls_pkey_path.empty()) {
       pkey_file = config.import.tls_pkey_path;
     } else {
-      pkey_file = config.storage.tls_pkey_path.get("");
+      pkey_file = config.storage.tls_pkey_path;
     }
 
     if (!config.import.tls_clientcert_path.empty()) {
       cert_file = config.import.tls_clientcert_path;
     } else {
-      cert_file = config.storage.tls_clientcert_path.get("");
+      cert_file = config.storage.tls_clientcert_path;
     }
     if (provide_ca) {
       if (!config.import.tls_cacert_path.empty()) {
         ca_file = config.import.tls_cacert_path;
       } else {
-        ca_file = config.storage.tls_cacert_path.get("");
+        ca_file = config.storage.tls_cacert_path;
       }
     }
     if (provide_url) {
@@ -424,10 +424,10 @@ int main(int argc, char* argv[]) {
     directory = commandline_map["directory"].as<boost::filesystem::path>();
   }
 
-  TemporaryFile tmp_pkey_file(pkey_file.filename().string());
-  TemporaryFile tmp_cert_file(cert_file.filename().string());
-  TemporaryFile tmp_ca_file(ca_file.filename().string());
-  TemporaryFile tmp_url_file(url_file.filename().string());
+  TemporaryFile tmp_pkey_file(pkey_file.get("").filename().string());
+  TemporaryFile tmp_cert_file(cert_file.get("").filename().string());
+  TemporaryFile tmp_ca_file(ca_file.get("").filename().string());
+  TemporaryFile tmp_url_file(url_file.get("").filename().string());
 
   std::string pkey;
   std::string cert;
@@ -487,13 +487,13 @@ int main(int argc, char* argv[]) {
 
   if (!local_dir.empty()) {
     std::cout << "Writing client certificate and keys to " << local_dir << " ...\n";
-    copyLocal(tmp_pkey_file.PathString(), local_dir / pkey_file);
-    copyLocal(tmp_cert_file.PathString(), local_dir / cert_file);
+    copyLocal(tmp_pkey_file.PathString(), local_dir / pkey_file.get("").filename());
+    copyLocal(tmp_cert_file.PathString(), local_dir / cert_file.get("").filename());
     if (provide_ca) {
-      copyLocal(tmp_ca_file.PathString(), local_dir / ca_file);
+      copyLocal(tmp_ca_file.PathString(), local_dir / ca_file.get("").filename());
     }
     if (provide_url) {
-      copyLocal(tmp_url_file.PathString(), local_dir / url_file);
+      copyLocal(tmp_url_file.PathString(), local_dir / url_file.get("").filename());
     }
     std::cout << "...success\n";
   }
@@ -508,15 +508,15 @@ int main(int argc, char* argv[]) {
     SSHRunner ssh{target, skip_checks, port};
 
     try {
-      ssh.transferFile(tmp_pkey_file.Path(), Utils::absolutePath(directory, pkey_file));
+      ssh.transferFile(tmp_pkey_file.Path(), pkey_file.get(directory));
 
-      ssh.transferFile(tmp_cert_file.Path(), Utils::absolutePath(directory, cert_file));
+      ssh.transferFile(tmp_cert_file.Path(), cert_file.get(directory));
 
       if (provide_ca) {
-        ssh.transferFile(tmp_ca_file.Path(), Utils::absolutePath(directory, ca_file));
+        ssh.transferFile(tmp_ca_file.Path(), ca_file.get(directory));
       }
       if (provide_url) {
-        ssh.transferFile(tmp_url_file.Path(), Utils::absolutePath(directory, url_file));
+        ssh.transferFile(tmp_url_file.Path(), url_file.get(directory));
       }
 
       std::cout << "...success\n";

--- a/src/libaktualizr/package_manager/ostreemanager_test.cc
+++ b/src/libaktualizr/package_manager/ostreemanager_test.cc
@@ -23,9 +23,9 @@ TEST(OstreeManager, PullBadUriNoCreds) {
   config.pacman.type = PackageManager::kOstree;
   config.pacman.sysroot = test_sysroot;
   config.storage.path = temp_dir.Path();
-  config.storage.uptane_metadata_path = "metadata";
-  config.storage.uptane_private_key_path = "private.key";
-  config.storage.uptane_private_key_path = "public.key";
+  config.storage.uptane_metadata_path = BasedPath("metadata");
+  config.storage.uptane_private_key_path = BasedPath("private.key");
+  config.storage.uptane_private_key_path = BasedPath("public.key");
 
   std::shared_ptr<INvStorage> storage = std::make_shared<FSStorage>(config.storage);
   KeyManager keys(storage, config.keymanagerConfig());
@@ -43,9 +43,9 @@ TEST(OstreeManager, PullBadUriWithCreds) {
   config.pacman.type = PackageManager::kOstree;
   config.pacman.sysroot = test_sysroot;
   config.storage.path = temp_dir.Path();
-  config.storage.uptane_metadata_path = "metadata";
-  config.storage.uptane_private_key_path = "private.key";
-  config.storage.uptane_private_key_path = "public.key";
+  config.storage.uptane_metadata_path = BasedPath("metadata");
+  config.storage.uptane_private_key_path = BasedPath("private.key");
+  config.storage.uptane_private_key_path = BasedPath("public.key");
 
   std::shared_ptr<INvStorage> storage = std::make_shared<FSStorage>(config.storage);
   std::string ca = Utils::readFile("tests/test_data/prov/root.crt");
@@ -72,9 +72,9 @@ TEST(OstreeManager, InstallBadUri) {
   config.pacman.type = PackageManager::kOstree;
   config.pacman.sysroot = test_sysroot;
   config.storage.path = temp_dir.Path();
-  config.storage.uptane_metadata_path = "metadata";
-  config.storage.uptane_private_key_path = "private.key";
-  config.storage.uptane_private_key_path = "public.key";
+  config.storage.uptane_metadata_path = BasedPath("metadata");
+  config.storage.uptane_private_key_path = BasedPath("private.key");
+  config.storage.uptane_private_key_path = BasedPath("public.key");
 
   std::shared_ptr<INvStorage> storage = std::make_shared<FSStorage>(config.storage);
   OstreeManager ostree(config.pacman, storage);

--- a/src/libaktualizr/storage/fsstorage.h
+++ b/src/libaktualizr/storage/fsstorage.h
@@ -70,7 +70,7 @@ class FSStorage : public INvStorage {
   Uptane::Version latest_images_root;
 
   boost::filesystem::path targetFilepath(const std::string& filename) const;
-  bool loadTlsCommon(std::string* data, const boost::filesystem::path& path_in);
+  bool loadTlsCommon(std::string* data, const BasedPath& path_in);
 
   bool splitNameRoleVersion(const std::string& full_name, std::string* role_name, int* version);
   Uptane::Version findMaxVersion(const boost::filesystem::path& meta_directory, Uptane::Role role);

--- a/src/libaktualizr/storage/invstorage.cc
+++ b/src/libaktualizr/storage/invstorage.cc
@@ -40,12 +40,12 @@ void StorageConfig::writeToStream(std::ostream& out_stream) const {
   writeOption(out_stream, type, "type");
   writeOption(out_stream, path, "path");
   writeOption(out_stream, sqldb_path.get(""), "sqldb_path");
-  writeOption(out_stream, uptane_metadata_path, "uptane_metadata_path");
-  writeOption(out_stream, uptane_private_key_path, "uptane_private_key_path");
-  writeOption(out_stream, uptane_public_key_path, "uptane_public_key_path");
-  writeOption(out_stream, tls_cacert_path, "tls_cacert_path");
-  writeOption(out_stream, tls_pkey_path, "tls_pkey_path");
-  writeOption(out_stream, tls_clientcert_path, "tls_clientcert_path");
+  writeOption(out_stream, uptane_metadata_path.get(""), "uptane_metadata_path");
+  writeOption(out_stream, uptane_private_key_path.get(""), "uptane_private_key_path");
+  writeOption(out_stream, uptane_public_key_path.get(""), "uptane_public_key_path");
+  writeOption(out_stream, tls_cacert_path.get(""), "tls_cacert_path");
+  writeOption(out_stream, tls_pkey_path.get(""), "tls_pkey_path");
+  writeOption(out_stream, tls_clientcert_path.get(""), "tls_clientcert_path");
 }
 
 void ImportConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt) {

--- a/src/libaktualizr/storage/invstorage.h
+++ b/src/libaktualizr/storage/invstorage.h
@@ -87,6 +87,7 @@ class INvStorage {
  public:
   explicit INvStorage(const StorageConfig& config) : config_(config) {}
   virtual ~INvStorage() = default;
+  virtual StorageType type() = 0;
   virtual void storePrimaryKeys(const std::string& public_key, const std::string& private_key) = 0;
   virtual bool loadPrimaryKeys(std::string* public_key, std::string* private_key) = 0;
   virtual bool loadPrimaryPublic(std::string* public_key) = 0;
@@ -146,20 +147,22 @@ class INvStorage {
 
   virtual void cleanUp() = 0;
 
-  // Not purely virtual
-  virtual void importData(const ImportConfig& import_config);
-  void saveInstalledVersion(const Uptane::Target& target);
-
+  // Special constructors and utilities
   static std::shared_ptr<INvStorage> newStorage(const StorageConfig& config,
                                                 const boost::filesystem::path& path = "/var/sota");
   static void FSSToSQLS(const std::shared_ptr<INvStorage>& fs_storage, std::shared_ptr<INvStorage>& sql_storage);
-  virtual StorageType type() = 0;
+
+  // Not purely virtual
+  void importData(const ImportConfig& import_config);
+  void saveInstalledVersion(const Uptane::Target& target);
 
  private:
-  void importSimple(store_data_t store_func, load_data_t load_func, boost::filesystem::path imported_data_path);
-  void importUpdateSimple(store_data_t store_func, load_data_t load_func, boost::filesystem::path imported_data_path);
-  void importPrimaryKeys(const boost::filesystem::path& import_pubkey_path,
-                         const boost::filesystem::path& import_privkey_path);
+  void importSimple(const boost::filesystem::path& base_path, store_data_t store_func, load_data_t load_func,
+                    const BasedPath& imported_data_path);
+  void importUpdateSimple(const boost::filesystem::path& base_path, store_data_t store_func, load_data_t load_func,
+                          const BasedPath& imported_data_path);
+  void importPrimaryKeys(const boost::filesystem::path& base_path, const BasedPath& import_pubkey_path,
+                         const BasedPath& import_privkey_path);
 
  protected:
   const StorageConfig& config_;

--- a/src/libaktualizr/storage/sql_utils.h
+++ b/src/libaktualizr/storage/sql_utils.h
@@ -4,6 +4,7 @@
 #include <list>
 #include <memory>
 
+#include <boost/filesystem.hpp>
 #include <boost/optional.hpp>
 
 #include <sqlite3.h>
@@ -139,6 +140,8 @@ class SQLite3Guard {
     rc_ = sqlite3_open(path, &h);
     handle_.reset(h);
   }
+
+  explicit SQLite3Guard(const boost::filesystem::path& path) : SQLite3Guard(path.c_str()) {}
 
   int exec(const char* sql, int (*callback)(void*, int, char**, char**), void* cb_arg) {
     return sqlite3_exec(handle_.get(), sql, callback, cb_arg, nullptr);

--- a/src/libaktualizr/storage/sqlstorage.h
+++ b/src/libaktualizr/storage/sqlstorage.h
@@ -74,6 +74,7 @@ class SQLStorage : public INvStorage {
 
   bool dbMigrate();
   DbVersion getVersion();  // non-negative integer on success or -1 on error
+  boost::filesystem::path dbPath() const;
 
  private:
   // request info

--- a/src/libaktualizr/storage/sqlstorage_test.cc
+++ b/src/libaktualizr/storage/sqlstorage_test.cc
@@ -137,10 +137,9 @@ TEST(sqlstorage, migrate) {
   TemporaryDirectory temp_dir;
   StorageConfig config;
   config.path = temp_dir.Path();
-  config.sqldb_path = temp_dir.Path() / "test.db";
 
   SQLStorage storage(config);
-  boost::filesystem::remove_all(config.sqldb_path);
+  boost::filesystem::remove_all(config.sqldb_path.get(config.path));
 
   EXPECT_FALSE(dbSchemaCheck(storage));
   EXPECT_TRUE(storage.dbMigrate());
@@ -151,7 +150,6 @@ TEST(sqlstorage, MigrationVersionCheck) {
   TemporaryDirectory temp_dir;
   StorageConfig config;
   config.path = temp_dir.Path();
-  config.sqldb_path = temp_dir.Path() / "test.db";
   SQLStorage storage(config);
 
   EXPECT_EQ(static_cast<int32_t>(storage.getVersion()), schema_migrations.size() - 1);
@@ -161,8 +159,7 @@ TEST(sqlstorage, WrongDatabaseCheck) {
   TemporaryDirectory temp_dir;
   StorageConfig config;
   config.path = temp_dir.Path();
-  config.sqldb_path = temp_dir.Path() / "test.db";
-  SQLite3Guard db(config.sqldb_path.c_str());
+  SQLite3Guard db(config.sqldb_path.get(config.path).c_str());
   if (db.exec("CREATE TABLE some_table(somefield INTEGER);", NULL, NULL) != SQLITE_OK) {
     FAIL();
   }
@@ -216,10 +213,9 @@ TEST(sqlstorage, migrate_root_works) {
   TemporaryDirectory temp_dir;
   StorageConfig config;
   config.path = temp_dir.Path();
-  config.sqldb_path = temp_dir.Path() / "test.db";
 
-  boost::filesystem::remove_all(config.sqldb_path);
-  boost::filesystem::copy(test_db_dir / "version5.sql", config.sqldb_path);
+  boost::filesystem::remove_all(config.sqldb_path.get(config.path));
+  boost::filesystem::copy(test_db_dir / "version5.sql", config.sqldb_path.get(config.path));
   SQLStorage storage(config);
 
   EXPECT_TRUE(storage.dbMigrate());

--- a/src/libaktualizr/storage/storage_atomic_test.cc
+++ b/src/libaktualizr/storage/storage_atomic_test.cc
@@ -27,18 +27,18 @@ std::unique_ptr<INvStorage> Storage(const StorageConfig& config) {
   }
 }
 
-StorageConfig MakeConfig(StorageType type, boost::filesystem::path storage_dir) {
+StorageConfig MakeConfig(StorageType type, const boost::filesystem::path& storage_dir) {
   StorageConfig config;
 
   config.type = type;
   if (type == StorageType::kFileSystem) {
     config.path = storage_dir;
-    config.uptane_metadata_path = "metadata";
-    config.uptane_public_key_path = "test_primary.pub";
-    config.uptane_private_key_path = "test_primary.priv";
-    config.tls_pkey_path = "test_tls.pkey";
-    config.tls_clientcert_path = "test_tls.cert";
-    config.tls_cacert_path = "test_tls.ca";
+    config.uptane_metadata_path = BasedPath("metadata");
+    config.uptane_public_key_path = BasedPath("test_primary.pub");
+    config.uptane_private_key_path = BasedPath("test_primary.priv");
+    config.tls_pkey_path = BasedPath("test_tls.pkey");
+    config.tls_clientcert_path = BasedPath("test_tls.cert");
+    config.tls_cacert_path = BasedPath("test_tls.ca");
   } else if (config.type == StorageType::kSqlite) {
     config.sqldb_path = storage_dir / "test.db";
   } else {

--- a/src/libaktualizr/storage/storage_common_test.cc
+++ b/src/libaktualizr/storage/storage_common_test.cc
@@ -26,18 +26,18 @@ std::unique_ptr<INvStorage> Storage(const StorageConfig &config) {
 
 std::unique_ptr<INvStorage> Storage() { return Storage(storage_test_config); }
 
-StorageConfig MakeConfig(StorageType type, boost::filesystem::path storage_dir) {
+StorageConfig MakeConfig(StorageType type, const boost::filesystem::path &storage_dir) {
   StorageConfig config;
 
   config.type = type;
   if (type == StorageType::kFileSystem) {
     config.path = storage_dir;
-    config.uptane_metadata_path = "metadata";
-    config.uptane_public_key_path = "test_primary.pub";
-    config.uptane_private_key_path = "test_primary.priv";
-    config.tls_pkey_path = "test_tls.pkey";
-    config.tls_clientcert_path = "test_tls.cert";
-    config.tls_cacert_path = "test_tls.ca";
+    config.uptane_metadata_path = BasedPath("metadata");
+    config.uptane_public_key_path = BasedPath("test_primary.pub");
+    config.uptane_private_key_path = BasedPath("test_primary.priv");
+    config.tls_pkey_path = BasedPath("test_tls.pkey");
+    config.tls_clientcert_path = BasedPath("test_tls.cert");
+    config.tls_cacert_path = BasedPath("test_tls.ca");
   } else if (config.type == StorageType::kSqlite) {
     config.sqldb_path = storage_dir / "test.db";
   } else {

--- a/src/libaktualizr/storage/storage_common_test.cc
+++ b/src/libaktualizr/storage/storage_common_test.cc
@@ -379,24 +379,27 @@ TEST(storage, import_data) {
   std::unique_ptr<INvStorage> storage = Storage();
 
   ImportConfig import_config;
-  import_config.uptane_private_key_path = storage_test_dir / "import" / "private";
-  import_config.uptane_public_key_path = storage_test_dir / "import" / "public";
-  import_config.tls_cacert_path = storage_test_dir / "import" / "ca";
-  import_config.tls_clientcert_path = storage_test_dir / "import" / "cert";
-  import_config.tls_pkey_path = storage_test_dir / "import" / "pkey";
+  import_config.base_path = storage_test_dir / "import";
+  import_config.uptane_private_key_path = BasedPath("private");
+  import_config.uptane_public_key_path = BasedPath("public");
+  import_config.tls_cacert_path = BasedPath("ca");
+  import_config.tls_clientcert_path = BasedPath("cert");
+  import_config.tls_pkey_path = BasedPath("pkey");
 
-  Utils::writeFile(import_config.uptane_private_key_path.string(), std::string("uptane_private_1"));
-  Utils::writeFile(import_config.uptane_public_key_path.string(), std::string("uptane_public_1"));
-  Utils::writeFile(import_config.tls_cacert_path.string(), std::string("tls_cacert_1"));
-  Utils::writeFile(import_config.tls_clientcert_path.string(), std::string("tls_cert_1"));
-  Utils::writeFile(import_config.tls_pkey_path.string(), std::string("tls_pkey_1"));
+  Utils::writeFile(import_config.uptane_private_key_path.get(import_config.base_path).string(),
+                   std::string("uptane_private_1"));
+  Utils::writeFile(import_config.uptane_public_key_path.get(import_config.base_path).string(),
+                   std::string("uptane_public_1"));
+  Utils::writeFile(import_config.tls_cacert_path.get(import_config.base_path).string(), std::string("tls_cacert_1"));
+  Utils::writeFile(import_config.tls_clientcert_path.get(import_config.base_path).string(), std::string("tls_cert_1"));
+  Utils::writeFile(import_config.tls_pkey_path.get(import_config.base_path).string(), std::string("tls_pkey_1"));
 
   // Initially the storage is empty
-  EXPECT_FALSE(storage->loadPrimaryPublic(NULL));
-  EXPECT_FALSE(storage->loadPrimaryPrivate(NULL));
-  EXPECT_FALSE(storage->loadTlsCa(NULL));
-  EXPECT_FALSE(storage->loadTlsCert(NULL));
-  EXPECT_FALSE(storage->loadTlsPkey(NULL));
+  EXPECT_FALSE(storage->loadPrimaryPublic(nullptr));
+  EXPECT_FALSE(storage->loadPrimaryPrivate(nullptr));
+  EXPECT_FALSE(storage->loadTlsCa(nullptr));
+  EXPECT_FALSE(storage->loadTlsCert(nullptr));
+  EXPECT_FALSE(storage->loadTlsPkey(nullptr));
 
   storage->importData(import_config);
 
@@ -419,11 +422,13 @@ TEST(storage, import_data) {
   EXPECT_EQ(tls_cert, "tls_cert_1");
   EXPECT_EQ(tls_pkey, "tls_pkey_1");
 
-  Utils::writeFile(import_config.uptane_private_key_path.string(), std::string("uptane_private_2"));
-  Utils::writeFile(import_config.uptane_public_key_path.string(), std::string("uptane_public_2"));
-  Utils::writeFile(import_config.tls_cacert_path.string(), std::string("tls_cacert_2"));
-  Utils::writeFile(import_config.tls_clientcert_path.string(), std::string("tls_cert_2"));
-  Utils::writeFile(import_config.tls_pkey_path.string(), std::string("tls_pkey_2"));
+  Utils::writeFile(import_config.uptane_private_key_path.get(import_config.base_path).string(),
+                   std::string("uptane_private_2"));
+  Utils::writeFile(import_config.uptane_public_key_path.get(import_config.base_path).string(),
+                   std::string("uptane_public_2"));
+  Utils::writeFile(import_config.tls_cacert_path.get(import_config.base_path).string(), std::string("tls_cacert_2"));
+  Utils::writeFile(import_config.tls_clientcert_path.get(import_config.base_path).string(), std::string("tls_cert_2"));
+  Utils::writeFile(import_config.tls_pkey_path.get(import_config.base_path).string(), std::string("tls_pkey_2"));
 
   storage->importData(import_config);
 

--- a/src/libaktualizr/storage/storage_config.h
+++ b/src/libaktualizr/storage/storage_config.h
@@ -31,11 +31,12 @@ struct StorageConfig {
 };
 
 struct ImportConfig {
-  boost::filesystem::path uptane_private_key_path;
-  boost::filesystem::path uptane_public_key_path;
-  boost::filesystem::path tls_cacert_path;
-  boost::filesystem::path tls_pkey_path;
-  boost::filesystem::path tls_clientcert_path;
+  boost::filesystem::path base_path{""};
+  BasedPath uptane_private_key_path{""};
+  BasedPath uptane_public_key_path{""};
+  BasedPath tls_cacert_path{""};
+  BasedPath tls_pkey_path{""};
+  BasedPath tls_clientcert_path{""};
 
   void updateFromPropertyTree(const boost::property_tree::ptree& pt);
   void writeToStream(std::ostream& out_stream) const;

--- a/src/libaktualizr/storage/storage_config.h
+++ b/src/libaktualizr/storage/storage_config.h
@@ -16,12 +16,12 @@ struct StorageConfig {
   boost::filesystem::path path{"/var/sota"};
 
   // FS storage
-  boost::filesystem::path uptane_metadata_path{"metadata"};
-  boost::filesystem::path uptane_private_key_path{"ecukey.der"};
-  boost::filesystem::path uptane_public_key_path{"ecukey.pub"};
-  boost::filesystem::path tls_cacert_path{"root.crt"};
-  boost::filesystem::path tls_pkey_path{"pkey.pem"};
-  boost::filesystem::path tls_clientcert_path{"client.pem"};
+  BasedPath uptane_metadata_path{"metadata"};
+  BasedPath uptane_private_key_path{"ecukey.der"};
+  BasedPath uptane_public_key_path{"ecukey.pub"};
+  BasedPath tls_cacert_path{"root.crt"};
+  BasedPath tls_pkey_path{"pkey.pem"};
+  BasedPath tls_clientcert_path{"client.pem"};
 
   // SQLite storage
   BasedPath sqldb_path{"sql.db"};  // based on `/var/sota`

--- a/src/libaktualizr/storage/storage_config.h
+++ b/src/libaktualizr/storage/storage_config.h
@@ -24,7 +24,7 @@ struct StorageConfig {
   boost::filesystem::path tls_clientcert_path{"client.pem"};
 
   // SQLite storage
-  boost::filesystem::path sqldb_path{"/var/sota/sql.db"};
+  BasedPath sqldb_path{"sql.db"};  // based on `/var/sota`
 
   void updateFromPropertyTree(const boost::property_tree::ptree& pt);
   void writeToStream(std::ostream& out_stream) const;

--- a/src/libaktualizr/uptane/uptane_implicit_test.cc
+++ b/src/libaktualizr/uptane/uptane_implicit_test.cc
@@ -25,10 +25,10 @@ TEST(UptaneImplicit, ImplicitFailure) {
 
   TemporaryDirectory temp_dir;
   config.storage.path = temp_dir.Path();
-  config.storage.uptane_metadata_path = "metadata";
-  config.storage.tls_cacert_path = "ca.pem";
-  config.storage.tls_clientcert_path = "client.pem";
-  config.storage.tls_pkey_path = "pkey.pem";
+  config.storage.uptane_metadata_path = BasedPath("metadata");
+  config.storage.tls_cacert_path = BasedPath("ca.pem");
+  config.storage.tls_clientcert_path = BasedPath("client.pem");
+  config.storage.tls_pkey_path = BasedPath("pkey.pem");
   config.postUpdateValues();
 
   auto storage = INvStorage::newStorage(config.storage);
@@ -47,9 +47,9 @@ TEST(UptaneImplicit, ImplicitIncomplete) {
   TemporaryDirectory temp_dir;
   Config config;
   config.storage.path = temp_dir.Path();
-  config.storage.tls_cacert_path = "ca.pem";
-  config.storage.tls_clientcert_path = "client.pem";
-  config.storage.tls_pkey_path = "pkey.pem";
+  config.storage.tls_cacert_path = BasedPath("ca.pem");
+  config.storage.tls_clientcert_path = BasedPath("client.pem");
+  config.storage.tls_pkey_path = BasedPath("pkey.pem");
   config.provision.device_id = "device_id";
   config.postUpdateValues();
   auto storage = INvStorage::newStorage(config.storage);
@@ -129,9 +129,9 @@ TEST(UptaneImplicit, ImplicitProvision) {
   boost::filesystem::copy_file("tests/test_data/implicit/client.pem", temp_dir / "client.pem");
   boost::filesystem::copy_file("tests/test_data/implicit/pkey.pem", temp_dir / "pkey.pem");
   config.storage.path = temp_dir.Path();
-  config.storage.tls_cacert_path = "ca.pem";
-  config.storage.tls_clientcert_path = "client.pem";
-  config.storage.tls_pkey_path = "pkey.pem";
+  config.storage.tls_cacert_path = BasedPath("ca.pem");
+  config.storage.tls_clientcert_path = BasedPath("client.pem");
+  config.storage.tls_pkey_path = BasedPath("pkey.pem");
 
   auto storage = INvStorage::newStorage(config.storage);
   HttpFake http(temp_dir.Path());

--- a/src/libaktualizr/uptane/uptane_key_test.cc
+++ b/src/libaktualizr/uptane/uptane_key_test.cc
@@ -27,9 +27,9 @@ void initKeyTests(Config& config, Uptane::SecondaryConfig& ecu_config1, Uptane::
   config.tls.server = tls_server;
   config.uptane.repo_server = tls_server + "/repo";
   config.storage.path = temp_dir.Path();
-  config.storage.uptane_metadata_path = "metadata";
-  config.storage.uptane_private_key_path = "private.key";
-  config.storage.uptane_public_key_path = "public.key";
+  config.storage.uptane_metadata_path = BasedPath("metadata");
+  config.storage.uptane_private_key_path = BasedPath("private.key");
+  config.storage.uptane_public_key_path = BasedPath("public.key");
   config.pacman.type = PackageManager::kNone;
 
   ecu_config1.secondary_type = Uptane::SecondaryType::kVirtual;
@@ -163,8 +163,8 @@ TEST(UptaneKey, RecoverWithoutKeys) {
   }
 
   // Remove ECU keys but keep TLS keys and try to initialize.
-  boost::filesystem::remove(config.storage.path / config.storage.uptane_public_key_path);
-  boost::filesystem::remove(config.storage.path / config.storage.uptane_private_key_path);
+  boost::filesystem::remove(config.storage.uptane_public_key_path.get(config.storage.path));
+  boost::filesystem::remove(config.storage.uptane_private_key_path.get(config.storage.path));
   boost::filesystem::remove(ecu_config1.full_client_dir / ecu_config1.ecu_public_key);
   boost::filesystem::remove(ecu_config1.full_client_dir / ecu_config1.ecu_private_key);
   boost::filesystem::remove(ecu_config2.full_client_dir / ecu_config2.ecu_public_key);

--- a/src/libaktualizr/uptane/uptane_network_test.cc
+++ b/src/libaktualizr/uptane/uptane_network_test.cc
@@ -30,9 +30,6 @@ bool doTestInit(StorageType storage_type, const std::string &device_register_sta
   TemporaryDirectory temp_dir;
   conf.storage.type = storage_type;
   conf.storage.path = temp_dir.Path();
-  if (storage_type == StorageType::kSqlite) {
-    conf.storage.sqldb_path = temp_dir / "test.db";
-  }
   conf.provision.expiry_days = device_register_state;
   conf.provision.primary_ecu_serial = ecu_register_state;
   std::string good_url = conf.provision.server;

--- a/src/libaktualizr/uptane/uptane_serial_test.cc
+++ b/src/libaktualizr/uptane/uptane_serial_test.cc
@@ -34,12 +34,12 @@ TEST(Uptane, RandomSerial) {
   conf_2.storage.path = temp_dir2.Path();
 
   conf_1.provision.primary_ecu_serial = "";
-  conf_1.storage.uptane_private_key_path = "private.key";
-  conf_1.storage.uptane_public_key_path = "public.key";
+  conf_1.storage.uptane_private_key_path = BasedPath("private.key");
+  conf_1.storage.uptane_public_key_path = BasedPath("public.key");
 
   conf_2.provision.primary_ecu_serial = "";
-  conf_2.storage.uptane_private_key_path = "private.key";
-  conf_2.storage.uptane_public_key_path = "public.key";
+  conf_2.storage.uptane_private_key_path = BasedPath("private.key");
+  conf_2.storage.uptane_public_key_path = BasedPath("public.key");
 
   // add secondaries
   Uptane::SecondaryConfig ecu_config;
@@ -120,8 +120,8 @@ TEST(Uptane, ReloadSerial) {
     Config conf("tests/config/basic.toml");
     conf.storage.path = temp_dir.Path();
     conf.provision.primary_ecu_serial = "";
-    conf.storage.uptane_private_key_path = "private.key";
-    conf.storage.uptane_public_key_path = "public.key";
+    conf.storage.uptane_private_key_path = BasedPath("private.key");
+    conf.storage.uptane_public_key_path = BasedPath("public.key");
     conf.uptane.secondary_configs.push_back(ecu_config);
 
     auto storage = INvStorage::newStorage(conf.storage);
@@ -142,8 +142,8 @@ TEST(Uptane, ReloadSerial) {
     Config conf("tests/config/basic.toml");
     conf.storage.path = temp_dir.Path();
     conf.provision.primary_ecu_serial = "";
-    conf.storage.uptane_private_key_path = "private.key";
-    conf.storage.uptane_public_key_path = "public.key";
+    conf.storage.uptane_private_key_path = BasedPath("private.key");
+    conf.storage.uptane_public_key_path = BasedPath("public.key");
     conf.uptane.secondary_configs.push_back(ecu_config);
 
     auto storage = INvStorage::newStorage(conf.storage);
@@ -189,8 +189,8 @@ TEST(Uptane, LegacySerial) {
   {
     Config conf(cmd);
     conf.provision.primary_ecu_serial = "";
-    conf.storage.uptane_private_key_path = "private.key";
-    conf.storage.uptane_public_key_path = "public.key";
+    conf.storage.uptane_private_key_path = BasedPath("private.key");
+    conf.storage.uptane_public_key_path = BasedPath("public.key");
 
     auto storage = INvStorage::newStorage(conf.storage);
     HttpFake http(temp_dir.Path());
@@ -210,8 +210,8 @@ TEST(Uptane, LegacySerial) {
   {
     Config conf(cmd);
     conf.provision.primary_ecu_serial = "";
-    conf.storage.uptane_private_key_path = "private.key";
-    conf.storage.uptane_public_key_path = "public.key";
+    conf.storage.uptane_private_key_path = BasedPath("private.key");
+    conf.storage.uptane_public_key_path = BasedPath("public.key");
 
     auto storage = INvStorage::newStorage(conf.storage);
     HttpFake http(temp_dir.Path());

--- a/src/libaktualizr/uptane/uptane_test.cc
+++ b/src/libaktualizr/uptane/uptane_test.cc
@@ -129,13 +129,13 @@ TEST(Uptane, Initialize) {
   conf.provision.primary_ecu_serial = "testecuserial";
 
   conf.storage.path = temp_dir.Path();
-  conf.storage.uptane_metadata_path = "metadata";
-  conf.storage.uptane_private_key_path = "private.key";
-  conf.storage.uptane_private_key_path = "public.key";
+  conf.storage.uptane_metadata_path = BasedPath("metadata");
+  conf.storage.uptane_private_key_path = BasedPath("private.key");
+  conf.storage.uptane_private_key_path = BasedPath("public.key");
 
-  EXPECT_FALSE(boost::filesystem::exists(conf.storage.path / conf.storage.tls_clientcert_path));
-  EXPECT_FALSE(boost::filesystem::exists(conf.storage.path / conf.storage.tls_cacert_path));
-  EXPECT_FALSE(boost::filesystem::exists(conf.storage.path / conf.storage.tls_pkey_path));
+  EXPECT_FALSE(boost::filesystem::exists(conf.storage.tls_clientcert_path.get(conf.storage.path)));
+  EXPECT_FALSE(boost::filesystem::exists(conf.storage.tls_cacert_path.get(conf.storage.path)));
+  EXPECT_FALSE(boost::filesystem::exists(conf.storage.tls_pkey_path.get(conf.storage.path)));
 
   auto storage = INvStorage::newStorage(conf.storage);
   std::string pkey;
@@ -143,18 +143,18 @@ TEST(Uptane, Initialize) {
   std::string ca;
   bool result = storage->loadTlsCreds(&ca, &cert, &pkey);
   EXPECT_FALSE(result);
-  EXPECT_FALSE(boost::filesystem::exists(conf.storage.path / conf.storage.tls_clientcert_path));
-  EXPECT_FALSE(boost::filesystem::exists(conf.storage.path / conf.storage.tls_cacert_path));
-  EXPECT_FALSE(boost::filesystem::exists(conf.storage.path / conf.storage.tls_pkey_path));
+  EXPECT_FALSE(boost::filesystem::exists(conf.storage.tls_clientcert_path.get(conf.storage.path)));
+  EXPECT_FALSE(boost::filesystem::exists(conf.storage.tls_cacert_path.get(conf.storage.path)));
+  EXPECT_FALSE(boost::filesystem::exists(conf.storage.tls_pkey_path.get(conf.storage.path)));
 
   KeyManager keys(storage, conf.keymanagerConfig());
   Initializer initializer(conf.provision, storage, http, keys, {});
 
   result = initializer.isSuccessful();
   EXPECT_TRUE(result);
-  EXPECT_TRUE(boost::filesystem::exists(conf.storage.path / conf.storage.tls_clientcert_path));
-  EXPECT_TRUE(boost::filesystem::exists(conf.storage.path / conf.storage.tls_cacert_path));
-  EXPECT_TRUE(boost::filesystem::exists(conf.storage.path / conf.storage.tls_pkey_path));
+  EXPECT_TRUE(boost::filesystem::exists(conf.storage.tls_clientcert_path.get(conf.storage.path)));
+  EXPECT_TRUE(boost::filesystem::exists(conf.storage.tls_cacert_path.get(conf.storage.path)));
+  EXPECT_TRUE(boost::filesystem::exists(conf.storage.tls_pkey_path.get(conf.storage.path)));
   Json::Value ecu_data = Utils::parseJSONFile(temp_dir.Path() / "post.json");
   EXPECT_EQ(ecu_data["ecus"].size(), 1);
   EXPECT_EQ(ecu_data["primary_ecu_serial"].asString(), conf.provision.primary_ecu_serial);
@@ -169,12 +169,12 @@ TEST(Uptane, InitializeTwice) {
   Config conf("tests/config/basic.toml");
   conf.storage.path = temp_dir.Path();
   conf.provision.primary_ecu_serial = "testecuserial";
-  conf.storage.uptane_private_key_path = "private.key";
-  conf.storage.uptane_public_key_path = "public.key";
+  conf.storage.uptane_private_key_path = BasedPath("private.key");
+  conf.storage.uptane_public_key_path = BasedPath("public.key");
 
-  EXPECT_FALSE(boost::filesystem::exists(conf.storage.path / conf.storage.tls_clientcert_path));
-  EXPECT_FALSE(boost::filesystem::exists(conf.storage.path / conf.storage.tls_cacert_path));
-  EXPECT_FALSE(boost::filesystem::exists(conf.storage.path / conf.storage.tls_pkey_path));
+  EXPECT_FALSE(boost::filesystem::exists(conf.storage.tls_clientcert_path.get(conf.storage.path)));
+  EXPECT_FALSE(boost::filesystem::exists(conf.storage.tls_cacert_path.get(conf.storage.path)));
+  EXPECT_FALSE(boost::filesystem::exists(conf.storage.tls_pkey_path.get(conf.storage.path)));
 
   auto storage = INvStorage::newStorage(conf.storage);
   std::string pkey1;
@@ -182,9 +182,9 @@ TEST(Uptane, InitializeTwice) {
   std::string ca1;
   bool result = storage->loadTlsCreds(&ca1, &cert1, &pkey1);
   EXPECT_FALSE(result);
-  EXPECT_FALSE(boost::filesystem::exists(conf.storage.path / conf.storage.tls_clientcert_path));
-  EXPECT_FALSE(boost::filesystem::exists(conf.storage.path / conf.storage.tls_cacert_path));
-  EXPECT_FALSE(boost::filesystem::exists(conf.storage.path / conf.storage.tls_pkey_path));
+  EXPECT_FALSE(boost::filesystem::exists(conf.storage.tls_clientcert_path.get(conf.storage.path)));
+  EXPECT_FALSE(boost::filesystem::exists(conf.storage.tls_cacert_path.get(conf.storage.path)));
+  EXPECT_FALSE(boost::filesystem::exists(conf.storage.tls_pkey_path.get(conf.storage.path)));
 
   HttpFake http(temp_dir.Path());
 
@@ -194,9 +194,9 @@ TEST(Uptane, InitializeTwice) {
 
     result = initializer.isSuccessful();
     EXPECT_TRUE(result);
-    EXPECT_TRUE(boost::filesystem::exists(conf.storage.path / conf.storage.tls_clientcert_path));
-    EXPECT_TRUE(boost::filesystem::exists(conf.storage.path / conf.storage.tls_cacert_path));
-    EXPECT_TRUE(boost::filesystem::exists(conf.storage.path / conf.storage.tls_pkey_path));
+    EXPECT_TRUE(boost::filesystem::exists(conf.storage.tls_clientcert_path.get(conf.storage.path)));
+    EXPECT_TRUE(boost::filesystem::exists(conf.storage.tls_cacert_path.get(conf.storage.path)));
+    EXPECT_TRUE(boost::filesystem::exists(conf.storage.tls_pkey_path.get(conf.storage.path)));
 
     result = storage->loadTlsCreds(&ca1, &cert1, &pkey1);
     EXPECT_TRUE(result);
@@ -208,9 +208,9 @@ TEST(Uptane, InitializeTwice) {
 
     result = initializer.isSuccessful();
     EXPECT_TRUE(result);
-    EXPECT_TRUE(boost::filesystem::exists(conf.storage.path / conf.storage.tls_clientcert_path));
-    EXPECT_TRUE(boost::filesystem::exists(conf.storage.path / conf.storage.tls_cacert_path));
-    EXPECT_TRUE(boost::filesystem::exists(conf.storage.path / conf.storage.tls_pkey_path));
+    EXPECT_TRUE(boost::filesystem::exists(conf.storage.tls_clientcert_path.get(conf.storage.path)));
+    EXPECT_TRUE(boost::filesystem::exists(conf.storage.tls_cacert_path.get(conf.storage.path)));
+    EXPECT_TRUE(boost::filesystem::exists(conf.storage.tls_pkey_path.get(conf.storage.path)));
 
     std::string pkey2;
     std::string cert2;
@@ -237,8 +237,8 @@ TEST(Uptane, PetNameProvided) {
   /* Make sure provided device ID is read as expected. */
   Config conf("tests/config/device_id.toml");
   conf.storage.path = temp_dir.Path();
-  conf.storage.uptane_private_key_path = "private.key";
-  conf.storage.uptane_public_key_path = "public.key";
+  conf.storage.uptane_private_key_path = BasedPath("private.key");
+  conf.storage.uptane_public_key_path = BasedPath("public.key");
   conf.provision.primary_ecu_serial = "testecuserial";
 
   auto storage = INvStorage::newStorage(conf.storage);
@@ -270,8 +270,8 @@ TEST(Uptane, PetNameCreation) {
   // Make sure name is created.
   Config conf("tests/config/basic.toml");
   conf.storage.path = temp_dir.Path();
-  conf.storage.uptane_private_key_path = "private.key";
-  conf.storage.uptane_public_key_path = "public.key";
+  conf.storage.uptane_private_key_path = BasedPath("private.key");
+  conf.storage.uptane_public_key_path = BasedPath("public.key");
   conf.provision.primary_ecu_serial = "testecuserial";
   boost::filesystem::copy_file("tests/test_data/cred.zip", temp_dir.Path() / "cred.zip");
   conf.provision.provision_path = temp_dir.Path() / "cred.zip";
@@ -353,8 +353,8 @@ TEST(Uptane, InitializeFail) {
   Config conf("tests/config/basic.toml");
   conf.uptane.repo_server = http.tls_server + "/director";
   conf.storage.path = temp_dir.Path();
-  conf.storage.uptane_private_key_path = "private.key";
-  conf.storage.uptane_public_key_path = "public.key";
+  conf.storage.uptane_private_key_path = BasedPath("private.key");
+  conf.storage.uptane_public_key_path = BasedPath("public.key");
 
   conf.uptane.repo_server = http.tls_server + "/repo";
   conf.tls.server = http.tls_server;
@@ -377,9 +377,9 @@ TEST(Uptane, AssembleManifestGood) {
   HttpFake http(temp_dir.Path());
   Config config;
   config.storage.path = temp_dir.Path();
-  config.storage.uptane_metadata_path = "metadata";
-  config.storage.uptane_private_key_path = "private.key";
-  config.storage.uptane_public_key_path = "public.key";
+  config.storage.uptane_metadata_path = BasedPath("metadata");
+  config.storage.uptane_private_key_path = BasedPath("private.key");
+  config.storage.uptane_public_key_path = BasedPath("public.key");
   boost::filesystem::copy_file("tests/test_data/cred.zip", (temp_dir / "cred.zip").string());
   boost::filesystem::copy_file("tests/test_data/firmware.txt", (temp_dir / "firmware.txt").string());
   boost::filesystem::copy_file("tests/test_data/firmware_name.txt", (temp_dir / "firmware_name.txt").string());
@@ -407,7 +407,7 @@ TEST(Uptane, AssembleManifestGood) {
   Uptane::Manifest uptane_manifest{config, storage};
   Bootloader bootloader{config.bootloader};
   ReportQueue report_queue(config, http);
-  SotaUptaneClient sota_client(config, NULL, uptane_manifest, storage, http, bootloader, report_queue);
+  SotaUptaneClient sota_client(config, nullptr, uptane_manifest, storage, http, bootloader, report_queue);
   EXPECT_TRUE(sota_client.initialize());
 
   Json::Value manifest = sota_client.AssembleManifest();
@@ -419,9 +419,9 @@ TEST(Uptane, AssembleManifestBad) {
   HttpFake http(temp_dir.Path());
   Config config;
   config.storage.path = temp_dir.Path();
-  config.storage.uptane_metadata_path = "metadata";
-  config.storage.uptane_private_key_path = "private.key";
-  config.storage.uptane_public_key_path = "public.key";
+  config.storage.uptane_metadata_path = BasedPath("metadata");
+  config.storage.uptane_private_key_path = BasedPath("private.key");
+  config.storage.uptane_public_key_path = BasedPath("public.key");
   boost::filesystem::copy_file("tests/test_data/cred.zip", (temp_dir / "cred.zip").string());
   boost::filesystem::copy_file("tests/test_data/firmware.txt", (temp_dir / "firmware.txt").string());
   boost::filesystem::copy_file("tests/test_data/firmware_name.txt", (temp_dir / "firmware_name.txt").string());
@@ -455,7 +455,7 @@ TEST(Uptane, AssembleManifestBad) {
   Uptane::Manifest uptane_manifest{config, storage};
   Bootloader bootloader{config.bootloader};
   ReportQueue report_queue(config, http);
-  SotaUptaneClient sota_client(config, NULL, uptane_manifest, storage, http, bootloader, report_queue);
+  SotaUptaneClient sota_client(config, nullptr, uptane_manifest, storage, http, bootloader, report_queue);
   EXPECT_TRUE(sota_client.initialize());
 
   Json::Value manifest = sota_client.AssembleManifest();
@@ -469,9 +469,9 @@ TEST(Uptane, PutManifest) {
   HttpFake http(temp_dir.Path());
   Config config;
   config.storage.path = temp_dir.Path();
-  config.storage.uptane_metadata_path = "metadata";
-  config.storage.uptane_private_key_path = "private.key";
-  config.storage.uptane_public_key_path = "public.key";
+  config.storage.uptane_metadata_path = BasedPath("metadata");
+  config.storage.uptane_private_key_path = BasedPath("private.key");
+  config.storage.uptane_public_key_path = BasedPath("public.key");
   boost::filesystem::copy_file("tests/test_data/cred.zip", (temp_dir / "cred.zip").string());
   boost::filesystem::copy_file("tests/test_data/firmware.txt", (temp_dir / "firmware.txt").string());
   boost::filesystem::copy_file("tests/test_data/firmware_name.txt", (temp_dir / "firmware_name.txt").string());
@@ -533,9 +533,9 @@ TEST(Uptane, RunForeverNoUpdates) {
   conf.uptane.running_mode = RunningMode::kFull;
   conf.provision.primary_ecu_hardware_id = "primary_hw";
   conf.storage.path = temp_dir.Path();
-  conf.storage.uptane_metadata_path = "metadata";
-  conf.storage.uptane_private_key_path = "private.key";
-  conf.storage.uptane_public_key_path = "public.key";
+  conf.storage.uptane_metadata_path = BasedPath("metadata");
+  conf.storage.uptane_private_key_path = BasedPath("private.key");
+  conf.storage.uptane_public_key_path = BasedPath("public.key");
   conf.pacman.sysroot = sysroot;
 
   conf.tls.server = http.tls_server;
@@ -589,9 +589,9 @@ TEST(Uptane, RunForeverHasUpdates) {
   conf.provision.primary_ecu_hardware_id = "primary_hw";
   conf.uptane.polling_sec = 1;
   conf.storage.path = temp_dir.Path();
-  conf.storage.uptane_metadata_path = "metadata";
-  conf.storage.uptane_private_key_path = "private.key";
-  conf.storage.uptane_public_key_path = "public.key";
+  conf.storage.uptane_metadata_path = BasedPath("metadata");
+  conf.storage.uptane_private_key_path = BasedPath("private.key");
+  conf.storage.uptane_public_key_path = BasedPath("public.key");
   conf.pacman.sysroot = sysroot;
 
   Uptane::SecondaryConfig ecu_config;
@@ -627,7 +627,7 @@ TEST(Uptane, RunForeverHasUpdates) {
   EXPECT_EQ(event->variant, "FetchMetaComplete");
   EXPECT_TRUE(*events_channel >> event);
   EXPECT_EQ(event->variant, "UpdateAvailable");
-  event::UpdateAvailable* targets_event = static_cast<event::UpdateAvailable*>(event.get());
+  auto targets_event = dynamic_cast<event::UpdateAvailable*>(event.get());
   EXPECT_EQ(targets_event->updates.size(), 2u);
   EXPECT_EQ(targets_event->updates[0].filename(), "primary_firmware.txt");
   EXPECT_EQ(targets_event->updates[1].filename(), "secondary_firmware.txt");
@@ -643,7 +643,7 @@ std::vector<Uptane::Target> makePackage(const std::string& serial, const std::st
   ot_json["custom"]["targetFormat"] = "OSTREE";
   ot_json["length"] = 0;
   ot_json["hashes"]["sha256"] = serial;
-  packages_to_install.push_back(Uptane::Target(serial, ot_json));
+  packages_to_install.emplace_back(serial, ot_json);
   return packages_to_install;
 }
 
@@ -657,8 +657,8 @@ TEST(Uptane, RunForeverInstall) {
   conf.uptane.repo_server = http.tls_server + "/repo";
   conf.uptane.polling_sec = 1;
   conf.storage.path = temp_dir.Path();
-  conf.storage.uptane_private_key_path = "private.key";
-  conf.storage.uptane_public_key_path = "public.key";
+  conf.storage.uptane_private_key_path = BasedPath("private.key");
+  conf.storage.uptane_public_key_path = BasedPath("public.key");
   conf.pacman.sysroot = sysroot;
 
   conf.tls.server = http.tls_server;
@@ -698,8 +698,8 @@ TEST(Uptane, UptaneSecondaryAdd) {
   config.tls.server = http.tls_server;
   config.provision.primary_ecu_serial = "testecuserial";
   config.storage.path = temp_dir.Path();
-  config.storage.uptane_private_key_path = "private.key";
-  config.storage.uptane_public_key_path = "public.key";
+  config.storage.uptane_private_key_path = BasedPath("private.key");
+  config.storage.uptane_public_key_path = BasedPath("public.key");
   config.pacman.type = PackageManager::kNone;
 
   Uptane::SecondaryConfig ecu_config;
@@ -793,11 +793,11 @@ TEST(Uptane, fs_to_sql_full) {
   (void)result;
   StorageConfig config;
   config.type = StorageType::kSqlite;
-  config.uptane_metadata_path = "metadata";
+  config.uptane_metadata_path = BasedPath("metadata");
   config.path = temp_dir.Path();
 
-  config.uptane_private_key_path = "ecukey.der";
-  config.tls_cacert_path = "root.crt";
+  config.uptane_private_key_path = BasedPath("ecukey.der");
+  config.tls_cacert_path = BasedPath("root.crt");
 
   FSStorage fs_storage(config);
 
@@ -835,14 +835,14 @@ TEST(Uptane, fs_to_sql_full) {
   EXPECT_TRUE(fs_storage.loadNonRoot(&images_timestamp, Uptane::RepositoryType::Images, Uptane::Role::Timestamp()));
   EXPECT_TRUE(fs_storage.loadNonRoot(&images_snapshot, Uptane::RepositoryType::Images, Uptane::Role::Snapshot()));
 
-  EXPECT_TRUE(boost::filesystem::exists(Utils::absolutePath(config.path, config.uptane_public_key_path)));
-  EXPECT_TRUE(boost::filesystem::exists(Utils::absolutePath(config.path, config.uptane_private_key_path)));
-  EXPECT_TRUE(boost::filesystem::exists(Utils::absolutePath(config.path, config.tls_cacert_path)));
-  EXPECT_TRUE(boost::filesystem::exists(Utils::absolutePath(config.path, config.tls_clientcert_path)));
-  EXPECT_TRUE(boost::filesystem::exists(Utils::absolutePath(config.path, config.tls_pkey_path)));
+  EXPECT_TRUE(boost::filesystem::exists(config.uptane_public_key_path.get(config.path)));
+  EXPECT_TRUE(boost::filesystem::exists(config.uptane_private_key_path.get(config.path)));
+  EXPECT_TRUE(boost::filesystem::exists(config.tls_cacert_path.get(config.path)));
+  EXPECT_TRUE(boost::filesystem::exists(config.tls_clientcert_path.get(config.path)));
+  EXPECT_TRUE(boost::filesystem::exists(config.tls_pkey_path.get(config.path)));
 
-  boost::filesystem::path image_path = Utils::absolutePath(config.path, config.uptane_metadata_path) / "repo";
-  boost::filesystem::path director_path = Utils::absolutePath(config.path, config.uptane_metadata_path) / "director";
+  boost::filesystem::path image_path = config.uptane_metadata_path.get(config.path) / "repo";
+  boost::filesystem::path director_path = config.uptane_metadata_path.get(config.path) / "director";
   EXPECT_TRUE(boost::filesystem::exists(director_path / "1.root.json"));
   EXPECT_TRUE(boost::filesystem::exists(director_path / "targets.json"));
   EXPECT_TRUE(boost::filesystem::exists(image_path / "1.root.json"));
@@ -856,11 +856,11 @@ TEST(Uptane, fs_to_sql_full) {
   EXPECT_TRUE(boost::filesystem::exists(Utils::absolutePath(config.path, "secondaries_list")));
   auto sql_storage = INvStorage::newStorage(config, temp_dir.Path());
 
-  EXPECT_FALSE(boost::filesystem::exists(Utils::absolutePath(config.path, config.uptane_public_key_path)));
-  EXPECT_FALSE(boost::filesystem::exists(Utils::absolutePath(config.path, config.uptane_private_key_path)));
-  EXPECT_FALSE(boost::filesystem::exists(Utils::absolutePath(config.path, config.tls_cacert_path)));
-  EXPECT_FALSE(boost::filesystem::exists(Utils::absolutePath(config.path, config.tls_clientcert_path)));
-  EXPECT_FALSE(boost::filesystem::exists(Utils::absolutePath(config.path, config.tls_pkey_path)));
+  EXPECT_FALSE(boost::filesystem::exists(config.uptane_public_key_path.get(config.path)));
+  EXPECT_FALSE(boost::filesystem::exists(config.uptane_private_key_path.get(config.path)));
+  EXPECT_FALSE(boost::filesystem::exists(config.tls_cacert_path.get(config.path)));
+  EXPECT_FALSE(boost::filesystem::exists(config.tls_clientcert_path.get(config.path)));
+  EXPECT_FALSE(boost::filesystem::exists(config.tls_pkey_path.get(config.path)));
 
   EXPECT_FALSE(boost::filesystem::exists(director_path / "root.json"));
   EXPECT_FALSE(boost::filesystem::exists(director_path / "targets.json"));
@@ -933,11 +933,11 @@ TEST(Uptane, fs_to_sql_partial) {
 
   StorageConfig config;
   config.type = StorageType::kSqlite;
-  config.uptane_metadata_path = "metadata";
+  config.uptane_metadata_path = BasedPath("metadata");
   config.path = temp_dir.Path();
 
-  config.uptane_private_key_path = "ecukey.der";
-  config.tls_cacert_path = "root.crt";
+  config.uptane_private_key_path = BasedPath("ecukey.der");
+  config.tls_cacert_path = BasedPath("root.crt");
 
   FSStorage fs_storage(config);
 
@@ -975,13 +975,13 @@ TEST(Uptane, fs_to_sql_partial) {
   fs_storage.loadNonRoot(&images_timestamp, Uptane::RepositoryType::Images, Uptane::Role::Timestamp());
   fs_storage.loadNonRoot(&images_snapshot, Uptane::RepositoryType::Images, Uptane::Role::Snapshot());
 
-  EXPECT_TRUE(boost::filesystem::exists(Utils::absolutePath(config.path, config.uptane_public_key_path)));
-  EXPECT_TRUE(boost::filesystem::exists(Utils::absolutePath(config.path, config.uptane_private_key_path)));
+  EXPECT_TRUE(boost::filesystem::exists(config.uptane_public_key_path.get(config.path)));
+  EXPECT_TRUE(boost::filesystem::exists(config.uptane_private_key_path.get(config.path)));
 
   auto sql_storage = INvStorage::newStorage(config, temp_dir.Path());
 
-  EXPECT_FALSE(boost::filesystem::exists(Utils::absolutePath(config.path, config.uptane_public_key_path)));
-  EXPECT_FALSE(boost::filesystem::exists(Utils::absolutePath(config.path, config.uptane_private_key_path)));
+  EXPECT_FALSE(boost::filesystem::exists(config.uptane_public_key_path.get(config.path)));
+  EXPECT_FALSE(boost::filesystem::exists(config.uptane_private_key_path.get(config.path)));
 
   std::string sql_public_key;
   std::string sql_private_key;
@@ -1039,9 +1039,9 @@ TEST(Uptane, SaveVersion) {
   TemporaryDirectory temp_dir;
   Config config;
   config.storage.path = temp_dir.Path();
-  config.storage.tls_cacert_path = "ca.pem";
-  config.storage.tls_clientcert_path = "client.pem";
-  config.storage.tls_pkey_path = "pkey.pem";
+  config.storage.tls_cacert_path = BasedPath("ca.pem");
+  config.storage.tls_clientcert_path = BasedPath("client.pem");
+  config.storage.tls_pkey_path = BasedPath("pkey.pem");
   config.provision.device_id = "device_id";
   config.postUpdateValues();
   auto storage = INvStorage::newStorage(config.storage);
@@ -1064,9 +1064,9 @@ TEST(Uptane, LoadVersion) {
   TemporaryDirectory temp_dir;
   Config config;
   config.storage.path = temp_dir.Path();
-  config.storage.tls_cacert_path = "ca.pem";
-  config.storage.tls_clientcert_path = "client.pem";
-  config.storage.tls_pkey_path = "pkey.pem";
+  config.storage.tls_cacert_path = BasedPath("ca.pem");
+  config.storage.tls_clientcert_path = BasedPath("client.pem");
+  config.storage.tls_pkey_path = BasedPath("pkey.pem");
   config.provision.device_id = "device_id";
   config.postUpdateValues();
   auto storage = INvStorage::newStorage(config.storage);
@@ -1101,7 +1101,7 @@ TEST(Uptane, krejectallTest) {
   Uptane::Manifest uptane_manifest{config, storage};
   Bootloader bootloader{config.bootloader};
   ReportQueue report_queue(config, http);
-  SotaUptaneClient sota_client(config, NULL, uptane_manifest, storage, http, bootloader, report_queue);
+  SotaUptaneClient sota_client(config, nullptr, uptane_manifest, storage, http, bootloader, report_queue);
   EXPECT_TRUE(sota_client.uptaneIteration());
 }
 
@@ -1115,15 +1115,15 @@ TEST(Uptane, restoreVerify) {
   config.pacman.type = PackageManager::kNone;
   config.provision.primary_ecu_serial = "CA:FE:A6:D2:84:9D";
   config.provision.primary_ecu_hardware_id = "primary_hw";
-  config.storage.uptane_metadata_path = "metadata";
-  config.storage.uptane_private_key_path = "private.key";
-  config.storage.uptane_public_key_path = "public.key";
+  config.storage.uptane_metadata_path = BasedPath("metadata");
+  config.storage.uptane_private_key_path = BasedPath("private.key");
+  config.storage.uptane_public_key_path = BasedPath("public.key");
   config.postUpdateValues();
   auto storage = INvStorage::newStorage(config.storage);
   Uptane::Manifest uptane_manifest{config, storage};
   Bootloader bootloader{config.bootloader};
   ReportQueue report_queue(config, http);
-  SotaUptaneClient sota_client(config, NULL, uptane_manifest, storage, http, bootloader, report_queue);
+  SotaUptaneClient sota_client(config, nullptr, uptane_manifest, storage, http, bootloader, report_queue);
 
   EXPECT_TRUE(sota_client.initialize());
   sota_client.AssembleManifest();
@@ -1172,15 +1172,15 @@ TEST(Uptane, offlineIteration) {
   config.pacman.type = PackageManager::kNone;
   config.provision.primary_ecu_serial = "CA:FE:A6:D2:84:9D";
   config.provision.primary_ecu_hardware_id = "primary_hw";
-  config.storage.uptane_metadata_path = "metadata";
-  config.storage.uptane_private_key_path = "private.key";
-  config.storage.uptane_public_key_path = "public.key";
+  config.storage.uptane_metadata_path = BasedPath("metadata");
+  config.storage.uptane_private_key_path = BasedPath("private.key");
+  config.storage.uptane_public_key_path = BasedPath("public.key");
   config.postUpdateValues();
   auto storage = INvStorage::newStorage(config.storage);
   Uptane::Manifest uptane_manifest{config, storage};
   Bootloader bootloader{config.bootloader};
   ReportQueue report_queue(config, http);
-  SotaUptaneClient sota_client(config, NULL, uptane_manifest, storage, http, bootloader, report_queue);
+  SotaUptaneClient sota_client(config, nullptr, uptane_manifest, storage, http, bootloader, report_queue);
 
   EXPECT_TRUE(sota_client.initialize());
   sota_client.AssembleManifest();
@@ -1207,7 +1207,7 @@ TEST(Uptane, Pkcs11Provision) {
   config.p11.tls_pkey_id = "02";
 
   config.storage.path = temp_dir.Path();
-  config.storage.tls_cacert_path = "ca.pem";
+  config.storage.tls_cacert_path = BasedPath("ca.pem");
   config.postUpdateValues();
 
   auto storage = INvStorage::newStorage(config.storage);

--- a/src/libaktualizr/uptane/uptane_test.cc
+++ b/src/libaktualizr/uptane/uptane_test.cc
@@ -795,7 +795,6 @@ TEST(Uptane, fs_to_sql_full) {
   config.type = StorageType::kSqlite;
   config.uptane_metadata_path = "metadata";
   config.path = temp_dir.Path();
-  config.sqldb_path = temp_dir.Path() / "database.db";
 
   config.uptane_private_key_path = "ecukey.der";
   config.tls_cacert_path = "root.crt";
@@ -936,7 +935,6 @@ TEST(Uptane, fs_to_sql_partial) {
   config.type = StorageType::kSqlite;
   config.uptane_metadata_path = "metadata";
   config.path = temp_dir.Path();
-  config.sqldb_path = temp_dir.Path() / "database.db";
 
   config.uptane_private_key_path = "ecukey.der";
   config.tls_cacert_path = "root.crt";
@@ -1095,7 +1093,6 @@ TEST(Uptane, krejectallTest) {
   config.uptane.director_server = http.tls_server + "/director";
   config.uptane.repo_server = http.tls_server + "/repo";
   config.storage.type = StorageType::kSqlite;
-  config.storage.sqldb_path = temp_dir / "db.sqlite";
   config.pacman.type = PackageManager::kNone;
 
   config.provision.device_id = "device_id";

--- a/src/libaktualizr/utilities/config_utils.h
+++ b/src/libaktualizr/utilities/config_utils.h
@@ -102,6 +102,15 @@ inline void CopyFromConfig(RunningMode& dest, const std::string& option_name, co
   }
 }
 
+template <>
+inline void CopyFromConfig(BasedPath& dest, const std::string& option_name, const boost::property_tree::ptree& pt) {
+  boost::optional<std::string> value = pt.get_optional<std::string>(option_name);
+  if (value.is_initialized()) {
+    BasedPath bp{StripQuotesFromStrings(value.get())};
+    dest = bp;
+  }
+}
+
 template <typename T>
 inline void CopySubtreeFromConfig(T& dest, const std::string& subtree_name, const boost::property_tree::ptree& pt) {
   auto subtree = pt.get_child_optional(subtree_name);

--- a/src/libaktualizr/utilities/utils.h
+++ b/src/libaktualizr/utilities/utils.h
@@ -76,6 +76,28 @@ class TemporaryDirectory {
   boost::filesystem::path tmp_name_;
 };
 
+// Can represent an absolute or relative path, only readable through the
+// `.get()` method
+//
+// The intent is to avoid unintentional use of the "naked" relative path by
+// mandating a base directory for each instantiation
+class BasedPath {
+ public:
+  BasedPath(boost::filesystem::path p) : p_(std::move(p)) {}
+
+  boost::filesystem::path get(const boost::filesystem::path &base) const {
+    // note: BasedPath(bp.get()) == bp
+    return Utils::absolutePath(base, p_);
+  }
+
+  bool operator==(const BasedPath &b) const { return p_ == b.p_; }
+
+  bool operator!=(const BasedPath &b) const { return !(*this == b); }
+
+ private:
+  boost::filesystem::path p_;
+};
+
 // helper template for C (mostly openssl) data structured
 //   user should still take care about the order of destruction
 //   by instantiating StructGuard<> in a right order.

--- a/src/libaktualizr/utilities/utils.h
+++ b/src/libaktualizr/utilities/utils.h
@@ -90,8 +90,8 @@ class BasedPath {
     return Utils::absolutePath(base, p_);
   }
 
+  bool empty() const { return p_.empty(); }
   bool operator==(const BasedPath &b) const { return p_ == b.p_; }
-
   bool operator!=(const BasedPath &b) const { return !(*this == b); }
 
  private:

--- a/src/libaktualizr/utilities/utils_test.cc
+++ b/src/libaktualizr/utilities/utils_test.cc
@@ -305,6 +305,19 @@ TEST(Utils, shell) {
   EXPECT_NE(statuscode, 0);
 }
 
+TEST(Utils, BasedPath) {
+  BasedPath bp("a/test.xml");
+
+  EXPECT_EQ(BasedPath(bp.get("")), bp);
+  EXPECT_EQ(bp.get("/"), "/a/test.xml");
+  EXPECT_EQ(bp.get("/x"), "/x/a/test.xml");
+
+  BasedPath abp("/a/test.xml");
+
+  EXPECT_EQ(abp.get(""), "/a/test.xml");
+  EXPECT_EQ(abp.get("/root/var"), "/a/test.xml");
+}
+
 #ifndef __NO_MAIN__
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/tests/uptane_vector_tests.cc
+++ b/tests/uptane_vector_tests.cc
@@ -42,7 +42,7 @@ bool run_test(const std::string& test_name, const Json::Value& vector, const std
   config.uptane.director_server = "http://127.0.0.1:" + port + "/" + test_name + "/director";
   config.uptane.repo_server = "http://127.0.0.1:" + port + "/" + test_name + "/image_repo";
   config.storage.path = temp_dir.Path();
-  config.storage.uptane_metadata_path = port + "/aktualizr_repos";
+  config.storage.uptane_metadata_path = BasedPath(port + "/aktualizr_repos");
   config.pacman.type = PackageManager::kNone;
   // config.pacman.os = "myos";
   // config.pacman.sysroot = "./sysroot";


### PR DESCRIPTION
And set `storage_config.sqldb_path` to be relative to `storage_config.path` by default (an absolute path is also accepted).