### PR TITLE
Silence warnings in partial external code

### DIFF
--- a/partial/CMakeLists.txt
+++ b/partial/CMakeLists.txt
@@ -97,8 +97,8 @@ aktualizr_source_file_checks(${LIBUPTINY_SOURCES} ${LIBUPTINY_HEADERS})
 include_directories(. ed25519 libuptiny extern)
 add_library(uptiny STATIC ${LIBUPTINY_SOURCES} extern/jsmn/jsmn.c)
 target_compile_options(uptiny PUBLIC -Os -g -Wpedantic -Wno-long-long -DJSMN_STRICT -DJSMN_PARENT_LINKS)
-set_source_files_properties(extern/jsmn/jsmn.c PROPERTIES COMPILE_FLAGS "-Wno-error=sign-conversion -Wno-error=switch-default")
-set_source_files_properties(${ED25519_SOURCES} PROPERTIES COMPILE_FLAGS "-Wno-error=sign-compare -Wno-error=sign-conversion -Wno-error=conversion")
+set_source_files_properties(extern/jsmn/jsmn.c PROPERTIES COMPILE_FLAGS "-Wno-sign-conversion -Wno-switch-default")
+set_source_files_properties(${ED25519_SOURCES} PROPERTIES COMPILE_FLAGS "-Wno-sign-compare -Wno-sign-conversion -Wno-conversion")
 
 include_directories(extern/isotp-c/src extern/isotp-c/deps/bitfield-c/src/)
 set(ISOTP_SOURCES extern/isotp-c/src/isotp/isotp.c
@@ -112,9 +112,9 @@ set(ISOTP_SOURCES extern/isotp-c/src/isotp/isotp.c
 add_library(isotp STATIC ${ISOTP_SOURCES})
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-  target_compile_options(isotp PUBLIC -Os -g -Wno-long-long -Wno-error=conversion -Wno-error=sign-conversion)
+  target_compile_options(isotp PUBLIC -Os -g -Wno-long-long -Wno-conversion -Wno-sign-conversion)
 elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  target_compile_options(isotp PUBLIC -Os -g -Wno-long-long -Wno-error=conversion -Wno-error=sign-conversion -Wno-error=gnu-designator)
+  target_compile_options(isotp PUBLIC -Os -g -Wno-long-long -Wno-conversion -Wno-sign-conversion -Wno-gnu-designator)
 endif ()
 
 # Machine is not set, building tests to run in Linux environment
@@ -123,7 +123,7 @@ if(NOT LIBUPTINY_MACHINE)
 
         set(LIBUPTINY_TEST_ENVIRONMENT tests/test_state.cc tests/test_common_data.cc tests/test_crypto.c ${ED25519_SOURCES})
 
-        set_source_files_properties(${LIBUPTINY_TEST_ENVIRONMENT} tests/signatures_test.cc tests/root_signed_test.cc tests/root_test.cc tests/targets_test.cc PROPERTIES COMPILE_FLAGS "-Wno-error=sign-compare -Wno-error=sign-conversion -Wno-error=conversion")
+        set_source_files_properties(${LIBUPTINY_TEST_ENVIRONMENT} tests/signatures_test.cc tests/root_signed_test.cc tests/root_test.cc tests/targets_test.cc PROPERTIES COMPILE_FLAGS "-Wno-sign-compare -Wno-sign-conversion -Wno-conversion")
 
         add_aktualizr_test(NAME tiny_base64 SOURCES libuptiny/base64.c tests/base64_test.cc)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,9 +13,6 @@ add_subdirectory("aktualizr_check_discovery")
 add_subdirectory("cert_provider")
 add_subdirectory("implicit_writer")
 
-# Temporarily remove flag not supported by isotp-c and bitfield.
-remove_definitions(-Wconversion)
 add_subdirectory("external_secondaries")
-add_definitions(-Wconversion)
 
 add_subdirectory("load_tests")

--- a/src/external_secondaries/CMakeLists.txt
+++ b/src/external_secondaries/CMakeLists.txt
@@ -28,6 +28,7 @@ set(ISOTP_SRC ${ISOTP_PATH_PREFIX}/isotp/isotp.c
     ${BITFIELD_PATH_PREFIX}/bitfield/bitfield.c)
 set(ISOTP_TEST_SRC test_isotp_interface.cc isotp_allocate.cc isotp_protocol.cc )
 set(ISOTP_TEST_HEADERS test_isotp_interface.h)
+set_source_files_properties(${ISOTP_SRC} PROPERTIES COMPILE_FLAGS "-Wno-sign-conversion -Wno-conversion")
 aktualizr_source_file_checks(${ISOTP_TEST_SRC} ${ISOTP_TEST_HEADERS})
 
 if(BUILD_ISOTP)

--- a/src/external_secondaries/example_flasher.cc
+++ b/src/external_secondaries/example_flasher.cc
@@ -9,7 +9,7 @@
 std::string filename;
 std::string serial;
 
-ExampleFlasher::ExampleFlasher(const unsigned int loglevel) : loglevel_(loglevel) {
+ExampleFlasher::ExampleFlasher(unsigned int loglevel) : loglevel_(loglevel) {
   // Use /var/sota if it is available and accessible to the current user.
   // Generally this is true for devices but not hosts.
   if (boost::filesystem::exists("/var/sota")) {

--- a/src/external_secondaries/example_flasher.h
+++ b/src/external_secondaries/example_flasher.h
@@ -13,7 +13,7 @@ class ExampleFlasher : public ECUInterface {
                                 const std::string &firmware) override;
 
  private:
-  int loglevel_;
+  unsigned int loglevel_;
 };
 
 #endif  // EXAMPLE_FLASHER_H_

--- a/src/external_secondaries/validate_secondary_interface_test.cc
+++ b/src/external_secondaries/validate_secondary_interface_test.cc
@@ -45,7 +45,7 @@ bool isECUListValid(const std::string &output) {
   size_t matched_symbols = 0;
   std::string::const_iterator search_start(output.cbegin());
   while (std::regex_search(search_start, output.cend(), ecu_match, ecu_regex)) {
-    matched_symbols += ecu_match.length();
+    matched_symbols += static_cast<size_t>(ecu_match.length());
     search_start += ecu_match.position() + ecu_match.length();
   }
   return matched_symbols == output.size();


### PR DESCRIPTION
Instead of just making them not fail the build (all these warnings are
distracting)