### PR TITLE
gcc8 warnings

### DIFF
--- a/src/libaktualizr/crypto/crypto.cc
+++ b/src/libaktualizr/crypto/crypto.cc
@@ -147,7 +147,7 @@ std::string Crypto::RSAPSSSign(ENGINE *engine, const std::string &private_key, c
 #endif
   }
 
-  const auto sign_size = static_cast<const unsigned int>(RSA_size(rsa.get()));
+  const auto sign_size = static_cast<unsigned int>(RSA_size(rsa.get()));
   boost::scoped_array<unsigned char> EM(new unsigned char[sign_size]);
   boost::scoped_array<unsigned char> pSignature(new unsigned char[sign_size]);
 
@@ -202,7 +202,7 @@ bool Crypto::RSAPSSVerify(const std::string &public_key, const std::string &sign
   RSA_set_method(rsa.get(), RSA_PKCS1_OpenSSL());
 #endif
 
-  const auto size = static_cast<const unsigned int>(RSA_size(rsa.get()));
+  const auto size = static_cast<unsigned int>(RSA_size(rsa.get()));
   boost::scoped_array<unsigned char> pDecrypted(new unsigned char[size]);
   /* now we will verify the signature
     Start by a RAW decrypt of the signature

--- a/src/libaktualizr/primary/commands_test.cc
+++ b/src/libaktualizr/primary/commands_test.cc
@@ -93,7 +93,7 @@ TEST(command, Nonexistent_command_from_json) {
   reader.parse(json, val);
   try {
     std::shared_ptr<command::BaseCommand> command = command::BaseCommand::fromJson(val);
-  } catch (std::runtime_error e) {
+  } catch (const std::runtime_error &e) {
     ASSERT_STREQ(e.what(), "wrong command variant = Nonexistent");
   }
 }

--- a/src/libaktualizr/uptane/uptane_test.cc
+++ b/src/libaktualizr/uptane/uptane_test.cc
@@ -125,8 +125,8 @@ TEST(Uptane, VerifyDataBadThreshold) {
     Uptane::Root root(Uptane::Root::Policy::kAcceptAll);
     Uptane::Root(Uptane::RepositoryType::Director, data_json, root);
     FAIL();
-  } catch (Uptane::IllegalThreshold ex) {
-  } catch (Uptane::UnmetThreshold ex) {
+  } catch (const Uptane::IllegalThreshold& ex) {
+  } catch (const Uptane::UnmetThreshold& ex) {
   }
 }
 


### PR DESCRIPTION
Got blessed with an automatic update from gcc 7 to 8 this morning.


    ../src/libaktualizr/crypto/crypto.cc:150:77: error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]
       const auto sign_size = static_cast<const unsigned int>(RSA_size(rsa.get()));

And

    ../src/libaktualizr/uptane/uptane_test.cc:128:37: error: catching polymorphic type ‘class Uptane::IllegalThreshold’ by value [-Werror=catch-value=]
       } catch (Uptane::IllegalThreshold ex) {