### PR TITLE
Fixed 5 vector tests

### DIFF
--- a/src/libaktualizr/uptane/exceptions.h
+++ b/src/libaktualizr/uptane/exceptions.h
@@ -91,6 +91,12 @@ class NonUniqueSignatures : public Exception {
   ~NonUniqueSignatures() noexcept override = default;
 };
 
+class BadKeyId : public Exception {
+ public:
+  BadKeyId(const std::string& reponame) : Exception(reponame, "A key has an incorrect associated key ID") {}
+  ~BadKeyId() noexcept override = default;
+};
+
 class BadEcuId : public Exception {
  public:
   BadEcuId(const std::string& reponame)

--- a/src/libaktualizr/uptane/root.cc
+++ b/src/libaktualizr/uptane/root.cc
@@ -53,7 +53,7 @@ Root::Root(RepositoryType repo, const Json::Value &json) : policy_(Policy::kChec
       // this occurs in Boost 1.62 (and possibly other versions)
       LOG_DEBUG << "Failing with threshold for role " << role << " too small: " << requiredThreshold << " < "
                 << static_cast<int64_t>(kMinSignatures);
-      throw IllegalThreshold(RepoString(repo), "The role " + role.ToString() + " had an illegal signature threshold.");
+      throw IllegalThreshold(RepoString(repo), "The role " + role_name + " had an illegal signature threshold.");
     }
     if (kMaxSignatures < requiredThreshold) {
       // static_cast<int> is to stop << taking a reference to kMaxSignatures
@@ -105,8 +105,7 @@ void Uptane::Root::UnpackSignedObject(RepositoryType repo, const Json::Value &si
     }
     std::string keyid = (*sig)["keyid"].asString();
     if (keys_.count(keyid) == 0u) {
-      LOG_DEBUG << "Signed by unknown keyid, " << keyid << ", skipping";
-      continue;
+      throw BadKeyId(repository);
     }
 
     if (keys_for_role_.count(std::make_pair(role, keyid)) == 0u) {

--- a/src/libaktualizr/uptane/uptane_test.cc
+++ b/src/libaktualizr/uptane/uptane_test.cc
@@ -107,7 +107,7 @@ TEST(Uptane, VerifyDataBadKeyId) {
   data_json["signatures"][0]["keyid"] = "badkeyid";
 
   Uptane::Root root(Uptane::Root::Policy::kAcceptAll);
-  EXPECT_THROW(Uptane::Root(Uptane::RepositoryType::Director, data_json, root), Uptane::UnmetThreshold);
+  EXPECT_THROW(Uptane::Root(Uptane::RepositoryType::Director, data_json, root), Uptane::BadKeyId);
 }
 
 TEST(Uptane, VerifyDataBadThreshold) {


### PR DESCRIPTION
There is one issue in vector tests. The test 'director_targets_zero_threshold' expects 'The role root had an illegal signature threshold.' which is incorrect. The problem is not in the json file because 'director_targets_zero_threshold.json' contains the correct error. So the problem is that `POST /director_targets_zero_threshold/step` returns following result:

```
{
83: 	"director" : 
83: 	{
83: 		"targets" : 
83: 		{
83: 			"file.txt" : 
83: 			{
83: 				"is_success" : true
83: 			}
83: 		},
83: 		"update" : 
83: 		{
83: 			"err" : "IllegalThreshold::Root",
83: 			"err_msg" : "The role root had an illegal signature threshold.",
83: 			"is_success" : false
83: 		}
83: 	},
83: 	"image_repo" : 
83: 	{
83: 		"targets" : 
83: 		{
83: 			"file.txt" : 
83: 			{
83: 				"is_success" : true
83: 			}
83: 		},
83: 		"update" : 
83: 		{
83: 			"is_success" : true
83: 		}
83: 	}
83: }
``` 
