### PR TITLE
Make dependancies visible in parent scope

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,6 +356,11 @@ set (AKTUALIZR_EXTERNAL_LIBS
     ${GLIB2_LIBRARIES}
     ${SYSTEMD_LIBRARY})
 
+get_directory_property(hasParent PARENT_DIRECTORY)
+if(hasParent)
+    set (AKTUALIZR_EXTERNAL_LIBS ${AKTUALIZR_EXTERNAL_LIBS} PARENT_SCOPE)
+endif()
+
 set (TEST_LIBS ${AKTUALIZR_EXTERNAL_LIBS} gtest gmock)
 if(BUILD_WITH_CODE_COVERAGE)
     set(COVERAGE_EXCLUDES '/usr/include/*' 'build*' 'third_party/*' 'tests/*' '*_test.cc')


### PR DESCRIPTION
This small change allows to reuse aktualizr repository as cmake subdirectory from another projects