### PR TITLE
Scripts to use aktualizr-repo as a replacement to the backend

### DIFF
--- a/docs/aktualizr-repo.adoc
+++ b/docs/aktualizr-repo.adoc
@@ -1,0 +1,38 @@
+= Aktualizr repo
+
+aktualizr-repo director contains a basic implementation of Uptane server. It is comprised of three tools:
+
+. `create_repo.sh` is a script to generate a new repo
+. `serve_repo.py` is a minimalistic Uptane server
+. `aktualizr-repo` itself is a tool to control the repo once created with `create_repo.sh`
+
+== create_repo.sh
+
+`create_repo.sh` generates the whole Uptane repo together with client and server certificates and OSTree repo that can be used both by meta-updater and by the device. `create_repo.sh` uses `aktualizr-repo`, so make sure it's in `PATH`.
+
+=== Usage
+
+`create_repo.sh /path/to/repo/to/create hostname`
+Make sure that the path to create doesn't exist and the machine where `serve_repo.py` will be running is accessible from the device under given `hostname`
+
+=== Integration with bitbake
+
+`create_repo.sh` can work with bitbake running on the same machine. Copy `site.conf` from the generated directory to your `build/conf` or append it to your existing `site.conf` and `bitbake` should commit built rootfs to the generated OSTree repository and provision devices to automatically connect to `serve_repo.py`.
+
+== serve_repo.py
+
+`serve_repo.py` serves Uptane metadata and OSTree objects to the devices.
+
+=== Usage
+
+`serve_repo.py <port number> /path/to/created/repo` 
+
+== aktualizr-repo
+
+See `aktualizr-repo --help` for details.
+
+=== Example usage scenario
+
+. Add target to images metadata `aktualizr-repo --path /path/to/created/repo/uptane --command image --filename firmware_image.fmw`
+. Prepare director targets `aktaulizr-repo --path /path/to/created/repo/uptane --command addtarget --filename firmware_image.fmw --hwid my-hardware-id --serial my-ecu-serial`
+. Schedule the prepared update `aktualizr-repo --path /path/to/created/repo/uptane --command signtargets`

--- a/src/aktualizr_repo/run/create_repo.sh
+++ b/src/aktualizr_repo/run/create_repo.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+repo_dir=$(realpath ${1})
+host_addr=${2}
+ip_port=9000
+
+gen_certs () {
+	certs_dir=${repo_dir}/certs
+	mkdir -p ${certs_dir}/client
+	mkdir -p ${certs_dir}/server
+	cat <<EOF >${certs_dir}/ca.cnf
+[req]
+req_extensions = cacert
+distinguished_name = req_distinguished_name
+
+[req_distinguished_name]
+
+[cacert]
+basicConstraints = critical,CA:true
+keyUsage = keyCertSign
+EOF
+        openssl genrsa -out ${certs_dir}/client/ca.private.pem 4096
+        openssl req -key ${certs_dir}/client/ca.private.pem -new -x509 -days 7300 -out ${certs_dir}/client/cacert.pem -subj "/C=DE/ST=Berlin/O=Reis und Kichererbsen e.V/commonName=aktualizr-repo-client-ca" -batch -config ${certs_dir}/ca.cnf -extensions cacert
+
+        openssl genrsa -out ${certs_dir}/server/ca.private.pem 4096
+        openssl req -key ${certs_dir}/server/ca.private.pem -new -x509 -days 7300 -out ${certs_dir}/server/cacert.pem -subj "/C=DE/ST=Berlin/O=Reis und Kichererbsen e.V/commonName=aktualizr-repo-server-ca" -batch -config ${certs_dir}/ca.cnf -extensions cacert
+        openssl req -out ${certs_dir}/server/cert.csr -subj "/C=DE/ST=Berlin/O=Reis und Kichererbsen e.V/commonName=${host_addr}" -batch -new -newkey rsa:2048 -nodes -keyout ${certs_dir}/server/private.pem
+	openssl x509 -req -in ${certs_dir}/server/cert.csr -CA ${certs_dir}/server/cacert.pem -CAkey ${certs_dir}/server/ca.private.pem -CAcreateserial -out ${certs_dir}/server/cert.pem
+
+	# bootstrap credentials for device registration. Will not be probably ever used, just to make boostrap process happy
+	openssl req -out ${certs_dir}/server/device_bootstrap_cert.csr -subj "/C=DE/ST=Berlin/O=Reis und Kichererbsen e.V/commonName=device_registation" -batch -new -newkey rsa:2048 -nodes -keyout ${certs_dir}/server/device_bootstrap_private.pem
+	openssl x509 -req -in ${certs_dir}/server/device_bootstrap_cert.csr -CA ${certs_dir}/server/cacert.pem -CAkey ${certs_dir}/server/ca.private.pem -CAcreateserial -out ${certs_dir}/server/device_bootstrap_cert.pem
+}
+
+gen_repo () {
+	aktualizr-repo --command generate --path ${repo_dir}/uptane --keytype ED25519 --expires "3021-07-04T00:00:00Z"
+}
+
+gen_ostree () {
+	ostree --repo=${repo_dir}/ostree init --mode=archive-z2
+}
+
+gen_credentials () {
+	TEMPDIR=$(mktemp -d)
+	echo "https://${host_addr}:${ip_port}" >${TEMPDIR}/autoprov.url
+	openssl pkcs12 -export -out ${TEMPDIR}/autoprov_credentials.p12 -in ${repo_dir}/certs/server/device_bootstrap_cert.pem -inkey ${repo_dir}/certs/server/device_bootstrap_private.pem -CAfile ${repo_dir}/certs/server/cacert.pem -chain -password pass: -passin pass:
+	CURDIR=$(pwd)
+	cd "$TEMPDIR"
+	zip ${repo_dir}/credentials.zip ./*
+	cd "$CURDIR"
+	rm -r ${TEMPDIR}
+}
+
+gen_site_conf () {
+	cat <<EOF >${repo_dir}/site.conf
+OSTREE_REPO = "${repo_dir}/ostree"
+SOTA_PACKED_CREDENTIALS = "${repo_dir}/credentials.zip"
+SOTA_CLIENT_PROV = "aktualizr-ca-implicit-prov"
+SOTA_CACERT_PATH = "${repo_dir}/certs/client/cacert.pem"
+SOTA_CAKEY_PATH = "${repo_dir}/certs/client/ca.private.pem"
+EOF
+}
+
+if [ -e ${repo_dir} ]; then
+	echo "File or directory ${1} already exists"
+	exit -1
+fi
+
+rm -rf "$repo_dir"
+gen_certs
+gen_repo
+gen_ostree
+gen_credentials
+gen_site_conf

--- a/src/aktualizr_repo/run/serve_repo.py
+++ b/src/aktualizr_repo/run/serve_repo.py
@@ -1,0 +1,77 @@
+#!/usr/bin/python3
+
+import sys
+import os
+import socket
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import ssl
+import json
+from time import sleep
+
+top_path = sys.argv[2]
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        print("GET: " + self.path)
+        if self.path.startswith('/director/'):
+            self.do_get_static(top_path + "/uptane/repo/director/", self.path[10:])
+        elif self.path.startswith('/repo/'):
+            self.do_get_static(top_path + "/uptane/repo/image/", self.path[6:])
+        elif self.path.startswith('/treehub/'):
+            self.do_get_static(top_path + "/uptane/repo/ostree/", self.path[9:])
+        else:
+          self.send_response(404)
+          self.end_headers()
+
+    def do_get_static(self, dir_path, path):
+          path = os.path.join(dir_path, path)
+          if os.path.isfile(path):
+              self.send_response(200)
+              self.end_headers()
+              with open(path, "rb") as f:
+                  self.wfile.write(f.read())
+          else:
+              self.send_response(404)
+              self.end_headers()
+
+    def do_POST(self):
+        length = int(self.headers.get('content-length'))
+        data = json.loads(self.rfile.read(length).decode('utf-8'))
+        if self.path == "/director/ecus":
+            return self.do_ecuRegister(data)
+        elif self.path == "/director/manifest":
+            return self.do_manifest(data)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_ecuRegister(self, data):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"{}")
+
+    def do_manifest(self, data):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"{}")
+
+    def do_PUT(self):
+        self.do_POST()
+
+
+class ReUseHTTPServer(HTTPServer):
+    def server_bind(self):
+        self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        HTTPServer.server_bind(self)
+
+
+server_address = ('', int(sys.argv[1]))
+httpd = ReUseHTTPServer(server_address, Handler)
+
+context = ssl.SSLContext()
+context.load_cert_chain(certfile = top_path + '/certs/server/cert.pem', keyfile = top_path + '/certs/server/private.pem')
+context.load_verify_locations(cafile = top_path + '/certs/client/cacert.pem')
+context.verify_mode = ssl.CERT_REQUIRED
+httpd.socket = context.wrap_socket (httpd.socket, server_side = True)
+httpd.serve_forever()
+


### PR DESCRIPTION
Tested with meta-updater rocko and raspberrypi. Uptane metadata exchange works after minor fixes to cert_provider (following). OSTree not tested yet (would require more flexibility in `aktualizr-repo` utility wrt. adding packages to images repo).