### PR TITLE
Do not throw BadKeyId on every unknown KeyId.

### DIFF
--- a/src/libaktualizr/uptane/uptane_secondary_test.cc
+++ b/src/libaktualizr/uptane/uptane_secondary_test.cc
@@ -102,7 +102,7 @@ TEST(SecondaryFactory, Uptane_putMetadata_bad) {
   Json::Value json_targets = Utils::parseJSONFile("tests/test_data/repo/repo/director/targets_hasupdates.json");
   json_targets["signatures"][0]["sig"] = "Wrong signature";
   metadata.director_targets = Utils::jsonToStr(json_targets);
-  EXPECT_THROW(sec.putMetadata(metadata), Uptane::UnmetThreshold);
+  EXPECT_THROW(sec.putMetadata(metadata), Uptane::BadKeyId);
 }
 
 TEST(SecondaryFactory, Bad) {


### PR DESCRIPTION
Unknown signatures are fine as long as there are still enough known
signatures to pass the threshold. To keep tuf-test-vectors happy,
though, we now throw the BadKeyId exception if there is only one
signature and its KeyId is unknown.

We urgently need tests that actually test the case of multiple
signatures, some recognized and some not.