### PR TITLE
Fix duplicate signature validation

### DIFF
--- a/src/libaktualizr/uptane/root.cc
+++ b/src/libaktualizr/uptane/root.cc
@@ -92,7 +92,7 @@ void Uptane::Root::UnpackSignedObject(RepositoryType repo, const Json::Value &si
   std::set<std::string> used_keyids;
   for (Json::ValueIterator sig = signatures.begin(); sig != signatures.end(); ++sig) {
     std::string keyid = (*sig)["keyid"].asString();
-    if (std::find(used_keyids.begin(), used_keyids.end(), keyid) != used_keyids.end()) {
+    if (used_keyids.count(keyid) != 0) {
       throw NonUniqueSignatures(repository, role.ToString());
     }
     used_keyids.insert(keyid);


### PR DESCRIPTION
When role thresholds are used, it is required that the multiple signatures come
from different keys. It should not be possible for one role to just sign the
metadata twice.

Previously, the check was on the _value_ of the signature, but this is
meaningless when signatures are non-deterministic or when an attacker can craft
two signatures that serialise differently. The correct check is to compare
keyids: these come from root.json, and attackers can't create new ones at
random.