### PR TITLE
Fix docker WORKDIR mixup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ branches:
     - /^\d\d\d\d\.\d+$/
 env:
 - DOCKERFILE=Dockerfile CACHE=latest SCRIPT=src/scripts/test.sh
-  DARGS="-eTEST_CMAKE_BUILD_TYPE=Debug -eTEST_WITH_COVERAGE=1 -eTEST_WITH_P11=1 -eTEST_SOTA_PACKED_CREDENTIALS=/ostree/aktualizr/src/tests/test_data/credentials_ci.zip"
+  DARGS="-eTEST_CMAKE_BUILD_TYPE=Debug -eTEST_WITH_COVERAGE=1 -eTEST_WITH_P11=1 -eTEST_SOTA_PACKED_CREDENTIALS=/aktualizr/src/tests/test_data/credentials_ci.zip"
 - DOCKERFILE=Dockerfile.nop11 CACHE=latest SCRIPT=src/scripts/test.sh
   DARGS="-eTEST_TESTSUITE_ONLY=crypto"
 - DOCKERFILE=Dockerfile.deb-testing CACHE=latest-deb-unstable SCRIPT=src/scripts/test.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,8 +69,7 @@ RUN apt-get update && apt-get -y install \
   softhsm2 \
   valgrind
 
-RUN mkdir ostree
-WORKDIR ostree
+WORKDIR /ostree
 RUN git init && git remote add origin https://github.com/ostreedev/ostree
 RUN git fetch origin v2018.1 && git checkout FETCH_HEAD
 RUN NOCONFIGURE=1 ./autogen.sh
@@ -80,5 +79,5 @@ RUN make install
 
 RUN useradd testuser
 
-WORKDIR aktualizr
+WORKDIR /aktualizr
 ADD . src

--- a/Dockerfile.deb-testing
+++ b/Dockerfile.deb-testing
@@ -69,8 +69,7 @@ RUN apt-get update && apt-get -y install \
 RUN ln -s clang-6.0 /usr/bin/clang && \
     ln -s clang++-6.0 /usr/bin/clang++
 
-RUN mkdir ostree
-WORKDIR ostree
+WORKDIR /ostree
 RUN git init && git remote add origin https://github.com/ostreedev/ostree
 RUN git fetch origin v2018.1 && git checkout FETCH_HEAD
 RUN NOCONFIGURE=1 ./autogen.sh
@@ -79,5 +78,5 @@ RUN make VERBOSE=1 -j4
 RUN make install
 
 RUN useradd testuser
-WORKDIR aktualizr
+WORKDIR /aktualizr
 ADD . src

--- a/Dockerfile.noostree
+++ b/Dockerfile.noostree
@@ -62,5 +62,5 @@ RUN apt-get update && apt-get -y install \
   libp11-dev \
   softhsm2
 
-WORKDIR aktualizr
+WORKDIR /aktualizr
 ADD . src

--- a/Dockerfile.nop11
+++ b/Dockerfile.nop11
@@ -53,8 +53,7 @@ RUN apt-get update && apt-get -y install \
   sqlite3 \
   wget
 
-RUN mkdir ostree
-WORKDIR ostree
+WORKDIR /ostree
 RUN git init && git remote add origin https://github.com/ostreedev/ostree
 RUN git fetch origin v2018.1 && git checkout FETCH_HEAD
 RUN NOCONFIGURE=1 ./autogen.sh
@@ -70,7 +69,7 @@ RUN apt-get update && apt-get -y install \
   valgrind
 
 RUN useradd testuser
-WORKDIR aktualizr
+WORKDIR /aktualizr
 RUN chown -R testuser:testuser .
 ADD --chown=testuser:testuser . src
 USER testuser:testuser


### PR DESCRIPTION
It ended up being `/ostree/aktualizr` which doesn't make sense.

Relevant docker documentation extract:

  The WORKDIR instruction can be used multiple times in a Dockerfile. If
  a relative path is provided, it will be relative to the path of the
  previous WORKDIR instruction