### PR TITLE
Fix `test_install_aktualizr_and_update.sh`

### DIFF
--- a/scripts/test_install_aktualizr_and_update.sh
+++ b/scripts/test_install_aktualizr_and_update.sh
@@ -5,9 +5,13 @@ set -exuo pipefail
 /persistent/selfupdate_server.py 8000&
 
 dpkg-deb -I /persistent/aktualizr.deb && dpkg -i /persistent/aktualizr.deb
-aktualizr --version | grep "$(cat /persistent/aktualizr-version)" && aktualizr-info
+aktualizr --version | grep "$(cat /persistent/aktualizr-version)"
 
 mkdir -m 700 -p /tmp/aktualizr-storage
 aktualizr -c /persistent/selfupdate.toml --running-mode=once
 
+# check that the version was updated
 aktualizr --version | grep 2.0-selfupdate
+
+# check that aktualizr-info succeeds
+aktualizr-info


### PR DESCRIPTION
In the current state of things, aktualizr-info needs one aktualizr run
(or `--allow-migrate`) so that the storage db exists and can be read