### PR TITLE
Minor improvements to garage-push.

### DIFF
--- a/src/libaktualizr/utilities/utils.h
+++ b/src/libaktualizr/utilities/utils.h
@@ -137,6 +137,14 @@ class CurlEasyWrapper {
   CURL *handle;
 };
 
+template <typename... T>
+static void curlEasySetoptWrapper(CURL *curl_handle, CURLoption option, T &&... args) {
+  const CURLcode retval = curl_easy_setopt(curl_handle, option, std::forward<T>(args)...);
+  if (retval != 0u) {
+    throw std::runtime_error(std::string("curl_easy_setopt error: ") + curl_easy_strerror(retval));
+  }
+}
+
 // this is reference implementation of make_unique which is not yet included to C++11
 namespace std_ {
 template <class T>

--- a/src/sota_tools/authenticate_test.cc
+++ b/src/sota_tools/authenticate_test.cc
@@ -8,6 +8,7 @@
 #include "server_credentials.h"
 #include "test_utils.h"
 #include "treehub_server.h"
+#include "utilities/utils.h"
 
 TEST(authenticate, good_zip) {
   boost::filesystem::path filepath = "sota_tools/auth_test_good.zip";
@@ -22,7 +23,7 @@ TEST(authenticate, good_cert_zip) {
   int r = authenticate("", ServerCredentials(filepath), treehub);
   EXPECT_EQ(0, r);
   CurlEasyWrapper curl_handle;
-  curl_easy_setopt(curl_handle.get(), CURLOPT_VERBOSE, 1);
+  curlEasySetoptWrapper(curl_handle.get(), CURLOPT_VERBOSE, 1);
   treehub.InjectIntoCurl("test.txt", curl_handle.get());
   CURLcode rc = curl_easy_perform(curl_handle.get());
 
@@ -35,7 +36,7 @@ TEST(authenticate, good_cert_noauth_zip) {
   int r = authenticate("fake_http_server/client.crt", ServerCredentials(filepath), treehub);
   EXPECT_EQ(0, r);
   CurlEasyWrapper curl_handle;
-  curl_easy_setopt(curl_handle.get(), CURLOPT_VERBOSE, 1);
+  curlEasySetoptWrapper(curl_handle.get(), CURLOPT_VERBOSE, 1);
   treehub.InjectIntoCurl("test.txt", curl_handle.get());
   CURLcode rc = curl_easy_perform(curl_handle.get());
 
@@ -48,7 +49,7 @@ TEST(authenticate, bad_cert_zip) {
   int r = authenticate("", ServerCredentials(filepath), treehub);
   EXPECT_EQ(0, r);
   CurlEasyWrapper curl_handle;
-  curl_easy_setopt(curl_handle.get(), CURLOPT_VERBOSE, 1);
+  curlEasySetoptWrapper(curl_handle.get(), CURLOPT_VERBOSE, 1);
   treehub.InjectIntoCurl("test.txt", curl_handle.get());
   CURLcode rc = curl_easy_perform(curl_handle.get());
 

--- a/src/sota_tools/deploy.cc
+++ b/src/sota_tools/deploy.cc
@@ -9,6 +9,7 @@
 #include "rate_controller.h"
 #include "request_pool.h"
 #include "treehub_server.h"
+#include "utilities/utils.h"
 
 bool UploadToTreehub(const OSTreeRepo::ptr &src_repo, const ServerCredentials &push_credentials,
                      const OSTreeHash &ostree_commit, const std::string &cacerts, const bool dryrun,
@@ -116,7 +117,7 @@ bool PushRootRef(const ServerCredentials &push_credentials, const OSTreeRef &ref
 
   if (!dry_run) {
     CurlEasyWrapper easy_handle;
-    curl_easy_setopt(easy_handle.get(), CURLOPT_VERBOSE, get_curlopt_verbose());
+    curlEasySetoptWrapper(easy_handle.get(), CURLOPT_VERBOSE, get_curlopt_verbose());
     ref.PushRef(push_server, easy_handle.get());
     CURLcode err = curl_easy_perform(easy_handle.get());
     if (err != 0u) {

--- a/src/sota_tools/garage_check.cc
+++ b/src/sota_tools/garage_check.cc
@@ -104,8 +104,8 @@ int main(int argc, char **argv) {
     LOG_FATAL << "Error initializing curl";
     return EXIT_FAILURE;
   }
-  curl_easy_setopt(curl.get(), CURLOPT_VERBOSE, get_curlopt_verbose());
-  curl_easy_setopt(curl.get(), CURLOPT_NOBODY, 1L);  // HEAD
+  curlEasySetoptWrapper(curl.get(), CURLOPT_VERBOSE, get_curlopt_verbose());
+  curlEasySetoptWrapper(curl.get(), CURLOPT_NOBODY, 1L);  // HEAD
 
   treehub.InjectIntoCurl("objects/" + ref.substr(0, 2) + "/" + ref.substr(2) + ".commit", curl.get());
 
@@ -128,14 +128,14 @@ int main(int argc, char **argv) {
   LOG_INFO << "OSTree commit " << ref << " is found on treehub";
 
   // check if the ref is present in targets.json
-  curl_easy_setopt(curl.get(), CURLOPT_VERBOSE, get_curlopt_verbose());
-  curl_easy_setopt(curl.get(), CURLOPT_HTTPGET, 1L);
-  curl_easy_setopt(curl.get(), CURLOPT_NOBODY, 0L);
+  curlEasySetoptWrapper(curl.get(), CURLOPT_VERBOSE, get_curlopt_verbose());
+  curlEasySetoptWrapper(curl.get(), CURLOPT_HTTPGET, 1L);
+  curlEasySetoptWrapper(curl.get(), CURLOPT_NOBODY, 0L);
   treehub.InjectIntoCurl("/api/v1/user_repo/targets.json", curl.get(), true);
 
   std::string targets_str;
-  curl_easy_setopt(curl.get(), CURLOPT_WRITEFUNCTION, writeString);
-  curl_easy_setopt(curl.get(), CURLOPT_WRITEDATA, (void *)&targets_str);
+  curlEasySetoptWrapper(curl.get(), CURLOPT_WRITEFUNCTION, writeString);
+  curlEasySetoptWrapper(curl.get(), CURLOPT_WRITEDATA, static_cast<void *>(&targets_str));
   result = curl_easy_perform(curl.get());
 
   if (result != CURLE_OK) {

--- a/src/sota_tools/garage_push.cc
+++ b/src/sota_tools/garage_push.cc
@@ -19,10 +19,8 @@ int main(int argc, char **argv) {
   boost::filesystem::path repo_path;
   string ref;
   int max_curl_requests;
-
-  string home_path = string(getenv("HOME"));
   string cacerts;
-  boost::filesystem::path credentials_path(home_path + "/.sota_tools.json");
+  boost::filesystem::path credentials_path;
 
   int verbosity;
   bool dry_run = false;
@@ -34,7 +32,7 @@ int main(int argc, char **argv) {
     ("quiet,q", "Quiet mode")
     ("repo,C", po::value<boost::filesystem::path>(&repo_path)->required(), "location of ostree repo")
     ("ref,r", po::value<string>(&ref)->required(), "ref to push")
-    ("credentials,j", po::value<boost::filesystem::path>(&credentials_path), "credentials (json or zip containing json)")
+    ("credentials,j", po::value<boost::filesystem::path>(&credentials_path)->required(), "credentials (json or zip containing json)")
     ("cacert", po::value<string>(&cacerts), "override path to CA root certificates, in the same format as curl --cacert")
     ("jobs", po::value<int>(&max_curl_requests)->default_value(30), "maximum number of parallel requests")
     ("dry-run,n", "check arguments and authenticate but don't upload");

--- a/src/sota_tools/oauth2.cc
+++ b/src/sota_tools/oauth2.cc
@@ -26,22 +26,22 @@ size_t curl_handle_write_sstream(void *buffer, size_t size, size_t nmemb, void *
 
 AuthenticationResult OAuth2::Authenticate() {
   CurlEasyWrapper curl_handle;
-  curl_easy_setopt(curl_handle.get(), CURLOPT_VERBOSE, get_curlopt_verbose());
-  curl_easy_setopt(curl_handle.get(), CURLOPT_URL, (server_ + "/token").c_str());
+  curlEasySetoptWrapper(curl_handle.get(), CURLOPT_VERBOSE, get_curlopt_verbose());
+  curlEasySetoptWrapper(curl_handle.get(), CURLOPT_URL, (server_ + "/token").c_str());
   if (ca_certs_ != "") {
-    curl_easy_setopt(curl_handle.get(), CURLOPT_CAINFO, ca_certs_.c_str());
-    curl_easy_setopt(curl_handle.get(), CURLOPT_CAPATH, NULL);
+    curlEasySetoptWrapper(curl_handle.get(), CURLOPT_CAINFO, ca_certs_.c_str());
+    curlEasySetoptWrapper(curl_handle.get(), CURLOPT_CAPATH, NULL);
   }
 
-  curl_easy_setopt(curl_handle.get(), CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
-  curl_easy_setopt(curl_handle.get(), CURLOPT_USERNAME, client_id_.c_str());
-  curl_easy_setopt(curl_handle.get(), CURLOPT_PASSWORD, client_secret_.c_str());
-  curl_easy_setopt(curl_handle.get(), CURLOPT_POST, 1);
-  curl_easy_setopt(curl_handle.get(), CURLOPT_COPYPOSTFIELDS, "grant_type=client_credentials");
+  curlEasySetoptWrapper(curl_handle.get(), CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+  curlEasySetoptWrapper(curl_handle.get(), CURLOPT_USERNAME, client_id_.c_str());
+  curlEasySetoptWrapper(curl_handle.get(), CURLOPT_PASSWORD, client_secret_.c_str());
+  curlEasySetoptWrapper(curl_handle.get(), CURLOPT_POST, 1);
+  curlEasySetoptWrapper(curl_handle.get(), CURLOPT_COPYPOSTFIELDS, "grant_type=client_credentials");
 
   stringstream body;
-  curl_easy_setopt(curl_handle.get(), CURLOPT_WRITEFUNCTION, &curl_handle_write_sstream);
-  curl_easy_setopt(curl_handle.get(), CURLOPT_WRITEDATA, &body);
+  curlEasySetoptWrapper(curl_handle.get(), CURLOPT_WRITEFUNCTION, &curl_handle_write_sstream);
+  curlEasySetoptWrapper(curl_handle.get(), CURLOPT_WRITEDATA, &body);
 
   curl_easy_perform(curl_handle.get());
 

--- a/src/sota_tools/ostree_http_repo.cc
+++ b/src/sota_tools/ostree_http_repo.cc
@@ -11,6 +11,7 @@
 #include <boost/property_tree/ini_parser.hpp>
 
 #include "logging/logging.h"
+#include "utilities/utils.h"
 
 using std::string;
 namespace pt = boost::property_tree;
@@ -45,9 +46,9 @@ OSTreeObject::ptr OSTreeHttpRepo::GetObject(const uint8_t sha256[32]) const { re
 bool OSTreeHttpRepo::Get(const boost::filesystem::path &path) const {
   CURLcode err = CURLE_OK;
   CurlEasyWrapper easy_handle;
-  curl_easy_setopt(easy_handle.get(), CURLOPT_VERBOSE, get_curlopt_verbose());
+  curlEasySetoptWrapper(easy_handle.get(), CURLOPT_VERBOSE, get_curlopt_verbose());
   server_->InjectIntoCurl(path.string(), easy_handle.get());
-  curl_easy_setopt(easy_handle.get(), CURLOPT_WRITEFUNCTION, &OSTreeHttpRepo::curl_handle_write);
+  curlEasySetoptWrapper(easy_handle.get(), CURLOPT_WRITEFUNCTION, &OSTreeHttpRepo::curl_handle_write);
   boost::filesystem::create_directories((root_ / path).parent_path());
   std::string filename = (root_ / path).string();
   int fp = open(filename.c_str(), O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH);
@@ -55,8 +56,8 @@ bool OSTreeHttpRepo::Get(const boost::filesystem::path &path) const {
     LOG_ERROR << "Failed to open file: " << filename;
     return false;
   }
-  curl_easy_setopt(easy_handle.get(), CURLOPT_WRITEDATA, &fp);
-  curl_easy_setopt(easy_handle.get(), CURLOPT_FAILONERROR, true);
+  curlEasySetoptWrapper(easy_handle.get(), CURLOPT_WRITEDATA, &fp);
+  curlEasySetoptWrapper(easy_handle.get(), CURLOPT_FAILONERROR, true);
   err = curl_easy_perform(easy_handle.get());
   close(fp);
 

--- a/src/sota_tools/ostree_object.cc
+++ b/src/sota_tools/ostree_object.cc
@@ -172,16 +172,16 @@ void OSTreeObject::MakeTestRequest(const TreehubServer &push_target, CURLM *curl
   if (curl_handle_ == nullptr) {
     throw std::runtime_error("Could not initialize curl handle");
   }
-  curl_easy_setopt(curl_handle_, CURLOPT_VERBOSE, get_curlopt_verbose());
+  curlEasySetoptWrapper(curl_handle_, CURLOPT_VERBOSE, get_curlopt_verbose());
   current_operation_ = CurrentOp::kOstreeObjectPresenceCheck;
 
   push_target.InjectIntoCurl(Url(), curl_handle_);
-  curl_easy_setopt(curl_handle_, CURLOPT_NOBODY, 1L);  // HEAD
+  curlEasySetoptWrapper(curl_handle_, CURLOPT_NOBODY, 1L);  // HEAD
 
-  curl_easy_setopt(curl_handle_, CURLOPT_WRITEFUNCTION, &OSTreeObject::curl_handle_write);
-  curl_easy_setopt(curl_handle_, CURLOPT_WRITEDATA, this);
-  curl_easy_setopt(curl_handle_, CURLOPT_PRIVATE, this);  // Used by ostree_object_from_curl
-  http_response_.str("");                                 // Empty the response buffer
+  curlEasySetoptWrapper(curl_handle_, CURLOPT_WRITEFUNCTION, &OSTreeObject::curl_handle_write);
+  curlEasySetoptWrapper(curl_handle_, CURLOPT_WRITEDATA, this);
+  curlEasySetoptWrapper(curl_handle_, CURLOPT_PRIVATE, this);  // Used by ostree_object_from_curl
+  http_response_.str("");                                      // Empty the response buffer
 
   const CURLMcode err = curl_multi_add_handle(curl_multi_handle, curl_handle_);
   if (err != 0) {
@@ -205,11 +205,11 @@ void OSTreeObject::Upload(const TreehubServer &push_target, CURLM *curl_multi_ha
   if (curl_handle_ == nullptr) {
     throw std::runtime_error("Could not initialize curl handle");
   }
-  curl_easy_setopt(curl_handle_, CURLOPT_VERBOSE, get_curlopt_verbose());
+  curlEasySetoptWrapper(curl_handle_, CURLOPT_VERBOSE, get_curlopt_verbose());
   current_operation_ = CurrentOp::kOstreeObjectUploading;
   push_target.InjectIntoCurl(Url(), curl_handle_);
-  curl_easy_setopt(curl_handle_, CURLOPT_WRITEFUNCTION, &OSTreeObject::curl_handle_write);
-  curl_easy_setopt(curl_handle_, CURLOPT_WRITEDATA, this);
+  curlEasySetoptWrapper(curl_handle_, CURLOPT_WRITEFUNCTION, &OSTreeObject::curl_handle_write);
+  curlEasySetoptWrapper(curl_handle_, CURLOPT_WRITEDATA, this);
   http_response_.str("");  // Empty the response buffer
 
   assert(form_post_ == nullptr);
@@ -220,13 +220,10 @@ void OSTreeObject::Upload(const TreehubServer &push_target, CURLM *curl_multi_ha
     // Apparently there is not strerror for formadd.
     LOG_ERROR << "curl_formadd error: " << form_err;
   }
-  curl_easy_setopt(curl_handle_, CURLOPT_POST, 1);
-  const CURLcode e = curl_easy_setopt(curl_handle_, CURLOPT_HTTPPOST, form_post_);
-  if (e != 0u) {
-    LOG_ERROR << "curl_easy_setopt error: " << curl_easy_strerror(e);
-  }
+  curlEasySetoptWrapper(curl_handle_, CURLOPT_POST, 1);
+  curlEasySetoptWrapper(curl_handle_, CURLOPT_HTTPPOST, form_post_);
 
-  curl_easy_setopt(curl_handle_, CURLOPT_PRIVATE, this);  // Used by ostree_object_from_curl
+  curlEasySetoptWrapper(curl_handle_, CURLOPT_PRIVATE, this);  // Used by ostree_object_from_curl
 
   const CURLMcode err = curl_multi_add_handle(curl_multi_handle, curl_handle_);
   if (err != 0) {

--- a/src/sota_tools/ostree_object.h
+++ b/src/sota_tools/ostree_object.h
@@ -61,6 +61,8 @@ class OSTreeObject {
 
   void AppendChild(const OSTreeObject::ptr& child);
   std::string Url() const;
+  void PresenceUnknown(RequestPool& pool, int64_t rescode);
+  void ObjectMissing(RequestPool& pool, int64_t rescode);
 
   static size_t curl_handle_write(void* buffer, size_t size, size_t nmemb, void* userp);
 

--- a/src/sota_tools/ostree_ref.cc
+++ b/src/sota_tools/ostree_ref.cc
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "logging/logging.h"
+#include "utilities/utils.h"
 
 using std::string;
 
@@ -34,10 +35,10 @@ OSTreeRef::OSTreeRef(const TreehubServer &serve_repo, string ref_name)
     : is_valid(true), ref_name_(std::move(ref_name)) {
   CurlEasyWrapper curl_handle;
   serve_repo.InjectIntoCurl(Url(), curl_handle.get());
-  curl_easy_setopt(curl_handle.get(), CURLOPT_WRITEFUNCTION, &OSTreeRef::curl_handle_write);
-  curl_easy_setopt(curl_handle.get(), CURLOPT_WRITEDATA, this);
-  curl_easy_setopt(curl_handle.get(), CURLOPT_VERBOSE, get_curlopt_verbose());
-  curl_easy_setopt(curl_handle.get(), CURLOPT_FAILONERROR, true);
+  curlEasySetoptWrapper(curl_handle.get(), CURLOPT_WRITEFUNCTION, &OSTreeRef::curl_handle_write);
+  curlEasySetoptWrapper(curl_handle.get(), CURLOPT_WRITEDATA, this);
+  curlEasySetoptWrapper(curl_handle.get(), CURLOPT_VERBOSE, get_curlopt_verbose());
+  curlEasySetoptWrapper(curl_handle.get(), CURLOPT_FAILONERROR, true);
   CURLcode rc = curl_easy_perform(curl_handle.get());
   if (rc != CURLE_OK) {
     is_valid = false;
@@ -49,14 +50,14 @@ void OSTreeRef::PushRef(const TreehubServer &push_target, CURL *curl_handle) con
   assert(IsValid());
 
   push_target.InjectIntoCurl(Url(), curl_handle);
-  curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, &OSTreeRef::curl_handle_write);
-  curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, this);
-  curl_easy_setopt(curl_handle, CURLOPT_PRIVATE, this);  // Used by ostree_ref_from_curl
+  curlEasySetoptWrapper(curl_handle, CURLOPT_WRITEFUNCTION, &OSTreeRef::curl_handle_write);
+  curlEasySetoptWrapper(curl_handle, CURLOPT_WRITEDATA, this);
+  curlEasySetoptWrapper(curl_handle, CURLOPT_PRIVATE, this);  // Used by ostree_ref_from_curl
 
-  curl_easy_setopt(curl_handle, CURLOPT_POST, 1);
-  curl_easy_setopt(curl_handle, CURLOPT_POSTFIELDSIZE, ref_content_.size());
-  curl_easy_setopt(curl_handle, CURLOPT_COPYPOSTFIELDS, ref_content_.c_str());
-  curl_easy_setopt(curl_handle, CURLOPT_VERBOSE, get_curlopt_verbose());
+  curlEasySetoptWrapper(curl_handle, CURLOPT_POST, 1);
+  curlEasySetoptWrapper(curl_handle, CURLOPT_POSTFIELDSIZE, ref_content_.size());
+  curlEasySetoptWrapper(curl_handle, CURLOPT_COPYPOSTFIELDS, ref_content_.c_str());
+  curlEasySetoptWrapper(curl_handle, CURLOPT_VERBOSE, get_curlopt_verbose());
 }
 
 bool OSTreeRef::IsValid() const { return is_valid; }

--- a/src/sota_tools/rate_controller.cc
+++ b/src/sota_tools/rate_controller.cc
@@ -9,8 +9,10 @@ const RateController::clock::duration RateController::kMaxSleepTime = std::chron
 
 const RateController::clock::duration RateController::kInitialSleepTime = std::chrono::seconds(1);
 
-RateController::RateController(int concurrency_cap) : concurrency_cap_(concurrency_cap) { CheckInvariants(); }
-void RateController::RequestCompleted(clock::time_point start_time, clock::time_point end_time, bool succeeded) {
+RateController::RateController(const int concurrency_cap) : concurrency_cap_(concurrency_cap) { CheckInvariants(); }
+
+void RateController::RequestCompleted(const clock::time_point start_time, const clock::time_point end_time,
+                                      const bool succeeded) {
   if (last_concurrency_update_ < start_time) {
     last_concurrency_update_ = end_time;
     if (succeeded) {

--- a/src/sota_tools/request_pool.cc
+++ b/src/sota_tools/request_pool.cc
@@ -112,9 +112,9 @@ void RequestPool::LoopListen() {
     if ((msg != nullptr) && msg->msg == CURLMSG_DONE) {
       OSTreeObject::ptr h = ostree_object_from_curl(msg->easy_handle);
       h->CurlDone(multi_, *this);
-      bool server_responded_ok = h->LastOperationResult() == ServerResponse::kOk;
-      RateController::clock::time_point start_time = h->RequestStartTime();
-      RateController::clock::time_point end_time = RateController::clock::now();
+      const bool server_responded_ok = h->LastOperationResult() == ServerResponse::kOk;
+      const RateController::clock::time_point start_time = h->RequestStartTime();
+      const RateController::clock::time_point end_time = RateController::clock::now();
       rate_controller_.RequestCompleted(start_time, end_time, server_responded_ok);
       if (rate_controller_.ServerHasFailed()) {
         Abort();

--- a/src/sota_tools/treehub_server.cc
+++ b/src/sota_tools/treehub_server.cc
@@ -52,25 +52,25 @@ void TreehubServer::InjectIntoCurl(const string& url_suffix, CURL* curl_handle, 
 
   boost::trim_if(url, boost::is_any_of(" \t\r\n"));
 
-  curl_easy_setopt(curl_handle, CURLOPT_URL, (url + url_suffix).c_str());
+  curlEasySetoptWrapper(curl_handle, CURLOPT_URL, (url + url_suffix).c_str());
 
-  curl_easy_setopt(curl_handle, CURLOPT_HTTPHEADER, &auth_header_);
+  curlEasySetoptWrapper(curl_handle, CURLOPT_HTTPHEADER, &auth_header_);
   // If we need authentication but don't have an OAuth2 token, fall back to
   // legacy username/password.
   if (method_ == AuthMethod::kBasic || method_ == AuthMethod::kCert) {
-    curl_easy_setopt(curl_handle, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
-    curl_easy_setopt(curl_handle, CURLOPT_USERNAME, username_.c_str());
-    curl_easy_setopt(curl_handle, CURLOPT_PASSWORD, password_.c_str());
+    curlEasySetoptWrapper(curl_handle, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curlEasySetoptWrapper(curl_handle, CURLOPT_USERNAME, username_.c_str());
+    curlEasySetoptWrapper(curl_handle, CURLOPT_PASSWORD, password_.c_str());
   }
 
   std::string all_root_certs;
   if (method_ == AuthMethod::kCert) {
-    curl_easy_setopt(curl_handle, CURLOPT_SSL_VERIFYPEER, 1);
-    curl_easy_setopt(curl_handle, CURLOPT_SSL_VERIFYHOST, 2);
-    curl_easy_setopt(curl_handle, CURLOPT_USE_SSL, CURLUSESSL_ALL);
+    curlEasySetoptWrapper(curl_handle, CURLOPT_SSL_VERIFYPEER, 1);
+    curlEasySetoptWrapper(curl_handle, CURLOPT_SSL_VERIFYHOST, 2);
+    curlEasySetoptWrapper(curl_handle, CURLOPT_USE_SSL, CURLUSESSL_ALL);
 
-    curl_easy_setopt(curl_handle, CURLOPT_SSLCERT, client_cert_path_.PathString().c_str());
-    curl_easy_setopt(curl_handle, CURLOPT_SSLKEY, client_key_path_.PathString().c_str());
+    curlEasySetoptWrapper(curl_handle, CURLOPT_SSLCERT, client_cert_path_.PathString().c_str());
+    curlEasySetoptWrapper(curl_handle, CURLOPT_SSLKEY, client_key_path_.PathString().c_str());
     if (!root_cert_.empty()) {
       all_root_certs = root_cert_;
     }
@@ -80,8 +80,8 @@ void TreehubServer::InjectIntoCurl(const string& url_suffix, CURL* curl_handle, 
   }
   if (!all_root_certs.empty()) {
     Utils::writeFile(root_cert_path_.PathString(), all_root_certs);
-    curl_easy_setopt(curl_handle, CURLOPT_CAINFO, root_cert_path_.PathString().c_str());
-    curl_easy_setopt(curl_handle, CURLOPT_CAPATH, NULL);
+    curlEasySetoptWrapper(curl_handle, CURLOPT_CAINFO, root_cert_path_.PathString().c_str());
+    curlEasySetoptWrapper(curl_handle, CURLOPT_CAPATH, NULL);
   }
 }
 

--- a/tests/sota_tools/test-bare-mode-repo
+++ b/tests/sota_tools/test-bare-mode-repo
@@ -2,4 +2,4 @@
 set -eu
 
 TARGET="OSTree repo is not in archive-z2 format"
-$1 --ref master --repo sota_tools/bare-repo | grep -q "$TARGET"
+$1 --ref master --repo sota_tools/bare-repo --credentials sota_tools/auth_test_good.zip | grep -q "$TARGET"

--- a/tests/sota_tools/test-invalid-repo
+++ b/tests/sota_tools/test-invalid-repo
@@ -2,4 +2,4 @@
 set -eu
 
 TARGET="does not appear to contain a valid OSTree repository"
-$1 --ref master --repo invalid | grep -q "$TARGET"
+$1 --ref master --repo invalid --credentials sota_tools/auth_test_good.zip | grep -q "$TARGET"


### PR DESCRIPTION
* Require credentials, no longer silently accept an undocumented default
option. Fix associated tests.
* Remove an unused getenv system call.
* More const-correctness and error checking.

Note that the return code from `curl_easy_setopt` is almost never checked. Is that worth changing?