### PR TITLE
Adding documentation of two new campaign related options

### DIFF
--- a/docs/selectively-triggering-aktualizr.adoc
+++ b/docs/selectively-triggering-aktualizr.adoc
@@ -58,7 +58,7 @@ Installation reports are sent when aktualizr polls the server for updates, so th
 
     aktualizr --running-mode=check
 
-=== Check for campaigns target the device
+=== Check for campaigns that target the device
 
 Campaigns provide a way to target software updates to specific groups of devices. You can set up campaigns in the OTA Connect web app. When a device comes online that matches the targeting criteria of a campaign, the OTA Connect server notifies the device that new software updates are available. 
 
@@ -75,3 +75,5 @@ This running mode works together with the `campaign_check` mode. After you have 
 For example:
 
     aktualizr --running-mode=campaign_accept --campaign-id=4df1a199-59d4-47f6-a261-d79b83020f65
+    
+Once aktualizr has accepted the campaign, the scheduled update becomes available to the device. The device can then install the update during a normal full update cycle or when the device runs in `check` mode.

--- a/docs/selectively-triggering-aktualizr.adoc
+++ b/docs/selectively-triggering-aktualizr.adoc
@@ -1,20 +1,20 @@
 = Selectively triggering aktualizr
 
-Aktualizr normally runs as a systemd service and regularly polls for updates. The default polling interval is set at 10s, and this should be increased by a few orders of magnitude in a production system.
+Aktualizr normally runs as a `systemd` service and regularly polls for updates. The default polling interval is set at 10s, and this should be increased by a few orders of magnitude in a production system.
 
 It is also possible to trigger the update cycle, or individual parts of the update cycle, manually or programmatically. This is done by using aktualizr's `--running-mode` option (or by setting `running_mode` in the `[uptane]` configuration section).
 
 [NOTE]
 ====
-To selectively trigger aktualizr, you should disable the systemd service; a continuously-running aktualizr will interfere with the manual triggering.
+To selectively trigger aktualizr, you should disable the `systemd` service. If aktualizr runs continuously, it interferes with the manual triggering.
 
 To run the update cycle manually, first stop and disable the aktualizr background service:
 
     systemctl stop aktualizr && systemctl disable aktualizr
 
-Assuming aktualizr is being built using Yocto and meta-updater, the systemd service can also be disabled by default by adding the following to `local.conf`:
+Assuming aktualizr is being built using Yocto and meta-updater, the `systemd` service can also be disabled by default by adding the following to `local.conf`:
 
-    SYSTEMD_AUTO_ENABLE_aktualizr = "disable"
+    `systemd`_AUTO_ENABLE_aktualizr = "disable"
 ====
 
 WARNING: This interface may change in the future, possibly to a socket- or dbus-based system.
@@ -23,12 +23,12 @@ WARNING: This interface may change in the future, possibly to a socket- or dbus-
 
 An update cycle consists of:
 
-. Polling the server for updates and downloading (and verifying) update metadata
-. Downloading (and verifying) any update binaries available
-. Installing the update
-. Reporting the install results
+. Polling the server for updates and downloading (and verifying) update metadata.
+. Downloading (and verifying) any update binaries available.
+. Installing the update.
+. Reporting the install results.
 
-To trigger the whole cycle, use
+To trigger the whole cycle, use the following command:
 
     aktualizr --running-mode=once
 
@@ -58,3 +58,20 @@ Installation reports are sent when aktualizr polls the server for updates, so th
 
     aktualizr --running-mode=check
 
+=== Check for campaigns target the device
+
+In the OTA Connect web app, you can create smart groups that filter for devices based on specific criteria. When OTA Connect detects a new device that matches this criteria, it automatically publishes the campaign to the device. This running mode checks to see if the device matches the filter criteria used in an active campaign.
+
+    aktualizr --running-mode=campaign_check
+
+If the device matches one or more campaigns, aktualizr prints details of each applicable campaign including the campaign ID. You can then use the campaign ID for the `campaign_accept` command.
+
+=== Accept campaigns that target the device
+
+This running mode works together with the `campaign_check`. After you have received a list of applicable campaigns, you can accept specific campaigns so that they update the device.
+
+    aktualizr --running-mode=campaign_accept <CAMPAIGN_ID>
+
+For example:
+
+    aktualizr --running-mode=campaign_accept 4df1a199-59d4-47f6-a261-d79b83020f65

--- a/docs/selectively-triggering-aktualizr.adoc
+++ b/docs/selectively-triggering-aktualizr.adoc
@@ -60,18 +60,18 @@ Installation reports are sent when aktualizr polls the server for updates, so th
 
 === Check for campaigns target the device
 
-In the OTA Connect web app, you can create smart groups that filter for devices based on specific criteria. When OTA Connect detects a new device that matches this criteria, it automatically publishes the campaign to the device. This running mode checks to see if the device matches the filter criteria used in an active campaign.
+Campaigns provide a way to target software updates to specific groups of devices. You can set up campaigns in the OTA Connect web app. When a device comes online that matches the targeting criteria of a campaign, the OTA Connect server notifies the device that new software updates are available. 
 
     aktualizr --running-mode=campaign_check
 
-If the device matches one or more campaigns, aktualizr prints details of each applicable campaign including the campaign ID. You can then use the campaign ID for the `campaign_accept` command.
+If the device is targeted by one or more campaigns, aktualizr prints details of each applicable campaign including the campaign ID. You can then use the campaign ID for the `campaign_accept` command.
 
 === Accept campaigns that target the device
 
-This running mode works together with the `campaign_check` mode. After you have received a list of applicable campaigns, you can accept specific campaigns so that they update the device.
+This running mode works together with the `campaign_check` mode. After you have received a list of applicable campaigns, you can accept the campaigns so that they are included in the software update process.
 
-    aktualizr --running-mode=campaign_accept <CAMPAIGN_ID>
+    aktualizr --running-mode=campaign_accept --campaign-id=<CAMPAIGN_ID>
 
 For example:
 
-    aktualizr --running-mode=campaign_accept 4df1a199-59d4-47f6-a261-d79b83020f65
+    aktualizr --running-mode=campaign_accept --campaign-id=4df1a199-59d4-47f6-a261-d79b83020f65

--- a/docs/selectively-triggering-aktualizr.adoc
+++ b/docs/selectively-triggering-aktualizr.adoc
@@ -14,7 +14,7 @@ To run the update cycle manually, first stop and disable the aktualizr backgroun
 
 Assuming aktualizr is being built using Yocto and meta-updater, the `systemd` service can also be disabled by default by adding the following to `local.conf`:
 
-    `systemd`_AUTO_ENABLE_aktualizr = "disable"
+    SYSTEMD_AUTO_ENABLE_aktualizr = "disable"
 ====
 
 WARNING: This interface may change in the future, possibly to a socket- or dbus-based system.

--- a/docs/selectively-triggering-aktualizr.adoc
+++ b/docs/selectively-triggering-aktualizr.adoc
@@ -68,7 +68,7 @@ If the device matches one or more campaigns, aktualizr prints details of each ap
 
 === Accept campaigns that target the device
 
-This running mode works together with the `campaign_check`. After you have received a list of applicable campaigns, you can accept specific campaigns so that they update the device.
+This running mode works together with the `campaign_check` mode. After you have received a list of applicable campaigns, you can accept specific campaigns so that they update the device.
 
     aktualizr --running-mode=campaign_accept <CAMPAIGN_ID>
 


### PR DESCRIPTION
Adding documentation of "campaign_check" and "campaign_accept" which
needs developer review.

I'm not entirely sure about my explanation for "accept". In the UI, there are some campaigns that the end-user (ie: motorist) has to accept before installing, and some campaigns that are allowed to auto install. Does this "accept" refer to the same thing?

Also, why is the "full" mode not documented anywhere?