### PR TITLE
Try a few different locations for finding the p11 engine library.

### DIFF
--- a/src/libaktualizr/crypto/crypto_test.cc
+++ b/src/libaktualizr/crypto/crypto_test.cc
@@ -47,6 +47,12 @@ TEST(crypto, sign_verify_rsa_file) {
 }
 
 #ifdef BUILD_P11
+TEST(crypto, findPkcsLibrary) {
+  const boost::filesystem::path pkcs11Path = P11Engine::findPkcsLibrary();
+  EXPECT_NE(pkcs11Path, "");
+  EXPECT_TRUE(boost::filesystem::exists(pkcs11Path));
+}
+
 TEST(crypto, sign_verify_rsa_p11) {
   P11Config config;
   config.module = TEST_PKCS11_MODULE_PATH;

--- a/src/libaktualizr/crypto/p11engine.h
+++ b/src/libaktualizr/crypto/p11engine.h
@@ -1,14 +1,14 @@
 #ifndef P11ENGINE_H_
 #define P11ENGINE_H_
 
-#include <openssl/engine.h>
-#include <openssl/err.h>
-#include <boost/filesystem.hpp>
 #include <memory>
 
-#include "p11_config.h"
+#include <gtest/gtest.h>
+#include <openssl/engine.h>
+#include <openssl/err.h>
 
 #include "logging/logging.h"
+#include "p11_config.h"
 
 class P11ContextWrapper {
  public:
@@ -68,11 +68,13 @@ class P11Engine {
   P11ContextWrapper ctx_;
   P11SlotsWrapper slots_;
 
+  static boost::filesystem::path findPkcsLibrary();
   PKCS11_slot_st *findTokenSlot() const;
 
   explicit P11Engine(P11Config config);
 
   friend class P11EngineGuard;
+  FRIEND_TEST(crypto, findPkcsLibrary);
 };
 
 class P11EngineGuard {


### PR DESCRIPTION
If a path is provided, try that. If that doesn't work, try the new path
for openssl-1.1. If that doesn't work, try the old default location.

Also add a test.

This is part of the work to get HSM support working on master again. meta-updater PR is at https://github.com/advancedtelematic/meta-updater/pull/391.