### PR TITLE
Send campaigns metadata in CampaignCheckComplete

### DIFF
--- a/src/libaktualizr/campaign/campaign.cc
+++ b/src/libaktualizr/campaign/campaign.cc
@@ -18,6 +18,8 @@ Campaign Campaign::fromJson(const Json::Value &json) {
       throw CampaignParseError();
     }
 
+    bool autoAccept = json.get("autoAccept", false).asBool();
+
     std::string description;
     int estInstallationDuration = 0;
     int estPreparationDuration = 0;
@@ -44,7 +46,7 @@ Campaign Campaign::fromJson(const Json::Value &json) {
       }
     }
 
-    return {id, name, description, estInstallationDuration, estPreparationDuration};
+    return {id, name, autoAccept, description, estInstallationDuration, estPreparationDuration};
   } catch (const std::runtime_error &exc) {
     LOG_ERROR << exc.what();
     throw CampaignParseError();

--- a/src/libaktualizr/campaign/campaign.h
+++ b/src/libaktualizr/campaign/campaign.h
@@ -22,6 +22,7 @@ class Campaign {
 
   std::string id;
   std::string name;
+  bool autoAccept;
   std::string description;
   int estInstallationDuration;
   int estPreparationDuration;

--- a/src/libaktualizr/campaign/campaign_test.cc
+++ b/src/libaktualizr/campaign/campaign_test.cc
@@ -13,9 +13,20 @@ TEST(campaign, Campaigns_from_json) {
   EXPECT_EQ(campaigns.size(), 1);
 
   EXPECT_EQ(campaigns.at(0).name, "campaign1");
+  EXPECT_EQ(campaigns.at(0).id, "c2eb7e8d-8aa0-429d-883f-5ed8fdb2a493");
+  EXPECT_TRUE(campaigns.at(0).autoAccept);
   EXPECT_EQ(campaigns.at(0).description, "this is my message to show on the device");
   EXPECT_EQ(campaigns.at(0).estInstallationDuration, 10);
   EXPECT_EQ(campaigns.at(0).estPreparationDuration, 20);
+
+  // legacy: no autoAccept
+  Json::Value bad4;
+  bad4["campaigns"] = Json::Value(Json::arrayValue);
+  bad4["campaigns"][0] = Json::Value();
+  bad4["campaigns"][0]["name"] = "a";
+  bad4["campaigns"][0]["id"] = "a";
+  auto campaignsNoAutoAccept = campaign::campaignsFromJson(bad4);
+  EXPECT_FALSE(campaignsNoAutoAccept.at(0).autoAccept);
 }
 
 TEST(campaign, Campaigns_from_invalid_json) {

--- a/src/libaktualizr/campaign/test/campaigns_sample.json
+++ b/src/libaktualizr/campaign/test/campaigns_sample.json
@@ -17,7 +17,8 @@
           "value": "20"
         }
       ],
-      "name" : "campaign1"
+      "name" : "campaign1",
+      "autoAccept": true
     }
   ],
   "deviceId" : "15d655cb-7174-4ee7-9422-f10d587d344b"

--- a/src/libaktualizr/primary/aktualizr.h
+++ b/src/libaktualizr/primary/aktualizr.h
@@ -116,6 +116,7 @@ class Aktualizr {
   FRIEND_TEST(Aktualizr, CheckWithUpdates);
   FRIEND_TEST(Aktualizr, DownloadWithUpdates);
   FRIEND_TEST(Aktualizr, InstallWithUpdates);
+  FRIEND_TEST(Aktualizr, CampaignCheck);
   Aktualizr(Config& config, std::shared_ptr<INvStorage> storage_in, std::shared_ptr<SotaUptaneClient> uptane_client_in,
             std::shared_ptr<event::Channel> sig_in);
   void systemSetup();

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -826,7 +826,7 @@ void SotaUptaneClient::campaignCheck() {
     LOG_INFO << "Campaign id: " << c.id;
     LOG_INFO << "Message: " << c.description;
   }
-  sendEvent<event::CampaignCheckComplete>();
+  sendEvent<event::CampaignCheckComplete>(std::move(campaigns));
 }
 
 void SotaUptaneClient::campaignAccept(const std::string &campaign_id) {

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -824,6 +824,7 @@ void SotaUptaneClient::campaignCheck() {
   for (const auto &c : campaigns) {
     LOG_INFO << "Campaign: " << c.name;
     LOG_INFO << "Campaign id: " << c.id;
+    LOG_INFO << "CampaignAccept required: " << (c.autoAccept ? "no" : "yes");
     LOG_INFO << "Message: " << c.description;
   }
   sendEvent<event::CampaignCheckComplete>(std::move(campaigns));

--- a/src/libaktualizr/utilities/events.cc
+++ b/src/libaktualizr/utilities/events.cc
@@ -116,7 +116,10 @@ InstallComplete::InstallComplete(Uptane::EcuSerial serial_in, bool success_in)
 
 AllInstallsComplete::AllInstallsComplete() { variant = "AllInstallsComplete"; }
 
-CampaignCheckComplete::CampaignCheckComplete() { variant = "CampaignCheckComplete"; }
+CampaignCheckComplete::CampaignCheckComplete(std::vector<campaign::Campaign> campaigns_in)
+    : campaigns(std::move(campaigns_in)) {
+  variant = "CampaignCheckComplete";
+}
 
 CampaignAcceptComplete::CampaignAcceptComplete() { variant = "CampaignAcceptComplete"; }
 

--- a/src/libaktualizr/utilities/events.h
+++ b/src/libaktualizr/utilities/events.h
@@ -7,6 +7,7 @@
 #include <json/json.h>
 #include <boost/signals2.hpp>
 
+#include "campaign/campaign.h"
 #include "uptane/tuf.h"
 #include "utilities/types.h"
 
@@ -148,7 +149,8 @@ class AllInstallsComplete : public BaseEvent {
  */
 class CampaignCheckComplete : public BaseEvent {
  public:
-  explicit CampaignCheckComplete();
+  explicit CampaignCheckComplete(std::vector<campaign::Campaign> campaigns_in);
+  std::vector<campaign::Campaign> campaigns;
 };
 
 /**

--- a/tests/httpfake.h
+++ b/tests/httpfake.h
@@ -24,6 +24,7 @@ class HttpFake : public HttpInterface {
         ecu_registered(is_initialized) {
     Utils::copyDir("tests/test_data/repo/repo/image", metadata_path.Path() / "repo");
     Utils::copyDir("tests/test_data/repo/repo/director", metadata_path.Path() / "director");
+    Utils::copyDir("tests/test_data/repo/campaigner", metadata_path.Path() / "campaigner");
   }
 
   ~HttpFake() {}
@@ -65,6 +66,8 @@ class HttpFake : public HttpInterface {
         path = metadata_path.Path() / url.substr(tls_server.size() + strlen("noupdates/"));
       } else if (url.find("multisec/") != std::string::npos) {
         path = metadata_path.Path() / url.substr(tls_server.size() + strlen("multisec/"));
+      } else if (url.find("campaigner/") != std::string::npos) {
+        path = metadata_path.Path() / url.substr(tls_server.size() + strlen("campaigner/"));
       } else {
         path = metadata_path.Path() / url.substr(tls_server.size());
       }
@@ -110,6 +113,8 @@ class HttpFake : public HttpInterface {
                                        boost::filesystem::copy_option::overwrite_if_exists);
         }
         return HttpResponse(Utils::readFile(path), 200, CURLE_OK, "");
+      } else if (url.find("campaigner/campaigns") != std::string::npos) {
+        return HttpResponse(Utils::readFile(path.parent_path() / "campaigner/campaigns.json"), 200, CURLE_OK, "");
       } else {
         if (boost::filesystem::exists(path)) {
           return HttpResponse(Utils::readFile(path), 200, CURLE_OK, "");

--- a/tests/test_data/repo/campaigner/campaigns.json
+++ b/tests/test_data/repo/campaigner/campaigns.json
@@ -1,0 +1,1 @@
+../../../../src/libaktualizr/campaign/test/campaigns_sample.json


### PR DESCRIPTION
Previously, the api was only usable from the CLI