### PR TITLE
Changes to provisioning configs for delayed provisioning

### DIFF
--- a/config/sota_hsm_prov.toml
+++ b/config/sota_hsm_prov.toml
@@ -1,4 +1,5 @@
 [tls]
+server_url_path = "/var/sota/gateway.url"
 cert_source = "pkcs11"
 pkey_source = "pkcs11"
 
@@ -18,5 +19,3 @@ type = "sqlite"
 [import]
 base_path = "/var/sota/import"
 tls_cacert_path = "root.crt"
-tls_clientcert_path = "client.pem"
-tls_pkey_path = "pkey.pem"

--- a/config/sota_implicit_prov.toml
+++ b/config/sota_implicit_prov.toml
@@ -1,7 +1,0 @@
-[storage]
-type = "sqlite"
-
-[import]
-base_path = "/var/sota/import"
-tls_pkey_path = "pkey.pem"
-tls_clientcert_path = "client.pem"

--- a/config/sota_implicit_prov_ca.toml
+++ b/config/sota_implicit_prov_ca.toml
@@ -5,6 +5,7 @@ server_url_path = "/var/sota/gateway.url"
 type = "sqlite"
 
 [import]
-tls_cacert_path = "/var/sota/import_root.crt"
-tls_clientcert_path = "/var/sota/import_client.pem"
-tls_pkey_path = "/var/sota/import_pkey.pem"
+base_path = "/var/sota/import"
+tls_cacert_path = "root.crt"
+tls_clientcert_path = "client.pem"
+tls_pkey_path = "pkey.pem"

--- a/src/cert_provider/main.cc
+++ b/src/cert_provider/main.cc
@@ -490,13 +490,13 @@ int main(int argc, char* argv[]) {
 
   if (!local_dir.empty()) {
     std::cout << "Writing client certificate and keys to " << local_dir << " ...\n";
-    copyLocal(tmp_pkey_file.PathString(), local_dir / pkey_file.get("").filename());
-    copyLocal(tmp_cert_file.PathString(), local_dir / cert_file.get("").filename());
+    copyLocal(tmp_pkey_file.PathString(), local_dir / pkey_file.get(directory));
+    copyLocal(tmp_cert_file.PathString(), local_dir / cert_file.get(directory));
     if (provide_ca) {
-      copyLocal(tmp_ca_file.PathString(), local_dir / ca_file.get("").filename());
+      copyLocal(tmp_ca_file.PathString(), local_dir / ca_file.get(directory));
     }
     if (provide_url) {
-      copyLocal(tmp_url_file.PathString(), local_dir / url_file.get("").filename());
+      copyLocal(tmp_url_file.PathString(), local_dir / url_file.get(""));
     }
     std::cout << "...success\n";
   }

--- a/tests/hsm_prov_test.py
+++ b/tests/hsm_prov_test.py
@@ -119,7 +119,7 @@ def provision(tmp_dir, build_dir, src_dir, creds, pkcs11_module):
     # Run cert_provider.
     print('Device has not yet provisioned (as expected). Running cert_provider.')
     stdout, stderr, retcode = run_subprocess([str(akt_cp),
-        '-c', str(creds), '-l', str(certs_dir), '-r', '-s', '-g', str(conf_prov)])
+        '-c', str(creds), '-l', '/', '-r', '-s', '-g', str(conf_prov)])
     if retcode > 0:
         print('aktualizr_cert_provider failed (' + str(retcode) + '): ' +
               stderr.decode() + stdout.decode())

--- a/tests/implicit_prov_test.py
+++ b/tests/implicit_prov_test.py
@@ -33,6 +33,7 @@ path = "{tmp_dir}"
 type = "sqlite"
 
 [import]
+base_path = "{tmp_dir}/import"
 tls_pkey_path = "{pkey_path}"
 tls_clientcert_path = "{clientcert_path}"
 '''
@@ -45,8 +46,8 @@ def provision(tmp_dir, build_dir, creds):
     conf_server = conf_dir / '30-implicit_server.toml'
     with conf_prov.open('w') as f:
         f.write(CONFIG_TEMPLATE.format(tmp_dir=tmp_dir,
-                                       pkey_path=tmp_dir / 'import/pkey.pem',
-                                       clientcert_path=tmp_dir / 'import/client.pem'
+                                       pkey_path='pkey.pem',
+                                       clientcert_path='client.pem'
                                        ))
     akt = build_dir / 'src/aktualizr_primary/aktualizr'
     akt_info = build_dir / 'src/aktualizr_info/aktualizr-info'
@@ -84,7 +85,7 @@ def provision(tmp_dir, build_dir, creds):
     # Run cert_provider.
     print('Device has not yet provisioned (as expected). Running cert_provider.')
     stdout, stderr, retcode = run_subprocess([str(akt_cp),
-        '-c', str(creds), '-l', str(tmp_dir / 'import'), '-s', '-g', str(conf_prov)])
+        '-c', str(creds), '-l', '/', '-s', '-g', str(conf_prov)])
     if retcode > 0:
         print('aktualizr_cert_provider failed (' + str(retcode) + '): ' +
               stderr.decode() + stdout.decode())


### PR DESCRIPTION
- sota_implicit_prov is deprecated
- HSM provisioning should not import certificate and private key, they
belong to HSM, not to storage
- All the imported data should be under /var/sota/import
- Make cert provider respect path to import directory