### PR TITLE
Use upstream version of HdrHistogram

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/advancedtelematic/ostreesysroot
 [submodule "third_party/HdrHistogram_c"]
 	path = third_party/HdrHistogram_c
-	url = https://github.com/cajun-rat/HdrHistogram_c
+	url = https://github.com/HdrHistogram/HdrHistogram_c
 [submodule "third_party/googletest"]
 	path = third_party/googletest
 	url = https://github.com/google/googletest.git


### PR DESCRIPTION
Now includes Phil's fix! Using the old repo with a commit outside master was causing issues with bitbake.