### PR TITLE
Add lshw to xenial Dockerfile

### DIFF
--- a/docker/Dockerfile.ubuntu.xenial
+++ b/docker/Dockerfile.ubuntu.xenial
@@ -46,6 +46,7 @@ RUN apt-get update && apt-get -y install \
   libssl-dev \
   libsystemd-dev \
   libtool \
+  lshw \
   make \
   opensc \
   pkg-config \


### PR DESCRIPTION
It is now needed for the full run of the test suite (test_uptane)