### PR TITLE
Test/ota 815/ostree object

### DIFF
--- a/src/sota_tools/CMakeLists.txt
+++ b/src/sota_tools/CMakeLists.txt
@@ -113,12 +113,13 @@ set(ALL_SOTA_TOOLS_HEADERS
 if (NOT BUILD_SOTA_TOOLS)
     set (TEST_SOURCES
         authenticate_test.cc
-        ostree_hash_test.cc
-        rate_controller_test.cc
-        ostree_dir_repo_test.cc
-        ostree_http_repo_test.cc
-        treehub_server_test.cc
         deploy_test.cc
+        ostree_dir_repo_test.cc
+        ostree_hash_test.cc
+        ostree_http_repo_test.cc
+        ostree_object_test.cc
+        rate_controller_test.cc
+        treehub_server_test.cc
     )
 endif(NOT BUILD_SOTA_TOOLS)
 
@@ -141,6 +142,7 @@ if (BUILD_SOTA_TOOLS)
     add_aktualizr_test(NAME ostree_http_repo SOURCES ostree_http_repo_test.cc ${SOTA_TOOLS_LIB_SRC} PROJECT_WORKING_DIRECTORY)
     add_aktualizr_test(NAME treehub_server SOURCES treehub_server_test.cc ${SOTA_TOOLS_LIB_SRC} PROJECT_WORKING_DIRECTORY)
     add_aktualizr_test(NAME deploy SOURCES deploy_test.cc ${SOTA_TOOLS_LIB_SRC} PROJECT_WORKING_DIRECTORY)
+    add_aktualizr_test(NAME ostree_object SOURCES ostree_object_test.cc ${SOTA_TOOLS_LIB_SRC} PROJECT_WORKING_DIRECTORY)
 
     # Check the --help option works
     add_test(NAME option-help

--- a/src/sota_tools/CMakeLists.txt
+++ b/src/sota_tools/CMakeLists.txt
@@ -124,18 +124,18 @@ endif(NOT BUILD_SOTA_TOOLS)
 
 if (BUILD_SOTA_TOOLS)
     add_aktualizr_test(NAME sota_tools_auth_test SOURCES authenticate_test.cc
-                            PROJECT_WORKING_DIRECTORY NO_VALGRIND)
-        target_link_libraries(t_sota_tools_auth_test sota_tools_static_lib aktualizr_static_lib ${TEST_LIBS})
+                       PROJECT_WORKING_DIRECTORY NO_VALGRIND)
+    target_link_libraries(t_sota_tools_auth_test sota_tools_static_lib aktualizr_static_lib ${TEST_LIBS})
 
     add_aktualizr_test(NAME ostree_hash SOURCES ostree_hash_test.cc)
-        target_link_libraries(t_ostree_hash sota_tools_static_lib)
-        target_include_directories(t_ostree_hash
-                                PUBLIC ${PROJECT_SOURCE_DIR}/src/sota_tools ${GLIB2_INCLUDE_DIRS})
+    target_link_libraries(t_ostree_hash sota_tools_static_lib)
+    target_include_directories(t_ostree_hash
+                               PUBLIC ${PROJECT_SOURCE_DIR}/src/sota_tools ${GLIB2_INCLUDE_DIRS})
 
     add_aktualizr_test(NAME rate_controller SOURCES rate_controller_test.cc)
     target_link_libraries(t_rate_controller
-                        sota_tools_static_lib
-                        ${Boost_LIBRARIES})
+                          sota_tools_static_lib
+                          ${Boost_LIBRARIES})
 
     add_aktualizr_test(NAME ostree_dir_repo SOURCES ostree_dir_repo_test.cc ${SOTA_TOOLS_LIB_SRC} PROJECT_WORKING_DIRECTORY)
     add_aktualizr_test(NAME ostree_http_repo SOURCES ostree_http_repo_test.cc ${SOTA_TOOLS_LIB_SRC} PROJECT_WORKING_DIRECTORY)

--- a/src/sota_tools/authenticate_test.cc
+++ b/src/sota_tools/authenticate_test.cc
@@ -11,14 +11,14 @@
 #include "utilities/utils.h"
 
 TEST(authenticate, good_zip) {
-  boost::filesystem::path filepath = "sota_tools/auth_test_good.zip";
+  boost::filesystem::path filepath = "tests/sota_tools/auth_test_good.zip";
   TreehubServer treehub;
   int r = authenticate("", ServerCredentials(filepath), treehub);
   EXPECT_EQ(0, r);
 }
 
 TEST(authenticate, good_cert_zip) {
-  boost::filesystem::path filepath = "sota_tools/auth_test_cert_good.zip";
+  boost::filesystem::path filepath = "tests/sota_tools/auth_test_cert_good.zip";
   TreehubServer treehub;
   int r = authenticate("", ServerCredentials(filepath), treehub);
   EXPECT_EQ(0, r);
@@ -31,9 +31,9 @@ TEST(authenticate, good_cert_zip) {
 }
 
 TEST(authenticate, good_cert_noauth_zip) {
-  boost::filesystem::path filepath = "sota_tools/auth_test_noauth_good.zip";
+  boost::filesystem::path filepath = "tests/sota_tools/auth_test_noauth_good.zip";
   TreehubServer treehub;
-  int r = authenticate("fake_http_server/client.crt", ServerCredentials(filepath), treehub);
+  int r = authenticate("tests/fake_http_server/client.crt", ServerCredentials(filepath), treehub);
   EXPECT_EQ(0, r);
   CurlEasyWrapper curl_handle;
   curlEasySetoptWrapper(curl_handle.get(), CURLOPT_VERBOSE, 1);
@@ -44,7 +44,7 @@ TEST(authenticate, good_cert_noauth_zip) {
 }
 
 TEST(authenticate, bad_cert_zip) {
-  boost::filesystem::path filepath = "sota_tools/auth_test_cert_bad.zip";
+  boost::filesystem::path filepath = "tests/sota_tools/auth_test_cert_bad.zip";
   TreehubServer treehub;
   int r = authenticate("", ServerCredentials(filepath), treehub);
   EXPECT_EQ(0, r);
@@ -57,39 +57,39 @@ TEST(authenticate, bad_cert_zip) {
 }
 
 TEST(authenticate, bad_zip) {
-  boost::filesystem::path filepath = "sota_tools/auth_test_bad.zip";
+  boost::filesystem::path filepath = "tests/sota_tools/auth_test_bad.zip";
   TreehubServer treehub;
   int r = authenticate("", ServerCredentials(filepath), treehub);
   EXPECT_EQ(1, r);
 }
 
 TEST(authenticate, no_json_zip) {
-  boost::filesystem::path filepath = "sota_tools/auth_test_no_json.zip";
+  boost::filesystem::path filepath = "tests/sota_tools/auth_test_no_json.zip";
   EXPECT_THROW(ServerCredentials creds(filepath), BadCredentialsContent);
 }
 
 TEST(authenticate, good_json) {
-  boost::filesystem::path filepath = "sota_tools/auth_test_good.json";
+  boost::filesystem::path filepath = "tests/sota_tools/auth_test_good.json";
   TreehubServer treehub;
   int r = authenticate("", ServerCredentials(filepath), treehub);
   EXPECT_EQ(0, r);
 }
 
 TEST(authenticate, bad_json) {
-  boost::filesystem::path filepath = "sota_tools/auth_test_bad.json";
+  boost::filesystem::path filepath = "tests/sota_tools/auth_test_bad.json";
   TreehubServer treehub;
   int r = authenticate("", ServerCredentials(filepath), treehub);
   EXPECT_EQ(1, r);
 }
 
 TEST(authenticate, invalid_file) {
-  boost::filesystem::path filepath = "sota_tools/auth_test.cc";
+  boost::filesystem::path filepath = "tests/sota_tools/auth_test.cc";
   EXPECT_THROW(ServerCredentials creds(filepath), BadCredentialsJson);
 }
 
 TEST(authenticate, offline_sign_creds) {
-  boost::filesystem::path auth_offline = "sota_tools/auth_test_good_offline.zip";
-  boost::filesystem::path auth_online = "sota_tools/auth_test_cert_good.zip";
+  boost::filesystem::path auth_offline = "tests/sota_tools/auth_test_good_offline.zip";
+  boost::filesystem::path auth_online = "tests/sota_tools/auth_test_cert_good.zip";
 
   ServerCredentials creds_offline(auth_offline);
   ServerCredentials creds_online(auth_online);
@@ -100,10 +100,8 @@ TEST(authenticate, offline_sign_creds) {
 #ifndef __NO_MAIN__
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  int result = chdir("tests");  // TODO
-  (void)result;
-  TestHelperProcess server_process("fake_http_server/ssl_server.py", "");
-  TestHelperProcess server_noauth_process("fake_http_server/ssl_noauth_server.py", "");
+  TestHelperProcess server_process("tests/fake_http_server/ssl_server.py", "");
+  TestHelperProcess server_noauth_process("tests/fake_http_server/ssl_noauth_server.py", "");
   sleep(4);
   return RUN_ALL_TESTS();
 }

--- a/src/sota_tools/deploy_test.cc
+++ b/src/sota_tools/deploy_test.cc
@@ -6,6 +6,7 @@
 #include "ostree_http_repo.h"
 #include "ostree_ref.h"
 #include "test_utils.h"
+
 std::string port = "2443";
 TemporaryDirectory temp_dir;
 

--- a/src/sota_tools/ostree_http_repo_test.cc
+++ b/src/sota_tools/ostree_http_repo_test.cc
@@ -3,7 +3,9 @@
 #include "deploy.h"
 #include "ostree_http_repo.h"
 #include "ostree_ref.h"
+#include "server_credentials.h"
 #include "test_utils.h"
+
 std::string port;
 
 TEST(http_repo, valid_repo) {

--- a/src/sota_tools/ostree_object.cc
+++ b/src/sota_tools/ostree_object.cc
@@ -25,6 +25,13 @@ OSTreeObject::OSTreeObject(const OSTreeRepo &repo, const std::string &object_nam
   assert(boost::filesystem::is_regular_file(file_path_));
 }
 
+OSTreeObject::~OSTreeObject() {
+  if (curl_handle_ != nullptr) {
+    curl_easy_cleanup(curl_handle_);
+    curl_handle_ = nullptr;
+  }
+}
+
 void OSTreeObject::AddParent(OSTreeObject *parent, std::list<OSTreeObject::ptr>::iterator parent_it) {
   parentref par;
 
@@ -67,7 +74,7 @@ void OSTreeObject::PopulateChildren() {
   const GVariantType *content_type;
   bool is_commit;
 
-  // variant types are borrowed from libostree/ostree_core.h,
+  // variant types are borrowed from libostree/ostree-core.h,
   // but we don't want to create dependency on it
   if (ext.compare(".commit") == 0) {
     content_type = G_VARIANT_TYPE("(a{sv}aya(say)sstayay)");
@@ -320,13 +327,6 @@ size_t OSTreeObject::curl_handle_write(void *buffer, size_t size, size_t nmemb, 
   auto *that = static_cast<OSTreeObject *>(userp);
   that->http_response_.write(static_cast<const char *>(buffer), static_cast<std::streamsize>(size * nmemb));
   return size * nmemb;
-}
-
-OSTreeObject::~OSTreeObject() {
-  if (curl_handle_ != nullptr) {
-    curl_easy_cleanup(curl_handle_);
-    curl_handle_ = nullptr;
-  }
 }
 
 OSTreeObject::ptr ostree_object_from_curl(CURL *curlhandle) {

--- a/src/sota_tools/ostree_object.cc
+++ b/src/sota_tools/ostree_object.cc
@@ -235,6 +235,7 @@ void OSTreeObject::Upload(const TreehubServer &push_target, CURLM *curl_multi_ha
   const CURLMcode err = curl_multi_add_handle(curl_multi_handle, curl_handle_);
   if (err != 0) {
     LOG_ERROR << "curl_multi_add_handle error:" << curl_multi_strerror(err);
+    return;
   }
   refcount_++;  // Because curl now has a reference to us
   request_start_time_ = std::chrono::steady_clock::now();

--- a/src/sota_tools/ostree_object.h
+++ b/src/sota_tools/ostree_object.h
@@ -34,32 +34,27 @@ class OSTreeObject {
 
   ~OSTreeObject();
 
-  PresenceOnServer is_on_server() const { return is_on_server_; }
-  CurrentOp operation() const { return current_operation_; }
-
+  void NotifyParents(RequestPool& pool);
+  void MakeTestRequest(const TreehubServer& push_target, CURLM* curl_multi_handle);
+  void Upload(const TreehubServer& push_target, CURLM* curl_multi_handle, bool dryrun);
   void CurlDone(CURLM* curl_multi_handle, RequestPool& pool);
 
-  void MakeTestRequest(const TreehubServer& push_target, CURLM* curl_multi_handle);
-
-  void Upload(const TreehubServer& push_target, CURLM* curl_multi_handle, bool dryrun);
-
-  void AddParent(OSTreeObject* parent, std::list<OSTreeObject::ptr>::iterator parent_it);
+  PresenceOnServer is_on_server() const { return is_on_server_; }
+  CurrentOp operation() const { return current_operation_; }
   bool children_ready() { return children_.empty(); }
-  void PopulateChildren();
-  void QueryChildren(RequestPool& pool);
-  void NotifyParents(RequestPool& pool);
-  void ChildNotify(std::list<OSTreeObject::ptr>::iterator child_it);
   void LaunchNotify() { is_on_server_ = PresenceOnServer::kObjectInProgress; }
-
   std::chrono::steady_clock::time_point RequestStartTime() const { return request_start_time_; }
-
   ServerResponse LastOperationResult() const { return last_operation_result_; }
 
  private:
   using childiter = std::list<OSTreeObject::ptr>::iterator;
   typedef std::pair<OSTreeObject*, childiter> parentref;
 
+  void AddParent(OSTreeObject* parent, std::list<OSTreeObject::ptr>::iterator parent_it);
+  void ChildNotify(std::list<OSTreeObject::ptr>::iterator child_it);
   void AppendChild(const OSTreeObject::ptr& child);
+  void PopulateChildren();
+  void QueryChildren(RequestPool& pool);
   std::string Url() const;
   void PresenceUnknown(RequestPool& pool, int64_t rescode);
   void ObjectMissing(RequestPool& pool, int64_t rescode);

--- a/src/sota_tools/ostree_object.h
+++ b/src/sota_tools/ostree_object.h
@@ -6,6 +6,7 @@
 #include <sstream>
 
 #include <curl/curl.h>
+#include <gtest/gtest.h>
 #include <boost/filesystem.hpp>
 #include <boost/intrusive_ptr.hpp>
 
@@ -61,6 +62,10 @@ class OSTreeObject {
 
   static size_t curl_handle_write(void* buffer, size_t size, size_t nmemb, void* userp);
 
+  FRIEND_TEST(OstreeObject, Request);
+  FRIEND_TEST(OstreeObject, UploadDryRun);
+  FRIEND_TEST(OstreeObject, UploadFail);
+  FRIEND_TEST(OstreeObject, UploadSuccess);
   friend void intrusive_ptr_add_ref(OSTreeObject* /*h*/);
   friend void intrusive_ptr_release(OSTreeObject* /*h*/);
   friend std::ostream& operator<<(std::ostream& stream, const OSTreeObject& o);

--- a/tests/fake_http_server/ssl_noauth_server.py
+++ b/tests/fake_http_server/ssl_noauth_server.py
@@ -3,6 +3,9 @@ from http.server import HTTPServer,SimpleHTTPRequestHandler
 import ssl
 
 httpd = HTTPServer(('localhost', 2443), SimpleHTTPRequestHandler)
-httpd.socket = ssl.wrap_socket (httpd.socket, certfile='fake_http_server/client.crt', keyfile='fake_http_server/client.key',
-    server_side=True, ca_certs = "fake_http_server/client.crt")
+httpd.socket = ssl.wrap_socket (httpd.socket,
+                                certfile='tests/fake_http_server/client.crt',
+                                keyfile='tests/fake_http_server/client.key',
+                                server_side=True,
+                                ca_certs = "tests/fake_http_server/client.crt")
 httpd.serve_forever()

--- a/tests/fake_http_server/ssl_server.py
+++ b/tests/fake_http_server/ssl_server.py
@@ -3,6 +3,10 @@ from http.server import HTTPServer,SimpleHTTPRequestHandler
 import ssl
 
 httpd = HTTPServer(('localhost', 1443), SimpleHTTPRequestHandler)
-httpd.socket = ssl.wrap_socket (httpd.socket, certfile='fake_http_server/client.crt', keyfile='fake_http_server/client.key',
-    server_side=True, cert_reqs = ssl.CERT_REQUIRED, ca_certs = "fake_http_server/client.crt")
+httpd.socket = ssl.wrap_socket (httpd.socket,
+                                certfile='tests/fake_http_server/client.crt',
+                                keyfile='tests/fake_http_server/client.key',
+                                server_side=True,
+                                cert_reqs = ssl.CERT_REQUIRED,
+                                ca_certs = "tests/fake_http_server/client.crt")
 httpd.serve_forever()

--- a/tests/sota_tools/treehub_deploy_server.py
+++ b/tests/sota_tools/treehub_deploy_server.py
@@ -16,11 +16,11 @@ class TreehubServerHandler(BaseHTTPRequestHandler):
         BaseHTTPRequestHandler.__init__(self, *args)
 
     def do_HEAD(self):
-        print("HEAD: %s\n"%self.path)
+        print("HEAD: %s\n" % self.path)
         self.send_response_only(404)
         self.end_headers()
     def do_POST(self):
-        print("POST: %s\n"%self.path)
+        print("POST: %s\n" % self.path)
         ctype, pdict = cgi.parse_header(self.headers['Content-Type'])
         if ctype == 'multipart/form-data':
             pdict['boundary'] = bytes(pdict['boundary'], 'utf-8')
@@ -42,12 +42,16 @@ class ReUseHTTPServer(HTTPServer):
         self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         HTTPServer.server_bind(self)
 
+
 tmp_dir = sys.argv[2]
 server_address = ('', int(sys.argv[1]))
 httpd = ReUseHTTPServer(server_address, TreehubServerHandler)
 
-httpd.socket = ssl.wrap_socket (httpd.socket, certfile='tests/fake_http_server/client.crt', keyfile='tests/fake_http_server/client.key',
-     server_side=True, ca_certs = "tests/fake_http_server/client.crt")
+httpd.socket = ssl.wrap_socket (httpd.socket,
+                                certfile='tests/fake_http_server/client.crt',
+                                keyfile='tests/fake_http_server/client.key',
+                                server_side=True,
+                                ca_certs = "tests/fake_http_server/client.crt")
 
 try:
     httpd.serve_forever()


### PR DESCRIPTION
Unit tests for OSTreeObject class.

Really only covers the constructor, MakeTestRequest, and Upload. These are the components that are easiest to verify and have the most external interaction. Testing CurlDone or the various OSTree parsing bits might be interesting, but it is quite difficult to decouple from other parts of the code, and the whole of it is already covered by higher-level tests. I'll take suggestsions for improvements, but I think this is a good start.