### PR TITLE
Read secondary configs json from one directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,74 @@
+# Changelog
+
+This file summarizes notable changes introduced in aktualizr version. It roughly follows the guidelines from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+Our versioning scheme is `YEAR.N` where `N` is incremented whenever a new release is deemed necessary. Thus it does not exactly map to months of the year.
+
+## [2018.13 (unreleased)]
+
+### Changed
+
+- Secondaries configuration files must now lie in a common directory which is passed in command line arguments or in static configuration
+
+## [2018.12] - 2018-10-10
+
+### Changed
+
+- Updates in aktualizr api
+- `sota_implicit_prov` is deprecated
+- All the imported data should be under /var/sota/import
+
+### Fixed
+
+- HSM provisioning should not import certificate and private key, they belong to HSM, not to storage
+- Make cert provider respect path to import directory
+
+## [2018.11] - 2018-09-05
+
+### Fixed
+
+- Really remove the local tuf repo before and after garage-sign.
+
+## [2018.10] - 2018-09-04
+
+### Added
+
+- garage-deploy and aktualizr releases for Ubuntu 18.04
+
+### Fixed
+
+- Prevent re-use of existing tuf repos
+
+## [2018.9] - 2018-08-30
+
+### Fixed
+
+- Fixes to garage-deploy to improve reliability and logging
+
+## [2018.8] - 2018-08-16
+
+### Fixed
+
+- Bug with path concatenation in garage-deploy
+
+## [2018.7] - 2018-05-31
+
+### Changed
+
+- garage-deploy package is now built against Ubuntu 16.04
+
+## [2018.6] - 2018-05-28
+
+### Fixed
+
+- Expiration in garage-sign
+
+## [2018.5] - 2018-02-26
+
+## [2018.4] - 2018-02-23
+
+## [2018.3] - 2018-02-16
+
+## [2018.2] - 2018-02-16
+
+## [2018.1] - 2018-02-05

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -6,13 +6,13 @@ install(FILES systemd/aktualizr-ubuntu.service
         COMPONENT aktualizr)
 
 install(FILES sota_ubuntu.toml
-        DESTINATION lib/sota
+        DESTINATION lib/sota/conf.d
         RENAME sota.toml
         PERMISSIONS OWNER_READ OWNER_WRITE
         COMPONENT aktualizr)
 
 install(FILES secondary/virtualsec.json
-        DESTINATION lib/sota
+        DESTINATION lib/sota/secondaries
         RENAME demo_secondary.json
         PERMISSIONS OWNER_READ OWNER_WRITE
         COMPONENT aktualizr)

--- a/config/sota_ubuntu.toml
+++ b/config/sota_ubuntu.toml
@@ -2,6 +2,9 @@
 provision_path = "/var/sota/sota_provisioning_credentials.zip"
 primary_ecu_hardware_id = "ubuntu"
 
+[uptane]
+secondary_configs_dir = "/usr/lib/sota/secondaries"
+
 [storage]
 type = "sqlite"
 

--- a/config/systemd/aktualizr-ubuntu.service
+++ b/config/systemd/aktualizr-ubuntu.service
@@ -7,7 +7,6 @@ Requires=network-online.target
 [Service]
 RestartSec=10
 Restart=always
-Environment="AKTUALIZR_SECONDARY_CONFIG=--secondary-config /usr/lib/sota/demo_secondary.json"
 EnvironmentFile=-/usr/lib/sota/sota.env
 ExecStart=/usr/bin/aktualizr --config /usr/lib/sota/sota.toml $AKTUALIZR_SECONDARY_CONFIG
 

--- a/config/systemd/aktualizr-ubuntu.service
+++ b/config/systemd/aktualizr-ubuntu.service
@@ -8,7 +8,7 @@ Requires=network-online.target
 RestartSec=10
 Restart=always
 EnvironmentFile=-/usr/lib/sota/sota.env
-ExecStart=/usr/bin/aktualizr --config /usr/lib/sota/sota.toml $AKTUALIZR_SECONDARY_CONFIG
+ExecStart=/usr/bin/aktualizr --config /usr/lib/sota/sota.toml
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/deb-package-install.adoc
+++ b/docs/deb-package-install.adoc
@@ -10,10 +10,10 @@ sudo apt install ./aktualizr.deb
 
 The debian package will install, enable, and start an `aktualizr` systemd service immediately after it's installed. However, there are some configuration steps that should be taken before the service starts. To use aktualizr with a server (i.e. https://github.com/advancedtelematic/ota-community-edition/[OTA Community Edition] or https://docs.atsgarage.com[HERE OTA Connect]), you will need to download the provisioning credentials file provided by the server and place it at `/var/sota/sota_provisioning_credentials.zip`.
 
-Additionally, if you wish to pass extra command line arguments to aktualizr, you can do so by creating `/usr/lib/sota/sota.env` to set the `AKTUALIZR_SECONDARY_CONFIG` environment variable. For example, to enable a secondary ECU with a config file at `/var/sota/sec_ecu.json`, the contents of the file would be:
+Additionally, if you wish to pass extra command line arguments to aktualizr, you can do so by creating `/usr/lib/sota/sota.env` to set the `AKTUALIZR_SECONDARY_CONFIG` environment variable. For example, to set up the log level to debug:
 
 ----
-AKTUALIZR_SECONDARY_CONFIG="--secondary-config /var/sota/sec_ecu.json"
+AKTUALIZR_SECONDARY_CONFIG="--loglevel 0"
 ----
 
 You can pass any other command line arguments in this file, as well.

--- a/docs/deb-package-install.adoc
+++ b/docs/deb-package-install.adoc
@@ -10,23 +10,13 @@ sudo apt install ./aktualizr.deb
 
 The debian package will install, enable, and start an `aktualizr` systemd service immediately after it's installed. However, there are some configuration steps that should be taken before the service starts. To use aktualizr with a server (i.e. https://github.com/advancedtelematic/ota-community-edition/[OTA Community Edition] or https://docs.atsgarage.com[HERE OTA Connect]), you will need to download the provisioning credentials file provided by the server and place it at `/var/sota/sota_provisioning_credentials.zip`.
 
-Additionally, if you wish to pass extra command line arguments to aktualizr, you can do so by creating `/usr/lib/sota/sota.env` to set the `AKTUALIZR_SECONDARY_CONFIG` environment variable. For example, to set up the log level to debug:
-
-----
-AKTUALIZR_SECONDARY_CONFIG="--loglevel 0"
-----
-
 You can pass any other command line arguments in this file, as well.
 
 For security reasons, we recommend creating the `/usr/lib/sota/sota.env` file even if you aren't going to use it. The file should be owned by root, with `600` permissions.
 
 === Secondary ECUs
 
-The debian package ships with a default secondary ECU configured. This acts like a dummy device, dropping whatever file you send it into `/tmp/demo-virtual-secondary/firmware.bin`. If you want to override this default, you'll need to create `/usr/lib/sota/sota.env` and override `AKTUALIZR_SECONDARY_CONFIG` with a blank string, like so:
-
-----
-AKTUALIZR_SECONDARY_CONFIG=""
-----
+The debian package ships with a default secondary ECU configured. This acts like a dummy device, dropping whatever file you send it into `/tmp/demo-virtual-secondary/firmware.bin`.
 
 === Building the debian package
 

--- a/docs/debugging-tips.adoc
+++ b/docs/debugging-tips.adoc
@@ -32,7 +32,9 @@ Edit ../config/basic.toml to point `provision_path` to your automatic provisioni
     src/aktualizr_primary/aktualizr --config ../config/basic.toml
 
 == Debuging secondaries update
+
 To do it, You need to create temporary OSTree environment described above and add `sysroot` and `os` to your config file:
+
 ```
 [ostree]
 os = "myos"
@@ -40,7 +42,8 @@ sysroot = "/tmp/sysroot "
 
 ```
 
-Then for each secondary You need to create a config file:
+Then for each secondary you need to create a config file:
+
 ```
 {
     "ecu_serial": "Your secondary serial",
@@ -49,11 +52,13 @@ Then for each secondary You need to create a config file:
     "ecu_public_key": "/tmp/pub.key",
     "firmware_path": "/firmware.txt"
 }
-
 ```
+
+Then, save them as `.json` files in a common directory.
+
 Now You are ready to run aktualizr:
 
-`./aktualizr -c config.toml --secondary-config mysecondary1.json --secondary-config mysecondary2.json`
+`./aktualizr -c config.toml --secondary-config secondaries_dir`
 
 This will create needed keys and register Your secondaries. But currently You cannot shcedule updates
 for secondaries because of it is not implemented in UI. So You have 2 options, You can change the ecu_serial

--- a/src/aktualizr_primary/main.cc
+++ b/src/aktualizr_primary/main.cc
@@ -41,7 +41,7 @@ bpo::variables_map parse_options(int argc, char *argv[]) {
       ("ostree-server", bpo::value<std::string>(), "url of the ostree repository")
       ("primary-ecu-serial", bpo::value<std::string>(), "serial number of primary ecu")
       ("primary-ecu-hardware-id", bpo::value<std::string>(), "hardware ID of primary ecu")
-      ("secondary-config", bpo::value<std::vector<boost::filesystem::path> >()->composing(), "secondary ECU json configuration file")
+      ("secondary-configs-dir", bpo::value<boost::filesystem::path>(), "directory containing secondary ECU configuration files")
       ("campaign-id", bpo::value<std::string>(), "id of the campaign to act on");
   // clang-format on
 

--- a/src/hmi_stub/main.cc
+++ b/src/hmi_stub/main.cc
@@ -45,7 +45,7 @@ bpo::variables_map parse_options(int argc, char *argv[]) {
       ("help,h", "print usage")
       ("version,v", "Current aktualizr version")
       ("config,c", bpo::value<std::vector<boost::filesystem::path> >()->composing(), "configuration file or directory")
-      ("secondary", bpo::value<std::vector<boost::filesystem::path> >()->composing(), "secondary ECU json configuration file")
+      ("secondary-configs-dir", bpo::value<boost::filesystem::path>(), "directory containing seconday ECU configuration files")
       ("loglevel", bpo::value<int>(), "set log level 0-5 (trace, debug, info, warning, error, fatal)");
   // clang-format on
 
@@ -144,13 +144,6 @@ int main(int argc, char *argv[]) {
     std::function<void(const std::shared_ptr<event::BaseEvent> event)> f_cb =
         [&aktualizr](const std::shared_ptr<event::BaseEvent> event) { process_event(aktualizr, event); };
     conn = aktualizr.SetSignalHandler(f_cb);
-
-    if (commandline_map.count("secondary") != 0) {
-      auto sconfigs = commandline_map["secondary"].as<std::vector<boost::filesystem::path>>();
-      for (const auto &sconf : sconfigs) {
-        aktualizr.AddSecondary(Uptane::SecondaryFactory::makeSecondary(sconf));
-      }
-    }
 
     aktualizr.Initialize();
 

--- a/src/libaktualizr/config/config.h
+++ b/src/libaktualizr/config/config.h
@@ -76,6 +76,7 @@ struct UptaneConfig {
   std::string repo_server;
   CryptoSource key_source{CryptoSource::kFile};
   KeyType key_type{KeyType::kRSA2048};
+  boost::filesystem::path secondary_configs_dir;
   std::vector<Uptane::SecondaryConfig> secondary_configs{};
 
   void updateFromPropertyTree(const boost::property_tree::ptree& pt);
@@ -127,7 +128,7 @@ class Config : public BaseConfig {
  private:
   void updateFromPropertyTree(const boost::property_tree::ptree& pt) override;
   void updateFromCommandLine(const boost::program_options::variables_map& cmd);
-  void readSecondaryConfigs(const std::vector<boost::filesystem::path>& sconfigs);
+  void readSecondaryConfigs(const boost::filesystem::path& sconfigs_dir);
 
   std::vector<boost::filesystem::path> config_dirs_ = {"/usr/lib/sota/conf.d", "/etc/sota/conf.d/"};
   bool loglevel_from_cmdline{false};

--- a/src/libaktualizr/config/config_test.cc
+++ b/src/libaktualizr/config/config_test.cc
@@ -107,12 +107,11 @@ TEST(config, SecondaryConfig) {
   bpo::options_description description("some text");
   // clang-format off
   description.add_options()
-    ("secondary-config", bpo::value<std::vector<boost::filesystem::path> >()->composing(), "secondary ECU json configuration file")
-    ("config,c", bpo::value<std::vector<boost::filesystem::path> >()->composing(), "configuration directory");
+    ("secondary-configs-dir", bpo::value<boost::filesystem::path>(), "directory containing secondary ECU configuration files")
+    ("config,c", bpo::value<std::vector<boost::filesystem::path> >()->composing(), "configuration file or directory");
 
   // clang-format on
-  const char *argv[] = {"aktualizr", "--secondary-config", "config/secondary/virtualsec.json", "-c",
-                        conf_path_str.c_str()};
+  const char *argv[] = {"aktualizr", "--secondary-configs-dir", "config/secondary", "-c", conf_path_str.c_str()};
   bpo::store(bpo::parse_command_line(5, argv, description), cmd);
 
   Config conf(cmd);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -152,11 +152,11 @@ add_test(NAME test-help-with-nonexistent-options
 set_tests_properties(test-help-with-nonexistent-options
                      PROPERTIES PASS_REGULAR_EXPRESSION "aktualizr command line options")
 
-add_test(NAME test-secondary-config-with-nonexistent-file
+add_test(NAME test-secondary-config-with-nonexisting-dir
          COMMAND aktualizr -c ${PROJECT_SOURCE_DIR}/config/sota_autoprov.toml
-         --tls-server fake --secondary-config nonexistentfile)
-set_tests_properties(test-secondary-config-with-nonexistent-file
-                     PROPERTIES PASS_REGULAR_EXPRESSION "nonexistentfile does not exist!")
+         --tls-server fake --secondary-configs-dir nonexistingdir)
+set_tests_properties(test-secondary-config-with-nonexisting-dir
+                     PROPERTIES PASS_REGULAR_EXPRESSION "\"nonexistingdir\": not a directory")
 
 # Check verbose config parsing output with debug loglevel.
 add_test(NAME test_log_debug


### PR DESCRIPTION
It allows us to treat `secondary_configs_dir` as a regular configuration option, which can be set in the main configuration and not only from the command line.

Will need changes in meta-updater and probably docs. Shout if you don't agree!