### PR TITLE
Only ship ubuntu config files with BUILD_DEB=on

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -1,21 +1,21 @@
-
-install(FILES systemd/aktualizr-ubuntu.service
+if(BUILD_DEB)
+    install(FILES systemd/aktualizr-ubuntu.service
         DESTINATION lib/systemd/system
         RENAME aktualizr.service
         PERMISSIONS OWNER_READ OWNER_WRITE
         COMPONENT aktualizr)
 
-install(FILES sota_ubuntu.toml
+    install(FILES sota_ubuntu.toml
         DESTINATION lib/sota/conf.d
-        RENAME sota.toml
         PERMISSIONS OWNER_READ OWNER_WRITE
         COMPONENT aktualizr)
 
-install(FILES secondary/virtualsec.json
+    install(FILES secondary/virtualsec.json
         DESTINATION lib/sota/secondaries
         RENAME demo_secondary.json
         PERMISSIONS OWNER_READ OWNER_WRITE
         COMPONENT aktualizr)
+endif(BUILD_DEB)
 
 install(DIRECTORY DESTINATION /etc/sota/conf.d COMPONENT aktualizr)
 install(DIRECTORY DESTINATION lib/sota/conf.d COMPONENT aktualizr)


### PR DESCRIPTION
We end up removing these files in meta-updater, so bettter not creating them in the first place