### PR TITLE
Fix/ota 1403/secondary configs and debian

### DIFF
--- a/config/systemd/aktualizr-ubuntu.service
+++ b/config/systemd/aktualizr-ubuntu.service
@@ -7,8 +7,7 @@ Requires=network-online.target
 [Service]
 RestartSec=10
 Restart=always
-EnvironmentFile=-/usr/lib/sota/sota.env
-ExecStart=/usr/bin/aktualizr --config /usr/lib/sota/sota.toml
+ExecStart=/usr/bin/aktualizr
 
 [Install]
 WantedBy=multi-user.target

--- a/src/libaktualizr/primary/initializer.cc
+++ b/src/libaktualizr/primary/initializer.cc
@@ -251,6 +251,10 @@ Initializer::Initializer(
       return;
     }
 
+    for (auto it = secondary_info_.begin(); it != secondary_info_.end(); ++it) {
+      it->second->Initialize();
+    }
+
     // TODO: acknowledge on server _before_ setting the flag
     storage_->storeEcuRegistered();
     success_ = true;

--- a/src/libaktualizr/uptane/managedsecondary.h
+++ b/src/libaktualizr/uptane/managedsecondary.h
@@ -24,6 +24,8 @@ class ManagedSecondary : public SecondaryInterface {
   explicit ManagedSecondary(const SecondaryConfig& sconfig_in);
   ~ManagedSecondary() override = default;
 
+  void Initialize() override;
+
   EcuSerial getSerial() override {
     if (!sconfig.ecu_serial.empty()) {
       return EcuSerial(sconfig.ecu_serial);

--- a/src/libaktualizr/uptane/secondaryinterface.h
+++ b/src/libaktualizr/uptane/secondaryinterface.h
@@ -23,6 +23,7 @@ class SecondaryInterface {
  public:
   explicit SecondaryInterface(SecondaryConfig sconfig_in) : sconfig(std::move(sconfig_in)) {}
   virtual ~SecondaryInterface() = default;
+  virtual void Initialize(){};  // optional step, called after device registration
   virtual EcuSerial getSerial() { return Uptane::EcuSerial(sconfig.ecu_serial); }
   virtual Uptane::HardwareIdentifier getHwId() { return Uptane::HardwareIdentifier(sconfig.ecu_hardware_id); }
   virtual PublicKey getPublicKey() = 0;


### PR DESCRIPTION
Save secondary keys at the end of the device registration.

Would have made my debugging much easier.