### PR TITLE
Return values for pause and resume.

### DIFF
--- a/src/hmi_stub/main.cc
+++ b/src/hmi_stub/main.cc
@@ -108,6 +108,8 @@ void process_event(const std::shared_ptr<event::BaseEvent> &event) {
     const auto install_complete = dynamic_cast<event::InstallTargetComplete *>(event.get());
     std::cout << "Installation complete for device " << install_complete->serial.ToString() << ": "
               << (install_complete->success ? "success" : "failure") << "\n";
+  } else if (event->variant == "DownloadPaused" || event->variant == "DownloadResumed") {
+    // Do nothing.
   } else {
     std::cout << "Received " << event->variant << " event\n";
   }
@@ -158,9 +160,34 @@ int main(int argc, char *argv[]) {
       } else if (buffer == "campaigncheck") {
         aktualizr.CampaignCheck();
       } else if (buffer == "pause") {
-        aktualizr.Pause();
+        PauseResult pause_result = aktualizr.Pause();
+        switch (pause_result) {
+          case PauseResult::kPaused:
+            std::cout << "Download paused.\n";
+            break;
+          case PauseResult::kAlreadyPaused:
+            std::cout << "Download already paused.\n";
+            break;
+          case PauseResult::kNotDownloading:
+            std::cout << "Download is not in progress.\n";
+            break;
+          default:
+            std::cout << "Unrecognized pause result.\n";
+            break;
+        }
       } else if (buffer == "resume") {
-        aktualizr.Resume();
+        PauseResult resume_result = aktualizr.Resume();
+        switch (resume_result) {
+          case PauseResult::kResumed:
+            std::cout << "Download resumed.\n";
+            break;
+          case PauseResult::kNotPaused:
+            std::cout << "Download not paused.\n";
+            break;
+          default:
+            std::cout << "Unrecognized resume result.\n";
+            break;
+        }
       } else if (!buffer.empty()) {
         std::cout << "Unknown command.\n";
       }

--- a/src/libaktualizr/primary/aktualizr.cc
+++ b/src/libaktualizr/primary/aktualizr.cc
@@ -97,9 +97,9 @@ InstallResult Aktualizr::Install(const std::vector<Uptane::Target> &updates) {
   return uptane_client_->uptaneInstall(updates);
 }
 
-void Aktualizr::Pause() { uptane_client_->pause(); }
+PauseResult Aktualizr::Pause() { return uptane_client_->pause(); }
 
-void Aktualizr::Resume() { uptane_client_->resume(); }
+PauseResult Aktualizr::Resume() { return uptane_client_->resume(); }
 
 boost::signals2::connection Aktualizr::SetSignalHandler(std::function<void(shared_ptr<event::BaseEvent>)> &handler) {
   return sig_->connect(handler);

--- a/src/libaktualizr/primary/aktualizr.h
+++ b/src/libaktualizr/primary/aktualizr.h
@@ -92,14 +92,16 @@ class Aktualizr {
   InstallResult Install(const std::vector<Uptane::Target>& updates);
 
   /**
-   * Pause download process.
+   * Pause a download current in progress.
+   * @return Information about pause results.
    */
-  void Pause();
+  PauseResult Pause();
 
   /**
-   * Resume download process.
+   * Resume a paused download.
+   * @return Information about resume results.
    */
-  void Resume();
+  PauseResult Resume();
 
   /**
    * Synchronously run an uptane cycle.

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -44,8 +44,8 @@ class SotaUptaneClient {
   void initialize();
   void addNewSecondary(const std::shared_ptr<Uptane::SecondaryInterface> &sec);
   DownloadResult downloadImages(const std::vector<Uptane::Target> &targets);
-  void pause() { uptane_fetcher->setPause(true); }
-  void resume() { uptane_fetcher->setPause(false); }
+  PauseResult pause() { return uptane_fetcher->setPause(true); }
+  PauseResult resume() { return uptane_fetcher->setPause(false); }
   void sendDeviceData();
   UpdateCheckResult fetchMeta();
   bool putManifest();

--- a/src/libaktualizr/uptane/fetcher.h
+++ b/src/libaktualizr/uptane/fetcher.h
@@ -7,6 +7,7 @@
 #include "http/httpinterface.h"
 #include "storage/invstorage.h"
 #include "utilities/events.h"
+#include "utilities/results.h"
 
 namespace Uptane {
 
@@ -39,9 +40,17 @@ class Fetcher {
     return fetchRole(result, maxsize, repo, role, Version());
   }
   bool isPaused() { return pause_; }
-  void setPause(bool pause);
+  PauseResult setPause(bool pause);
 
  private:
+  template <class T, class... Args>
+  void sendEvent(Args&&... args) {
+    std::shared_ptr<event::BaseEvent> event = std::make_shared<T>(std::forward<Args>(args)...);
+    if (events_channel) {
+      (*events_channel)(std::move(event));
+    }
+  }
+
   std::shared_ptr<HttpInterface> http;
   std::shared_ptr<INvStorage> storage;
   const Config& config;

--- a/src/libaktualizr/utilities/events.h
+++ b/src/libaktualizr/utilities/events.h
@@ -56,14 +56,22 @@ class UpdateCheckComplete : public BaseEvent {
   UpdateCheckResult result;
 };
 
+/**
+ * A download in progress has been paused.
+ */
 class DownloadPaused : public BaseEvent {
  public:
-  DownloadPaused() { variant = "DownloadPaused"; }
+  explicit DownloadPaused(PauseResult result_in) : result(result_in) { variant = "DownloadPaused"; }
+  PauseResult result;
 };
 
+/**
+ * A paused download has been resumed.
+ */
 class DownloadResumed : public BaseEvent {
  public:
-  DownloadResumed() { variant = "DownloadResumed"; }
+  explicit DownloadResumed(PauseResult result_in) : result(result_in) { variant = "DownloadResumed"; }
+  PauseResult result;
 };
 
 /**

--- a/src/libaktualizr/utilities/results.h
+++ b/src/libaktualizr/utilities/results.h
@@ -45,6 +45,24 @@ class UpdateCheckResult {
 };
 
 /**
+ * Result of an attempt to pause or resume a download.
+ */
+enum class PauseResult {
+  /* Download was paused successfully. */
+  kPaused = 0,
+  /* Download was resumed successfully. */
+  kResumed,
+  /* Download was already paused, so there is nothing to do. */
+  kAlreadyPaused,
+  /* Download has already completed, so there is nothing to do. */
+  kAlreadyComplete,
+  /* No download is in progress, so there is nothing to do. */
+  kNotDownloading,
+  /* Download was not paused, so there is nothing to do. */
+  kNotPaused,
+};
+
+/**
  * Status of an update download.
  */
 enum class DownloadStatus {


### PR DESCRIPTION
Sorry for the confusion of making a PR on a PR, but I realized we'd missed a requirement because of mutual misunderstanding (as in, I didn't realize we needed it until an hour ago) and I knew I could kick it out quickly. All this really does is add return values for pause/resume, since it is possible that they can succeed or fail for various reasons.