### PR TITLE
Make TestHelperProcess variadic

### DIFF
--- a/src/sota_tools/authenticate_test.cc
+++ b/src/sota_tools/authenticate_test.cc
@@ -100,8 +100,8 @@ TEST(authenticate, offline_sign_creds) {
 #ifndef __NO_MAIN__
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  TestHelperProcess server_process("tests/fake_http_server/ssl_server.py", "");
-  TestHelperProcess server_noauth_process("tests/fake_http_server/ssl_noauth_server.py", "");
+  TestHelperProcess server_process("tests/fake_http_server/ssl_server.py");
+  TestHelperProcess server_noauth_process("tests/fake_http_server/ssl_noauth_server.py");
   sleep(4);
   return RUN_ALL_TESTS();
 }

--- a/src/sota_tools/ostree_http_repo_test.cc
+++ b/src/sota_tools/ostree_http_repo_test.cc
@@ -57,7 +57,7 @@ TEST(http_repo, bad_connection) {
   TemporaryDirectory temp_dir;
   std::string sp = TestUtils::getFreePort();
 
-  TestHelperProcess server_process("tests/sota_tools/treehub_server.py", sp, "2");
+  TestHelperProcess server_process("tests/sota_tools/treehub_server.py", sp, std::string("2"));
   sleep(3);
 
   TreehubServer server;
@@ -68,7 +68,8 @@ TEST(http_repo, bad_connection) {
   Json::Value auth;
   auth["ostree"]["server"] = std::string("https://localhost:") + dp;
   Utils::writeFile(temp_dir.Path() / "auth.json", auth);
-  TestHelperProcess deploy_server_process("tests/sota_tools/treehub_deploy_server.py", dp, temp_dir.PathString(), "2");
+  TestHelperProcess deploy_server_process("tests/sota_tools/treehub_deploy_server.py", dp, temp_dir.PathString(),
+                                          std::string("2"));
   sleep(3);
 
   boost::filesystem::path filepath = (temp_dir.Path() / "auth.json").string();

--- a/tests/test_utils.cc
+++ b/tests/test_utils.cc
@@ -46,17 +46,16 @@ void TestUtils::writePathToConfig(const boost::filesystem::path &toml_in, const 
   cs << "\n[storage]\npath = " << storage_path.string() << "\n";
 }
 
-TestHelperProcess::TestHelperProcess(const std::string &argv0, const std::string &argv1, const std::string &argv2,
-                                     const std::string &argv3) {
+void TestHelperProcess::run(const char *argv0, const char *args[]) {
   pid_ = fork();
   if (pid_ == -1) {
-    throw std::runtime_error("Failed to execute process:" + argv0);
+    throw std::runtime_error("Failed to execute process:" + std::string(argv0));
   }
   if (pid_ == 0) {
 #if defined(OS_LINUX)
     prctl(PR_SET_PDEATHSIG, SIGTERM);
 #endif
-    execlp(argv0.c_str(), argv0.c_str(), argv1.c_str(), argv2.c_str(), argv3.c_str(), (char *)0);
+    execvp(argv0, const_cast<char *const *>(args));
   }
 }
 

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -14,13 +14,29 @@ struct TestUtils {
                                 const boost::filesystem::path &storage_path);
 };
 
+/**
+ * Launch a simple child subprocess, automatically kill it the object is destroyed
+ */
 class TestHelperProcess {
  public:
-  TestHelperProcess(const std::string &argv0, const std::string &argv1, const std::string &argv2 = "",
-                    const std::string &argv3 = "");
+  /**
+   * Launch the process: executable then arguments
+   *
+   * note: it uses templates for argument types but `args` are expected to be
+   * `std::string`
+   */
+  template <typename... Strings>
+  TestHelperProcess(const std::string &argv0, const Strings &... args) {
+    const int size = sizeof...(args);
+    const char *cmd_args[size + 2] = {argv0.c_str(), (args.c_str())..., nullptr};
+
+    run(cmd_args[0], cmd_args);
+  }
   ~TestHelperProcess();
 
  private:
+  void run(const char *argv0, const char *args[]);
+
   pid_t pid_;
 };
 


### PR DESCRIPTION
Avoid having to add a new string argument all the time and do not supply extraneous empty arguments to subprocesses