### PR TITLE
Disable timeout for download operation 

### DIFF
--- a/src/libaktualizr/http/httpclient.cc
+++ b/src/libaktualizr/http/httpclient.cc
@@ -239,6 +239,7 @@ HttpResponse HttpClient::download(const std::string& url, curl_write_callback ca
   curlEasySetoptWrapper(curl_download, CURLOPT_FOLLOWLOCATION, 1L);
   curlEasySetoptWrapper(curl_download, CURLOPT_WRITEFUNCTION, callback);
   curlEasySetoptWrapper(curl_download, CURLOPT_WRITEDATA, userp);
+  curlEasySetoptWrapper(curl_download, CURLOPT_TIMEOUT, 0);
   curlEasySetoptWrapper(curl_download, CURLOPT_LOW_SPEED_TIME, speed_limit_time_interval_);
   curlEasySetoptWrapper(curl_download, CURLOPT_LOW_SPEED_LIMIT, speed_limit_bytes_per_sec_);
   curlEasySetoptWrapper(curl_download, CURLOPT_RESUME_FROM, from);


### PR DESCRIPTION
Timeout for all libcurl operations is set to 60 sec,
which is not suitable for download, as it could take
much longer. To prevent slow retrieval attack we set
CURLOPT_LOW_SPEED_LIMIT and CURLOPT_LOW_SPEED_TIME.