### PR TITLE
api: add API to send installation manifest manually

### DIFF
--- a/src/libaktualizr/primary/aktualizr.cc
+++ b/src/libaktualizr/primary/aktualizr.cc
@@ -149,6 +149,13 @@ std::future<InstallResult> Aktualizr::Install(const std::vector<Uptane::Target> 
   return promise->get_future();
 }
 
+std::future<bool> Aktualizr::SendManifest(const Json::Value &custom) {
+  auto promise = std::make_shared<std::promise<bool>>();
+  std::function<void()> task([this, promise, custom]() { promise->set_value(uptane_client_->putManifest(custom)); });
+  api_queue_.enqueue(task);
+  return promise->get_future();
+}
+
 PauseResult Aktualizr::Pause() { return uptane_client_->pause(); }
 
 PauseResult Aktualizr::Resume() { return uptane_client_->resume(); }

--- a/src/libaktualizr/primary/aktualizr.h
+++ b/src/libaktualizr/primary/aktualizr.h
@@ -140,6 +140,13 @@ class Aktualizr {
   std::future<InstallResult> Install(const std::vector<Uptane::Target>& updates);
 
   /**
+   * Send installation report to the backend.
+   * @param custom Project-specific data to put in the custom field of Uptane manifest
+   * @return std::future object with manifest update result.
+   */
+  std::future<bool> SendManifest(const Json::Value& custom = Json::nullValue);
+
+  /**
    * Pause a download current in progress.
    * @return Information about pause results.
    */
@@ -181,6 +188,7 @@ class Aktualizr {
   FRIEND_TEST(Aktualizr, InstallWithUpdates);
   FRIEND_TEST(Aktualizr, CampaignCheck);
   FRIEND_TEST(Aktualizr, FullNoCorrelationId);
+  FRIEND_TEST(Aktualizr, ManifestCustom);
   FRIEND_TEST(Aktualizr, APICheck);
   Aktualizr(Config& config, std::shared_ptr<INvStorage> storage_in, std::shared_ptr<SotaUptaneClient> uptane_client_in,
             std::shared_ptr<event::Channel> sig_in);

--- a/src/libaktualizr/primary/aktualizr_test.cc
+++ b/src/libaktualizr/primary/aktualizr_test.cc
@@ -774,10 +774,14 @@ TEST(Aktualizr, APICheck) {
     Aktualizr aktualizr(conf, storage, up, sig);
     boost::signals2::connection conn = aktualizr.SetSignalHandler(f_cb);
     aktualizr.Initialize();
+    std::vector<std::future<UpdateCheckResult>> futures;
     for (int i = 0; i < 5; ++i) {
-      aktualizr.CheckUpdates();
+      futures.push_back(aktualizr.CheckUpdates());
     }
-    std::this_thread::sleep_for(std::chrono::seconds(12));
+
+    for (auto& f : futures) {
+      f.get();
+    }
     aktualizr.Shutdown();
   }
 

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -899,11 +899,12 @@ void SotaUptaneClient::campaignAccept(const std::string &campaign_id) {
   report_queue->enqueue(std_::make_unique<CampaignAcceptedReport>(campaign_id));
 }
 
-bool SotaUptaneClient::putManifestSimple() {
+bool SotaUptaneClient::putManifestSimple(const Json::Value &custom) {
   // does not send event, so it can be used as a subset of other steps
   auto manifest = AssembleManifest();
+
   if (!hasPendingUpdates(manifest)) {
-    auto signed_manifest = uptane_manifest.signManifest(manifest);
+    auto signed_manifest = uptane_manifest.signManifest(manifest, custom);
     HttpResponse response = http->put(config.uptane.director_server + "/manifest", signed_manifest);
     if (response.isOk()) {
       storage->clearInstallationResult();
@@ -913,8 +914,8 @@ bool SotaUptaneClient::putManifestSimple() {
   return false;
 }
 
-bool SotaUptaneClient::putManifest() {
-  bool success = putManifestSimple();
+bool SotaUptaneClient::putManifest(const Json::Value &custom) {
+  bool success = putManifestSimple(custom);
   sendEvent<event::PutManifestComplete>(success);
   return success;
 }

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -48,7 +48,7 @@ class SotaUptaneClient {
   PauseResult resume() { return uptane_fetcher->setPause(false); }
   void sendDeviceData();
   UpdateCheckResult fetchMeta();
-  bool putManifest();
+  bool putManifest(const Json::Value &custom = Json::nullValue);
   UpdateCheckResult checkUpdates();
   InstallResult uptaneInstall(const std::vector<Uptane::Target> &updates);
   void installationComplete(const std::shared_ptr<event::BaseEvent> &event);
@@ -96,7 +96,7 @@ class SotaUptaneClient {
   bool hasPendingUpdates(const Json::Value &manifests);
   void sendDownloadReport();
 
-  bool putManifestSimple();
+  bool putManifestSimple(const Json::Value &custom = Json::nullValue);
   bool getNewTargets(std::vector<Uptane::Target> *new_targets, unsigned int *ecus_count = nullptr);
   bool downloadTargets(const std::vector<Uptane::Target> &targets);
   std::pair<bool, Uptane::Target> downloadImage(Uptane::Target target);

--- a/src/libaktualizr/uptane/uptanerepository.cc
+++ b/src/libaktualizr/uptane/uptanerepository.cc
@@ -48,10 +48,13 @@ bool RepositoryCommon::verifyRoot(const std::string& root_raw) {
 
 void RepositoryCommon::resetRoot() { root = Root(Root::Policy::kAcceptAll); }
 
-Json::Value Manifest::signManifest(const Json::Value& version_manifests) const {
+Json::Value Manifest::signManifest(const Json::Value& version_manifests, const Json::Value& custom) const {
   Json::Value manifest;
   manifest["primary_ecu_serial"] = primary_ecu_serial.ToString();
   manifest["ecu_version_manifests"] = version_manifests;
+  if (custom != Json::nullValue) {
+    manifest["custom"] = custom;
+  }
 
   return keys_.signTuf(manifest);
 }

--- a/src/libaktualizr/uptane/uptanerepository.h
+++ b/src/libaktualizr/uptane/uptanerepository.h
@@ -18,7 +18,7 @@ class Manifest {
   Manifest(const Config &config_in, std::shared_ptr<INvStorage> storage_in)
       : storage_{std::move(storage_in)}, keys_(storage_, config_in.keymanagerConfig()) {}
 
-  Json::Value signManifest(const Json::Value &version_manifests) const;
+  Json::Value signManifest(const Json::Value &version_manifests, const Json::Value &custom = Json::nullValue) const;
   Json::Value signVersionManifest(const Json::Value &primary_version_manifests) const;
 
   void setPrimaryEcuSerialHwId(const std::pair<Uptane::EcuSerial, Uptane::HardwareIdentifier> &serials) {


### PR DESCRIPTION
A somewhat naive API to send installation result manually. A better way to solve the problem would be to redesign what Install call does, but it requires a bit more consideration (and we hope to deliver the demo next week).