### PR TITLE
Only sleep as long as it takes for the server to be ready.

### DIFF
--- a/src/libaktualizr/http/httpclient_test.cc
+++ b/src/libaktualizr/http/httpclient_test.cc
@@ -79,8 +79,7 @@ int main(int argc, char** argv) {
   std::string port = TestUtils::getFreePort();
   server += port;
   TestHelperProcess server_process("tests/fake_http_server/fake_http_server.py", port);
-
-  sleep(4);
+  TestUtils::waitForServer(server + "/");
 
   return RUN_ALL_TESTS();
 }

--- a/src/libaktualizr/uptane/fetcher_test.cc
+++ b/src/libaktualizr/uptane/fetcher_test.cc
@@ -150,8 +150,7 @@ int main(int argc, char** argv) {
   std::string port = TestUtils::getFreePort();
   server += port;
   TestHelperProcess server_process("tests/fake_http_server/fake_http_server.py", port);
-
-  sleep(3);
+  TestUtils::waitForServer(server + "/");
 
   return RUN_ALL_TESTS();
 }

--- a/src/libaktualizr/uptane/ipsecondary_discovery_test.cc
+++ b/src/libaktualizr/uptane/ipsecondary_discovery_test.cc
@@ -35,7 +35,8 @@ int main(int argc, char** argv) {
 
   port = TestUtils::getFreePort();
   TestHelperProcess server_process("tests/fake_discovery/discovery_secondary.py", port);
-  TestUtils::waitForServer("http://127.0.0.1:" + port + "/");
+  // TODO: cannot use waitForServer, since it's udp
+  sleep(3);
 
   return RUN_ALL_TESTS();
 }

--- a/src/libaktualizr/uptane/ipsecondary_discovery_test.cc
+++ b/src/libaktualizr/uptane/ipsecondary_discovery_test.cc
@@ -35,8 +35,7 @@ int main(int argc, char** argv) {
 
   port = TestUtils::getFreePort();
   TestHelperProcess server_process("tests/fake_discovery/discovery_secondary.py", port);
-
-  sleep(3);
+  TestUtils::waitForServer("http://127.0.0.1:" + port + "/");
 
   return RUN_ALL_TESTS();
 }

--- a/src/libaktualizr/uptane/uptane_network_test.cc
+++ b/src/libaktualizr/uptane/uptane_network_test.cc
@@ -120,8 +120,7 @@ int main(int argc, char **argv) {
 
   port = TestUtils::getFreePort();
   TestHelperProcess server_process("tests/fake_http_server/fake_uptane_server.py", port);
-
-  sleep(3);
+  TestUtils::waitForServer("http://127.0.0.1:" + port + "/");
 
   conf.provision.server = "http://127.0.0.1:" + port;
   conf.tls.server = "http://127.0.0.1:" + port;

--- a/src/sota_tools/authenticate_test.cc
+++ b/src/sota_tools/authenticate_test.cc
@@ -129,10 +129,11 @@ int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   TestHelperProcess server_process("tests/fake_http_server/ssl_server.py");
   TestHelperProcess server_noauth_process("tests/fake_http_server/ssl_noauth_server.py");
-  sleep(4);
-  // TODO: these do not work because the server expects auth!
+  // TODO: this do not work because the server expects auth! Let's sleep for now.
+  // (could be replaced by a check with raw tcp)
   // TestUtils::waitForServer("https://localhost:1443/");
-  // TestUtils::waitForServer("https://localhost:2443/");
+  sleep(4);
+  TestUtils::waitForServer("https://localhost:2443/");
   return RUN_ALL_TESTS();
 }
 #endif

--- a/src/sota_tools/authenticate_test.cc
+++ b/src/sota_tools/authenticate_test.cc
@@ -129,8 +129,10 @@ int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   TestHelperProcess server_process("tests/fake_http_server/ssl_server.py");
   TestHelperProcess server_noauth_process("tests/fake_http_server/ssl_noauth_server.py");
-  TestUtils::waitForServer("http://localhost:1443/");
-  TestUtils::waitForServer("http://localhost:2443/");
+  sleep(4);
+  // TODO: these do not work because the server expects auth!
+  // TestUtils::waitForServer("https://localhost:1443/");
+  // TestUtils::waitForServer("https://localhost:2443/");
   return RUN_ALL_TESTS();
 }
 #endif

--- a/src/sota_tools/authenticate_test.cc
+++ b/src/sota_tools/authenticate_test.cc
@@ -129,7 +129,8 @@ int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   TestHelperProcess server_process("tests/fake_http_server/ssl_server.py");
   TestHelperProcess server_noauth_process("tests/fake_http_server/ssl_noauth_server.py");
-  sleep(4);
+  TestUtils::waitForServer("http://localhost:1443/");
+  TestUtils::waitForServer("http://localhost:2443/");
   return RUN_ALL_TESTS();
 }
 #endif

--- a/src/sota_tools/deploy_test.cc
+++ b/src/sota_tools/deploy_test.cc
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
   Utils::writeFile(temp_dir.Path() / "auth.json", auth);
 
   TestHelperProcess server_process(server, port, temp_dir.PathString());
-  sleep(3);
+  TestUtils::waitForServer("https://localhost:" + port + "/");
   return RUN_ALL_TESTS();
 }
 #endif

--- a/src/sota_tools/ostree_http_repo_test.cc
+++ b/src/sota_tools/ostree_http_repo_test.cc
@@ -81,7 +81,7 @@ TEST(http_repo, bad_connection) {
   Utils::writeFile(temp_dir.Path() / "auth.json", auth);
   TestHelperProcess deploy_server_process("tests/sota_tools/treehub_deploy_server.py", dp, temp_dir.PathString(),
                                           std::string("2"));
-  TestUtils::waitForServer("http://localhost:" + dp + "/");
+  TestUtils::waitForServer("https://localhost:" + dp + "/");
 
   boost::filesystem::path filepath = (temp_dir.Path() / "auth.json").string();
   boost::filesystem::path cert_path = "tests/fake_http_server/client.crt";

--- a/src/sota_tools/ostree_http_repo_test.cc
+++ b/src/sota_tools/ostree_http_repo_test.cc
@@ -69,7 +69,7 @@ TEST(http_repo, bad_connection) {
   std::string sp = TestUtils::getFreePort();
 
   TestHelperProcess server_process("tests/sota_tools/treehub_server.py", sp, std::string("2"));
-  sleep(3);
+  TestUtils::waitForServer("http://localhost:" + sp + "/");
 
   TreehubServer server;
   server.root_url("http://localhost:" + sp);
@@ -81,7 +81,7 @@ TEST(http_repo, bad_connection) {
   Utils::writeFile(temp_dir.Path() / "auth.json", auth);
   TestHelperProcess deploy_server_process("tests/sota_tools/treehub_deploy_server.py", dp, temp_dir.PathString(),
                                           std::string("2"));
-  sleep(3);
+  TestUtils::waitForServer("http://localhost:" + dp + "/");
 
   boost::filesystem::path filepath = (temp_dir.Path() / "auth.json").string();
   boost::filesystem::path cert_path = "tests/fake_http_server/client.crt";
@@ -113,7 +113,7 @@ int main(int argc, char **argv) {
   port = TestUtils::getFreePort();
 
   TestHelperProcess server_process(server, port);
-  sleep(3);
+  TestUtils::waitForServer("http://localhost:" + port + "/");
 
   return RUN_ALL_TESTS();
 }

--- a/src/sota_tools/ostree_object_test.cc
+++ b/src/sota_tools/ostree_object_test.cc
@@ -143,10 +143,10 @@ TEST(OstreeObject, UploadSuccess) {
   auth["ostree"]["server"] = std::string("https://localhost:") + dp;
   Utils::writeFile(temp_dir.Path() / "auth.json", auth);
   TestHelperProcess deploy_server_process("tests/sota_tools/treehub_deploy_server.py", dp, temp_dir.Path().string());
-  TestUtils::waitForServer("http://localhost:" + dp + "/");
+  TestUtils::waitForServer("https://localhost:" + dp + "/");
 
   TreehubServer push_server;
-  push_server.root_url("http://localhost:" + dp);
+  push_server.root_url("https://localhost:" + dp);
 
   boost::filesystem::path filepath = (temp_dir.Path() / "auth.json").string();
   boost::filesystem::path cert_path = "tests/fake_http_server/client.crt";

--- a/src/sota_tools/ostree_object_test.cc
+++ b/src/sota_tools/ostree_object_test.cc
@@ -143,7 +143,7 @@ TEST(OstreeObject, UploadSuccess) {
   auth["ostree"]["server"] = std::string("https://localhost:") + dp;
   Utils::writeFile(temp_dir.Path() / "auth.json", auth);
   TestHelperProcess deploy_server_process("tests/sota_tools/treehub_deploy_server.py", dp, temp_dir.Path().string());
-  sleep(3);
+  TestUtils::waitForServer("http://localhost:" + dp + "/");
 
   TreehubServer push_server;
   push_server.root_url("http://localhost:" + dp);
@@ -200,7 +200,7 @@ int main(int argc, char** argv) {
   port = TestUtils::getFreePort();
 
   TestHelperProcess server_process(server, port);
-  sleep(3);
+  TestUtils::waitForServer("http://localhost:" + port + "/");
 
   return RUN_ALL_TESTS();
 }

--- a/src/sota_tools/treehub_server_test.cc
+++ b/src/sota_tools/treehub_server_test.cc
@@ -67,7 +67,7 @@ int main(int argc, char **argv) {
   port = TestUtils::getFreePort();
 
   TestHelperProcess server_process(server, port);
-  sleep(3);
+  TestUtils::waitForServer("http://127.0.0.1:" + port + "/");
 
   return RUN_ALL_TESTS();
 }

--- a/tests/fake_http_server/ssl_noauth_server.py
+++ b/tests/fake_http_server/ssl_noauth_server.py
@@ -1,8 +1,14 @@
 #!/usr/bin/python3
 from http.server import HTTPServer,SimpleHTTPRequestHandler
+import socket
 import ssl
 
-httpd = HTTPServer(('localhost', 2443), SimpleHTTPRequestHandler)
+class ReUseHTTPServer(HTTPServer):
+    def server_bind(self):
+        self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        HTTPServer.server_bind(self)
+
+httpd = ReUseHTTPServer(('localhost', 2443), SimpleHTTPRequestHandler)
 httpd.socket = ssl.wrap_socket (httpd.socket,
                                 certfile='tests/fake_http_server/client.crt',
                                 keyfile='tests/fake_http_server/client.key',

--- a/tests/fake_http_server/ssl_server.py
+++ b/tests/fake_http_server/ssl_server.py
@@ -1,8 +1,14 @@
 #!/usr/bin/python3
 from http.server import HTTPServer,SimpleHTTPRequestHandler
+import socket
 import ssl
 
-httpd = HTTPServer(('localhost', 1443), SimpleHTTPRequestHandler)
+class ReUseHTTPServer(HTTPServer):
+    def server_bind(self):
+        self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        HTTPServer.server_bind(self)
+
+httpd = ReUseHTTPServer(('localhost', 1443), SimpleHTTPRequestHandler)
 httpd.socket = ssl.wrap_socket (httpd.socket,
                                 certfile='tests/fake_http_server/client.crt',
                                 keyfile='tests/fake_http_server/client.key',

--- a/tests/test_utils.cc
+++ b/tests/test_utils.cc
@@ -56,6 +56,8 @@ void TestUtils::waitForServer(const std::string &address) {
   curlEasySetoptWrapper(handle, CURLOPT_URL, address.c_str());
   curlEasySetoptWrapper(handle, CURLOPT_CONNECTTIMEOUT, 3L);
   curlEasySetoptWrapper(handle, CURLOPT_NOBODY, 1L);
+  curlEasySetoptWrapper(handle, CURLOPT_VERBOSE, 1L);
+  curlEasySetoptWrapper(handle, CURLOPT_SSL_VERIFYPEER, 0L);
 
   CURLcode result;
   for (size_t counter = 1; counter <= 100; counter++) {
@@ -87,6 +89,8 @@ void TestHelperProcess::run(const char *argv0, const char *args[]) {
     prctl(PR_SET_PDEATHSIG, SIGTERM);
 #endif
     execvp(argv0, const_cast<char *const *>(args));
+    std::cout << "Could not execute child " << argv0 << "\n";
+    exit(1);
   }
 }
 

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -12,6 +12,7 @@ struct TestUtils {
   static std::string getFreePort();
   static void writePathToConfig(const boost::filesystem::path &toml_in, const boost::filesystem::path &toml_out,
                                 const boost::filesystem::path &storage_path);
+  static void waitForServer(const std::string &address);
 };
 
 /**


### PR DESCRIPTION
Lots of tests sleep for 3 or 4 seconds in the expectation that the test server will be ready in that time. However, our CI regularly fails when that assumption is not true. So instead of increasing the time, just poll the server for readiness and sleep only as long as necessary.

I'm not sure this is bulletproof yet, and it seems valgrind doesn't play nicely. But I think this is a better solution than just sleeping.