### PR TITLE
Change message about no new updates to debug level.

### DIFF
--- a/src/aktualizr_primary/main.cc
+++ b/src/aktualizr_primary/main.cc
@@ -85,7 +85,11 @@ bpo::variables_map parse_options(int argc, char *argv[]) {
 }
 
 void process_event(const std::shared_ptr<event::BaseEvent> &event) {
-  if (event->variant != "DownloadProgressReport") {
+  if (event->variant == "DownloadProgressReport") {
+    // Do nothing; libaktualizr already logs it.
+  } else if (event->variant == "UpdateCheckComplete") {
+    // Do nothing; libaktualizr already logs it.
+  } else {
     LOG_INFO << "got " << event->variant << " event";
   }
 }

--- a/src/hmi_stub/main.cc
+++ b/src/hmi_stub/main.cc
@@ -110,6 +110,8 @@ void process_event(const std::shared_ptr<event::BaseEvent> &event) {
               << (install_complete->success ? "success" : "failure") << "\n";
   } else if (event->variant == "DownloadPaused" || event->variant == "DownloadResumed") {
     // Do nothing.
+  } else if (event->variant == "UpdateCheckComplete") {
+    // Do nothing; libaktualizr already logs it.
   } else {
     std::cout << "Received " << event->variant << " event\n";
   }

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -843,10 +843,15 @@ UpdateCheckResult SotaUptaneClient::checkUpdates() {
     if (!updates.empty()) {
       result = UpdateCheckResult(updates, ecus_count, UpdateStatus::kUpdatesAvailable,
                                  Utils::parseJSON(director_targets), "");
+      if (updates.size() == 1) {
+        LOG_INFO << "1 new update found in Uptane metadata.";
+      } else {
+        LOG_INFO << updates.size() << " new updates found in Uptane metadata.";
+      }
     } else {
       result = UpdateCheckResult(updates, ecus_count, UpdateStatus::kNoUpdatesAvailable,
                                  Utils::parseJSON(director_targets), "");
-      LOG_INFO << "No new updates found in Uptane metadata.";
+      LOG_DEBUG << "No new updates found in Uptane metadata.";
     }
   }
   return result;


### PR DESCRIPTION
If there are updates, still print at info level. I also silenced the log message in aktualizr-primary and hmi-stub that we got the event; it was redundant.

Fixes #1021.