### PR TITLE
Small changes for Angel Delight project

### DIFF
--- a/src/libaktualizr/crypto/keymanager.cc
+++ b/src/libaktualizr/crypto/keymanager.cc
@@ -189,13 +189,13 @@ std::string KeyManager::getCN() const {
   return cn;
 }
 
-void KeyManager::copyCertsToCurl(const std::shared_ptr<HttpInterface> &http) {
+void KeyManager::copyCertsToCurl(HttpInterface &http) {
   std::string pkey = getPkey();
   std::string cert = getCert();
   std::string ca = getCa();
 
   if ((pkey.size() != 0u) && (cert.size() != 0u) && (ca.size() != 0u)) {
-    http->setCerts(ca, config_.tls_ca_source, cert, config_.tls_cert_source, pkey, config_.tls_pkey_source);
+    http.setCerts(ca, config_.tls_ca_source, cert, config_.tls_cert_source, pkey, config_.tls_pkey_source);
   }
 }
 

--- a/src/libaktualizr/crypto/keymanager.h
+++ b/src/libaktualizr/crypto/keymanager.h
@@ -12,7 +12,7 @@ class KeyManager {
  public:
   // std::string RSAPSSSign(const std::string &message);
   // Contains the logic from HttpClient::setCerts()
-  void copyCertsToCurl(const std::shared_ptr<HttpInterface> &http);
+  void copyCertsToCurl(HttpInterface &http);
   KeyManager(std::shared_ptr<INvStorage> backend, KeyManagerConfig config);
   void loadKeys(const std::string *pkey_content = nullptr, const std::string *cert_content = nullptr,
                 const std::string *ca_content = nullptr);

--- a/src/libaktualizr/http/httpclient.h
+++ b/src/libaktualizr/http/httpclient.h
@@ -1,6 +1,8 @@
 #ifndef HTTPCLIENT_H_
 #define HTTPCLIENT_H_
 
+#include <future>
+
 #include <curl/curl.h>
 #include <gtest/gtest.h>
 #include <memory>
@@ -33,9 +35,10 @@ class HttpClient : public HttpInterface {
   HttpResponse put(const std::string &url, const Json::Value &data) override;
 
   HttpResponse download(const std::string &url, curl_write_callback callback, void *userp, size_t from) override;
+  std::future<HttpResponse> downloadAsync(const std::string &url, curl_write_callback callback, void *userp,
+                                          size_t from, CurlHandler *easyp) override;
   void setCerts(const std::string &ca, CryptoSource ca_source, const std::string &cert, CryptoSource cert_source,
                 const std::string &pkey, CryptoSource pkey_source) override;
-  long http_code{};  // NOLINT
 
  private:
   FRIEND_TEST(GetTest, download_speed_limit);

--- a/src/libaktualizr/http/httpinterface.h
+++ b/src/libaktualizr/http/httpinterface.h
@@ -1,6 +1,7 @@
 #ifndef HTTPINTERFACE_H_
 #define HTTPINTERFACE_H_
 
+#include <future>
 #include <string>
 #include <utility>
 
@@ -9,6 +10,8 @@
 
 #include "utilities/types.h"
 #include "utilities/utils.h"
+
+using CurlHandler = std::shared_ptr<CURL>;
 
 struct HttpResponse {
   HttpResponse(std::string body_in, const long http_status_code_in, CURLcode curl_code_in,  // NOLINT
@@ -34,6 +37,8 @@ class HttpInterface {
   virtual HttpResponse put(const std::string &url, const Json::Value &data) = 0;
 
   virtual HttpResponse download(const std::string &url, curl_write_callback callback, void *userp, size_t from) = 0;
+  virtual std::future<HttpResponse> downloadAsync(const std::string &url, curl_write_callback callback, void *userp,
+                                                  size_t from, CurlHandler *easyp) = 0;
   virtual void setCerts(const std::string &ca, CryptoSource ca_source, const std::string &cert,
                         CryptoSource cert_source, const std::string &pkey, CryptoSource pkey_source) = 0;
   static constexpr int64_t kNoLimit = 0;  // no limit the size of downloaded data

--- a/src/libaktualizr/primary/initializer.cc
+++ b/src/libaktualizr/primary/initializer.cc
@@ -77,7 +77,7 @@ bool Initializer::initPrimaryEcuKeys() { return keys_.generateUptaneKeyPair().si
 void Initializer::resetEcuKeys() { storage_->clearPrimaryKeys(); }
 
 bool Initializer::loadSetTlsCreds() {
-  keys_.copyCertsToCurl(http_client_);
+  keys_.copyCertsToCurl(*http_client_);
   return keys_.isOk();
 }
 


### PR DESCRIPTION
For `copyCertsToCurl` it's just nice to be able to apply it to bare `HttpInterface` instances.

For `downloadAsync` it can be necessary to access curl handler from the caller. In the proxy we use it to set response code to what we've got from the server before we have returned from `curl_easy_perform`, which happens only after the whole file has been downloaded.