### PR TITLE
Fix races in aktualizr with running modes

### DIFF
--- a/src/aktualizr_primary/main.cc
+++ b/src/aktualizr_primary/main.cc
@@ -125,17 +125,17 @@ int main(int argc, char *argv[]) {
     // launch the first event
     switch (running_mode) {
       case RunningMode::kCampaignCheck:
-        aktualizr.CampaignCheck();
+        aktualizr.CampaignCheck().get();
         break;
       case RunningMode::kCampaignAccept:
         if (commandline_map.count("campaign-id") == 0) {
           throw std::runtime_error("Running mode " + StringFromRunningMode(running_mode) + " requires a campaign id");
         }
-        aktualizr.CampaignAccept(commandline_map["campaign-id"].as<std::string>());
+        aktualizr.CampaignAccept(commandline_map["campaign-id"].as<std::string>()).get();
         break;
       case RunningMode::kCheck:
-        aktualizr.SendDeviceData();
-        aktualizr.CheckUpdates();
+        aktualizr.SendDeviceData().get();
+        aktualizr.CheckUpdates().get();
         break;
       case RunningMode::kDownload:
       case RunningMode::kInstall:


### PR DESCRIPTION
We did not wait for the result of the futures after issuing commands like "CheckUpdates".

This broke the existing behaviour of `aktualizr check`.

Bug introduced in 79283a3c77a584d9a7f5e48f83297c4201e394fe