### PR TITLE
Improve locking on the SQLite database

### DIFF
--- a/src/libaktualizr/storage/CMakeLists.txt
+++ b/src/libaktualizr/storage/CMakeLists.txt
@@ -4,7 +4,7 @@ add_custom_command(OUTPUT sql_schemas.cc sql_schemas_target
 )
 
 if(STORAGE_TYPE STREQUAL "sqlite")
-  set(SOURCES sqlstorage.cc)
+  set(SOURCES sqlstorage.cc sql_utils.cc)
   set(HEADERS sqlstorage.h sql_utils.h)
 elseif(STORAGE_TYPE STREQUAL "android")
   set(SOURCES androidstorage.cc)

--- a/src/libaktualizr/storage/sql_utils.cc
+++ b/src/libaktualizr/storage/sql_utils.cc
@@ -1,0 +1,3 @@
+#include "sql_utils.h"
+std::map<boost::filesystem::path, std::mutex> SQLite3Transaction::db_locks;
+std::mutex SQLite3Transaction::db_locks_mutex;

--- a/src/libaktualizr/storage/sqlstorage.h
+++ b/src/libaktualizr/storage/sqlstorage.h
@@ -84,7 +84,8 @@ class SQLStorage : public INvStorage {
   boost::filesystem::path dbPath() const;
 
  private:
-  SQLite3Guard dbConnection() const;
+  SQLite3Guard dbConnection(bool ro = false) const;
+  SQLite3Guard dbReadConnection() const;
   // request info
   void cleanMetaVersion(Uptane::RepositoryType repo, Uptane::Role role);
   bool readonly_{false};


### PR DESCRIPTION
- one mutex per path instead of a global mutex
- automatically lock when two threads try to acquite database for
writing

Signed-off-by: Anton Gerasimov <anton.gerasimov@here.com>