### PR TITLE
Fix/more with installed versions

### DIFF
--- a/src/libaktualizr/primary/aktualizr_test.cc
+++ b/src/libaktualizr/primary/aktualizr_test.cc
@@ -386,6 +386,7 @@ TEST(Aktualizr, FullWithUpdatesNeedReboot) {
     UpdateCheckResult update_res = aktualizr.CheckUpdates().get();
     EXPECT_EQ(update_res.status, UpdateStatus::kNoUpdatesAvailable);
 
+    // primary is installed, nothing pending
     size_t current_target = SIZE_MAX;
     size_t pending_target = SIZE_MAX;
     std::vector<Uptane::Target> targets;
@@ -393,7 +394,13 @@ TEST(Aktualizr, FullWithUpdatesNeedReboot) {
     EXPECT_LT(current_target, targets.size());
     EXPECT_EQ(pending_target, SIZE_MAX);
 
-    // check that everything is installed, manifest sent
+    // secondary is installed, nothing pending
+    size_t sec_current_target = SIZE_MAX;
+    size_t sec_pending_target = SIZE_MAX;
+    std::vector<Uptane::Target> sec_targets;
+    storage->loadInstalledVersions("secondary_ecu_serial", &sec_targets, &sec_current_target, &sec_pending_target);
+    EXPECT_LT(sec_current_target, sec_targets.size());
+    EXPECT_EQ(sec_pending_target, SIZE_MAX);
   }
 
   // check that the manifest has been sent

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -1190,6 +1190,7 @@ std::vector<InstallReport> SotaUptaneClient::sendImagesToEcus(const std::vector<
     bool fut_result = f.second.get();
     if (fut_result) {
       f.first.status = data::OperationResult(f.first.update.filename(), data::UpdateResultCode::kOk, "");
+      storage->saveInstalledVersion(f.first.serial.ToString(), f.first.update, InstalledVersionUpdateMode::kCurrent);
     } else {
       f.first.status = data::OperationResult(f.first.update.filename(), data::UpdateResultCode::kInstallFailed, "");
     }

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -130,7 +130,6 @@ class SotaUptaneClient {
   std::shared_ptr<ReportQueue> report_queue;
   Json::Value last_network_info_reported;
   std::map<Uptane::EcuSerial, Uptane::HardwareIdentifier> hw_ids;
-  std::map<Uptane::EcuSerial, std::string> installed_images;
   std::shared_ptr<event::Channel> events_channel;
   boost::signals2::connection conn;
   Uptane::Exception last_exception{"", ""};

--- a/tests/uptane_vector_tests.cc
+++ b/tests/uptane_vector_tests.cc
@@ -58,7 +58,8 @@ class Uptane_Vector_Test {
     Uptane::EcuSerial ecu_serial(config.provision.primary_ecu_serial);
     Uptane::HardwareIdentifier hw_id(config.provision.primary_ecu_hardware_id);
     uptane_client->hw_ids.insert(std::make_pair(ecu_serial, hw_id));
-    uptane_client->installed_images[ecu_serial] = "test_filename";
+    Uptane::Target target("test_filename", {{Uptane::Hash::Type::kSha256, "sha256"}}, 1, "");
+    storage->saveInstalledVersion(ecu_serial.ToString(), target, InstalledVersionUpdateMode::kCurrent);
 
     HttpClient http_client;
     while (true) {


### PR DESCRIPTION
Part of the bigger installation result story.

I plan to move most of manifest generation out of the SotaUptaneClient class, as it can mostly be done from storage right now.