### PR TITLE
Fixes for fetcher

### DIFF
--- a/src/libaktualizr/http/httpclient.cc
+++ b/src/libaktualizr/http/httpclient.cc
@@ -213,12 +213,12 @@ HttpResponse HttpClient::perform(CURL* curl_handler, int retry_times, int64_t si
   return response;
 }
 
-HttpResponse HttpClient::download(const std::string& url, curl_write_callback callback, void* userp, size_t from) {
+HttpResponse HttpClient::download(const std::string& url, curl_write_callback callback, void* userp, curl_off_t from) {
   return downloadAsync(url, callback, userp, from, nullptr).get();
 }
 
 std::future<HttpResponse> HttpClient::downloadAsync(const std::string& url, curl_write_callback callback, void* userp,
-                                                    size_t from, CurlHandler* easyp) {
+                                                    curl_off_t from, CurlHandler* easyp) {
   CURL* curl_download = Utils::curlDupHandleWrapper(curl, pkcs11_key);
   CurlHandler curlp = CurlHandler(curl_download, curl_easy_cleanup);
 
@@ -234,7 +234,7 @@ std::future<HttpResponse> HttpClient::downloadAsync(const std::string& url, curl
   curlEasySetoptWrapper(curl_download, CURLOPT_TIMEOUT, 0);
   curlEasySetoptWrapper(curl_download, CURLOPT_LOW_SPEED_TIME, speed_limit_time_interval_);
   curlEasySetoptWrapper(curl_download, CURLOPT_LOW_SPEED_LIMIT, speed_limit_bytes_per_sec_);
-  curlEasySetoptWrapper(curl_download, CURLOPT_RESUME_FROM, from);
+  curlEasySetoptWrapper(curl_download, CURLOPT_RESUME_FROM_LARGE, from);
 
   std::promise<HttpResponse> resp_promise;
   auto resp_future = resp_promise.get_future();

--- a/src/libaktualizr/http/httpclient.h
+++ b/src/libaktualizr/http/httpclient.h
@@ -34,9 +34,9 @@ class HttpClient : public HttpInterface {
   HttpResponse post(const std::string &url, const Json::Value &data) override;
   HttpResponse put(const std::string &url, const Json::Value &data) override;
 
-  HttpResponse download(const std::string &url, curl_write_callback callback, void *userp, size_t from) override;
+  HttpResponse download(const std::string &url, curl_write_callback callback, void *userp, curl_off_t from) override;
   std::future<HttpResponse> downloadAsync(const std::string &url, curl_write_callback callback, void *userp,
-                                          size_t from, CurlHandler *easyp) override;
+                                          curl_off_t from, CurlHandler *easyp) override;
   void setCerts(const std::string &ca, CryptoSource ca_source, const std::string &cert, CryptoSource cert_source,
                 const std::string &pkey, CryptoSource pkey_source) override;
 

--- a/src/libaktualizr/http/httpinterface.h
+++ b/src/libaktualizr/http/httpinterface.h
@@ -41,9 +41,9 @@ class HttpInterface {
   virtual HttpResponse post(const std::string &url, const Json::Value &data) = 0;
   virtual HttpResponse put(const std::string &url, const Json::Value &data) = 0;
 
-  virtual HttpResponse download(const std::string &url, curl_write_callback callback, void *userp, size_t from) = 0;
+  virtual HttpResponse download(const std::string &url, curl_write_callback callback, void *userp, curl_off_t from) = 0;
   virtual std::future<HttpResponse> downloadAsync(const std::string &url, curl_write_callback callback, void *userp,
-                                                  size_t from, CurlHandler *easyp) = 0;
+                                                  curl_off_t from, CurlHandler *easyp) = 0;
   virtual void setCerts(const std::string &ca, CryptoSource ca_source, const std::string &cert,
                         CryptoSource cert_source, const std::string &pkey, CryptoSource pkey_source) = 0;
   static constexpr int64_t kNoLimit = 0;  // no limit the size of downloaded data

--- a/src/libaktualizr/http/httpinterface.h
+++ b/src/libaktualizr/http/httpinterface.h
@@ -14,6 +14,7 @@
 using CurlHandler = std::shared_ptr<CURL>;
 
 struct HttpResponse {
+  HttpResponse() = default;
   HttpResponse(std::string body_in, const long http_status_code_in, CURLcode curl_code_in,  // NOLINT
                std::string error_message_in)
       : body(std::move(body_in)),
@@ -21,10 +22,14 @@ struct HttpResponse {
         curl_code(curl_code_in),
         error_message(std::move(error_message_in)) {}
   std::string body;
-  long http_status_code;  // NOLINT
-  CURLcode curl_code;
+  long http_status_code{0};  // NOLINT
+  CURLcode curl_code{CURLE_OK};
   std::string error_message;
   bool isOk() { return (curl_code == CURLE_OK && http_status_code >= 200 && http_status_code < 400); }
+  std::string getStatusStr() {
+    return std::to_string(curl_code) + " " + error_message + " HTTP " + std::to_string(http_status_code);
+  }
+
   Json::Value getJson() { return Utils::parseJSON(body); }
 };
 

--- a/src/libaktualizr/package_manager/ostreemanager.h
+++ b/src/libaktualizr/package_manager/ostreemanager.h
@@ -25,15 +25,15 @@ template <typename T>
 using GObjectUniquePtr = std::unique_ptr<T, GObjectFinalizer<T>>;
 
 struct PullMetaStruct {
-  PullMetaStruct(Uptane::Target target_in, std::shared_ptr<std::mutex> pause_mutex_in,
+  PullMetaStruct(Uptane::Target target_in, const std::function<void()> &pause_cb,
                  std::shared_ptr<event::Channel> events_channel_in)
       : target{std::move(target_in)},
         percent_complete{0},
-        pause_mutex(std::move(pause_mutex_in)),
+        check_pause{pause_cb},
         events_channel{std::move(events_channel_in)} {}
   Uptane::Target target;
   unsigned int percent_complete;
-  std::shared_ptr<std::mutex> pause_mutex;
+  const std::function<void()> &check_pause;
   std::shared_ptr<event::Channel> events_channel;
 };
 
@@ -54,7 +54,7 @@ class OstreeManager : public PackageManagerInterface {
   static bool addRemote(OstreeRepo *repo, const std::string &url, const KeyManager &keys);
   static data::InstallOutcome pull(const boost::filesystem::path &sysroot_path, const std::string &ostree_server,
                                    const KeyManager &keys, const Uptane::Target &target,
-                                   const std::shared_ptr<std::mutex> &pause_mutex = std::shared_ptr<std::mutex>(),
+                                   const std::function<void()> &pause_cb = {},
                                    const std::shared_ptr<event::Channel> &events_channel = nullptr);
 
  private:

--- a/src/libaktualizr/uptane/fetcher.cc
+++ b/src/libaktualizr/uptane/fetcher.cc
@@ -119,7 +119,7 @@ bool Fetcher::fetchVerifyTarget(const Target& target) {
           ds.fhandle = storage->openTargetFile(target)->toWriteHandle();
         }
         response = http->download(config.uptane.repo_server + "/targets/" + Utils::urlEncode(target.filename()),
-                                  DownloadHandler, &ds, ds.downloaded_length);
+                                  DownloadHandler, &ds, static_cast<curl_off_t>(ds.downloaded_length));
         LOG_TRACE << "Download status: " << response.getStatusStr() << std::endl;
       } while (retry_);
       if (!response.isOk()) {

--- a/src/libaktualizr/uptane/fetcher.h
+++ b/src/libaktualizr/uptane/fetcher.h
@@ -76,6 +76,7 @@ struct DownloadMetaStruct {
         target{std::move(target_in)},
         fetcher{nullptr} {}
   uint64_t downloaded_length{};
+  unsigned int last_progress{0};
   std::unique_ptr<StorageTargetWHandle> fhandle;
   const Hash::Type hash_type;
   MultiPartHasher& hasher() {

--- a/src/libaktualizr/uptane/fetcher_test.cc
+++ b/src/libaktualizr/uptane/fetcher_test.cc
@@ -11,13 +11,32 @@
 #include "test_utils.h"
 #include "tuf.h"
 
+static const int pause_after = 50;        // percent
+static const int pause_duration = 1;      // seconds
+static const int download_timeout = 200;  // seconds.
+
 static std::string server = "http://127.0.0.1:";
 static std::string treehub_server = "http://127.0.0.1:";
 std::string sysroot;
 
 unsigned int num_events_DownloadPause = 0;
-void process_events_DownloadPauseResume(const std::shared_ptr<event::BaseEvent>& event) {
+static std::mutex pause_m;
+static std::condition_variable cv;
+static bool do_pause = false;
+
+Config config;
+
+void process_events(const std::shared_ptr<event::BaseEvent>& event) {
   if (event->variant == "DownloadProgressReport") {
+    const auto ev = dynamic_cast<event::DownloadProgressReport*>(event.get());
+    std::cout << "DownloadProgressReport: " << ev->progress << std::endl;
+    if (!do_pause) {
+      if (ev->progress >= pause_after) {
+        std::lock_guard<std::mutex> lk(pause_m);
+        do_pause = true;
+        cv.notify_all();
+      }
+    }
     return;
   }
   switch (num_events_DownloadPause) {
@@ -73,7 +92,6 @@ void process_events_DownloadPauseResume(const std::shared_ptr<event::BaseEvent>&
  */
 void test_pause(const Uptane::Target& target) {
   TemporaryDirectory temp_dir;
-  Config config;
   config.storage.path = temp_dir.Path();
   config.uptane.repo_server = server;
   config.pacman.sysroot = sysroot;
@@ -82,40 +100,51 @@ void test_pause(const Uptane::Target& target) {
   std::shared_ptr<INvStorage> storage(new SQLStorage(config.storage, false));
   auto http = std::make_shared<HttpClient>();
   auto events_channel = std::make_shared<event::Channel>();
-  std::function<void(std::shared_ptr<event::BaseEvent> event)> f_cb = process_events_DownloadPauseResume;
+  std::function<void(std::shared_ptr<event::BaseEvent> event)> f_cb = process_events;
   events_channel->connect(f_cb);
   Uptane::Fetcher f(config, storage, http, events_channel);
-
-  std::promise<void> end_pausing;
-
   EXPECT_EQ(f.setPause(true), PauseResult::kNotDownloading);
   EXPECT_EQ(f.setPause(false), PauseResult::kNotPaused);
 
-  std::thread([&f, &end_pausing] {
-    while (!f.isDownloading()) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));  // wait for download start
-    }
-    EXPECT_EQ(f.setPause(true), PauseResult::kPaused);
-    EXPECT_EQ(f.setPause(true), PauseResult::kAlreadyPaused);
-    std::this_thread::sleep_for(std::chrono::seconds(2));
-    EXPECT_EQ(f.setPause(false), PauseResult::kResumed);
-    EXPECT_EQ(f.setPause(false), PauseResult::kNotPaused);
-    end_pausing.set_value();
-  })
-      .detach();
+  std::promise<void> pause;
+  std::promise<bool> download;
+  auto result = download.get_future();
+  auto pause_res = pause.get_future();
 
   auto start = std::chrono::high_resolution_clock::now();
-  auto result = f.fetchVerifyTarget(target);
-  auto finish = std::chrono::high_resolution_clock::now();
 
-  auto status = end_pausing.get_future().wait_for(std::chrono::seconds(20));
-  if (status != std::future_status::ready) {
-    FAIL() << "Timed out waiting for installation to complete.";
-  }
+  std::thread([&f, &target](std::promise<bool> p) { p.set_value(f.fetchVerifyTarget(target)); }, std::move(download))
+      .detach();
 
-  EXPECT_TRUE(result);
+  std::thread(
+      [&f, &target](std::promise<void> p) {
+        if (!target.IsOstree()) {
+          std::unique_lock<std::mutex> lk(pause_m);
+          cv.wait(lk, [] { return do_pause; });
+        } else {
+          while (!f.isDownloading()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));  // wait for download start
+          }
+        }
+        EXPECT_EQ(f.setPause(true), PauseResult::kPaused);
+        EXPECT_EQ(f.setPause(true), PauseResult::kAlreadyPaused);
+        std::this_thread::sleep_for(std::chrono::seconds(pause_duration));
+        EXPECT_EQ(f.setPause(false), PauseResult::kResumed);
+        EXPECT_EQ(f.setPause(false), PauseResult::kNotPaused);
+        p.set_value();
+      },
+      std::move(pause))
+      .detach();
+
+  ASSERT_EQ(result.wait_for(std::chrono::seconds(download_timeout)), std::future_status::ready);
+  ASSERT_EQ(pause_res.wait_for(std::chrono::seconds(0)), std::future_status::ready);
+
+  auto duration =
+      std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count();
+
+  EXPECT_TRUE(result.get());
   EXPECT_EQ(num_events_DownloadPause, 6);
-  EXPECT_GE((finish - start), std::chrono::seconds(2));
+  EXPECT_GE(duration, pause_duration);
 }
 
 #ifdef BUILD_OSTREE

--- a/src/libaktualizr/uptane/fetcher_test.cc
+++ b/src/libaktualizr/uptane/fetcher_test.cc
@@ -110,7 +110,6 @@ void test_pause(const Uptane::Target& target) {
   std::promise<bool> download;
   auto result = download.get_future();
   auto pause_res = pause.get_future();
-
   auto start = std::chrono::high_resolution_clock::now();
 
   std::thread([&f, &target](std::promise<bool> p) { p.set_value(f.fetchVerifyTarget(target)); }, std::move(download))
@@ -141,7 +140,7 @@ void test_pause(const Uptane::Target& target) {
 
   auto duration =
       std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - start).count();
-
+  std::cout << "Downloaded 100MB in " << duration - pause_duration << "seconds\n";
   EXPECT_TRUE(result.get());
   EXPECT_EQ(num_events_DownloadPause, 6);
   EXPECT_GE(duration, pause_duration);
@@ -165,10 +164,10 @@ TEST(fetcher, test_pause_ostree) {
 
 TEST(fetcher, test_pause_binary) {
   Json::Value target_json;
-  target_json["hashes"]["sha256"] = "d03b1a2081755f3a5429854cc3e700f8cbf125db2bd77098ae79a7d783256a7d";
-  target_json["length"] = 2048;
+  target_json["hashes"]["sha256"] = "dd7bd1c37a3226e520b8d6939c30991b1c08772d5dab62b381c3a63541dc629a";
+  target_json["length"] = 100 * (1 << 20);
 
-  Uptane::Target target("large_interrupted", target_json);
+  Uptane::Target target("large_file", target_json);
   num_events_DownloadPause = 0;
   test_pause(target);
 }

--- a/tests/fake_http_server/fake_http_server.py
+++ b/tests/fake_http_server/fake_http_server.py
@@ -26,8 +26,9 @@ class Handler(BaseHTTPRequestHandler):
                 if auth_list[0] == 'Bearer' and auth_list[1] == 'token':
                     self.wfile.write(b'{"status": "good"}')
             self.wfile.write(b'{}')
-        elif self.path.endswith('/large_file') or self.path.endswith('/large_interrupted'):
-            response_size = 2048
+        elif self.path.endswith('/large_file'):
+            chunk_size = 1 << 20
+            response_size = 100 * chunk_size
             if "Range" in self.headers:
                 r = self.headers["Range"]
                 r_from = int(r.split("=")[1].split("-")[0])
@@ -35,14 +36,19 @@ class Handler(BaseHTTPRequestHandler):
                 self.send_header('Content-Range', 'bytes %d-%d/%d' %(r_from, response_size-1, response_size))
                 response_size = response_size - r_from
             else:
-                if self.path.endswith('/large_interrupted'):
-                    response_size = 1024
                 self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
             self.send_header('Content-Length', response_size)
             self.end_headers()
-            sleep(0.5)
-            for i in range(response_size):
-              self.wfile.write(b'@')
+            num_chunks, last_chunk = divmod(response_size, chunk_size)
+            b = b'@' * chunk_size
+            try:
+                while num_chunks > 0:
+                    self.wfile.write(b)
+                    num_chunks -= 1
+                self.wfile.write(b'@' * last_chunk)
+            except ConnectionResetError:
+                return
         elif self.path == '/slow_file':
             self.send_response(200)
             self.end_headers()
@@ -100,5 +106,8 @@ class ReUseHTTPServer(HTTPServer):
 
 server_address = ('', int(sys.argv[1]))
 httpd = ReUseHTTPServer(server_address, Handler)
-httpd.serve_forever()
+try:
+    httpd.serve_forever()
+except KeyboardInterrupt:
+    httpd.server_close()
 

--- a/tests/fake_http_server/fake_http_server.py
+++ b/tests/fake_http_server/fake_http_server.py
@@ -2,12 +2,12 @@
 
 import sys
 import socket
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import SimpleHTTPRequestHandler, HTTPServer
 from time import sleep
 
 last_fails = False
 
-class Handler(BaseHTTPRequestHandler):
+class Handler(SimpleHTTPRequestHandler):
     def do_GET(self):
         global last_fails
         if self.path == '/download':

--- a/tests/httpfake.h
+++ b/tests/httpfake.h
@@ -117,7 +117,7 @@ class HttpFake : public HttpInterface {
   }
 
   std::future<HttpResponse> downloadAsync(const std::string &url, curl_write_callback callback, void *userp,
-                                          size_t from, CurlHandler *easyp) override {
+                                          curl_off_t from, CurlHandler *easyp) override {
     (void)userp;
     (void)from;
     (void)easyp;
@@ -145,7 +145,7 @@ class HttpFake : public HttpInterface {
     return resp_future;
   }
 
-  HttpResponse download(const std::string &url, curl_write_callback callback, void *userp, size_t from) override {
+  HttpResponse download(const std::string &url, curl_write_callback callback, void *userp, curl_off_t from) override {
     return downloadAsync(url, callback, userp, from, nullptr).get();
   }
 


### PR DESCRIPTION
There are several problems with pause-resume fetcher API and the corresponding fetcher test that I see at the moment.
1. Fetcher test currently uses `large_interrupted` file for pause/resume. With `large_interrupted` server aborts after transferring half of a file (1000 bytes). This should lead to the `The target's calculated hash did not match the hash in the metadata` error and, after that, the upper layer may choose to retry. However, currently, the test succeeds, because while committing the first half to the db, fetcher gets `pause` event, which makes it retry silently after `resume` is called. This behavior itself is not a problem, the problem is that it is also correct for the test to fail, if `pause` comes after the first chunk is committed.
2. Race condition between `fetchVerifyTarget()` or `DownloadHandler()` and `setPause()`:
   ```
   http->download()
                                               setPause(true) 
   DownloadHandler() {
   ...
   return written_size + 1
                                               setPause(false)
   http->download() == CURLE_WRITE_ERROR && 
   pause_ == false
   throw OversizedTarget
   ```
3. Using a mutex to pause the fetcher is not only non-idiomatic, but it is also an undefined behavior, as the thread which called `pause` may terminate and/or resume might get called from another thread. See [https://en.cppreference.com/w/cpp/thread/mutex] and [https://en.cppreference.com/w/cpp/thread/mutex/unlock]. It seems to work now, but it can easily break anytime.
4. The `downloading_` guard in fetcher is pretty useless IMO. If I understand correctly its main purpose is to return `kNotDownloading`, if the `Download` API wasn't called yet. But the `downloading_` flag
   doesn't guarantee anything. The high-level `Download` API call is asynchronous and the execution of underlying `Fetcher::fetchVerifyTarget` will be performed at some point in the future on the command queue. `Pause`, on the other hand, is synchronous, so it's entirely possible that caller gets a `kNotDownloading` even after he has called `Download`. That means that caller should track the downloading state himself and provide some retry logic for the aforementioned case.

   So why bother with the `kNotDownloading` at all?
   Cleaner approach IMO would be to set `pause` no matter if the `Download` was called or not. In case `Download` called after a `Pause` it should just block until the `Resume` is called.

This PR attempts to solve issues 1-3, issue 4 is out of scope currently, I just want to start a discussion on it.