### PR TITLE
Hide events::Channel from testing Aktualizr constructor

### DIFF
--- a/src/libaktualizr/primary/aktualizr.cc
+++ b/src/libaktualizr/primary/aktualizr.cc
@@ -19,13 +19,12 @@ Aktualizr::Aktualizr(Config &config) : config_(config) {
   uptane_client_ = SotaUptaneClient::newDefaultClient(config_, storage_, sig_);
 }
 
-Aktualizr::Aktualizr(Config &config, std::shared_ptr<INvStorage> storage_in,
-                     std::shared_ptr<SotaUptaneClient> uptane_client_in, std::shared_ptr<event::Channel> sig_in)
+Aktualizr::Aktualizr(Config &config, std::shared_ptr<INvStorage> storage_in, std::shared_ptr<HttpInterface> http_in)
     : config_(config) {
   systemSetup();
+  sig_ = make_shared<boost::signals2::signal<void(shared_ptr<event::BaseEvent>)>>();
   storage_ = std::move(storage_in);
-  uptane_client_ = std::move(uptane_client_in);
-  sig_ = std::move(sig_in);
+  uptane_client_ = SotaUptaneClient::newTestClient(config_, storage_, std::move(http_in), sig_);
 }
 
 void Aktualizr::systemSetup() {

--- a/src/libaktualizr/primary/aktualizr.h
+++ b/src/libaktualizr/primary/aktualizr.h
@@ -186,8 +186,8 @@ class Aktualizr {
   FRIEND_TEST(Aktualizr, PutManifestError);
   FRIEND_TEST(Aktualizr, PauseResumeEvents);
 
-  Aktualizr(Config& config, std::shared_ptr<INvStorage> storage_in, std::shared_ptr<SotaUptaneClient> uptane_client_in,
-            std::shared_ptr<event::Channel> sig_in);
+  // This constructor is only being used in tests
+  Aktualizr(Config& config, std::shared_ptr<INvStorage> storage_in, std::shared_ptr<HttpInterface> http_in);
   void systemSetup();
 
   Config& config_;

--- a/src/libaktualizr/primary/aktualizr_test.cc
+++ b/src/libaktualizr/primary/aktualizr_test.cc
@@ -90,9 +90,7 @@ TEST(Aktualizr, FullNoUpdates) {
   conf.uptane.running_mode = RunningMode::kFull;
 
   auto storage = INvStorage::newStorage(conf.storage);
-  auto sig = std::make_shared<boost::signals2::signal<void(std::shared_ptr<event::BaseEvent>)>>();
-  auto up = SotaUptaneClient::newTestClient(conf, storage, http, sig);
-  Aktualizr aktualizr(conf, storage, up, sig);
+  Aktualizr aktualizr(conf, storage, http);
   std::function<void(std::shared_ptr<event::BaseEvent> event)> f_cb = process_events_FullNoUpdates;
   boost::signals2::connection conn = aktualizr.SetSignalHandler(f_cb);
 
@@ -113,7 +111,7 @@ TEST(Aktualizr, FullNoUpdates) {
     FAIL() << "Timed out waiting for metadata to be fetched.";
   }
 
-  verifyNothingInstalled(up->AssembleManifest());
+  verifyNothingInstalled(aktualizr.uptane_client_->AssembleManifest());
 }
 
 class HttpFakeEventCounter : public HttpFake {
@@ -251,9 +249,7 @@ TEST(Aktualizr, FullWithUpdates) {
   conf.uptane.running_mode = RunningMode::kFull;
 
   auto storage = INvStorage::newStorage(conf.storage);
-  auto sig = std::make_shared<boost::signals2::signal<void(std::shared_ptr<event::BaseEvent>)>>();
-  auto up = SotaUptaneClient::newTestClient(conf, storage, http, sig);
-  Aktualizr aktualizr(conf, storage, up, sig);
+  Aktualizr aktualizr(conf, storage, http);
   std::function<void(std::shared_ptr<event::BaseEvent> event)> f_cb = process_events_FullWithUpdates;
   boost::signals2::connection conn = aktualizr.SetSignalHandler(f_cb);
 
@@ -327,9 +323,7 @@ TEST(Aktualizr, FullWithUpdatesNeedReboot) {
   {
     // first run: do the install
     auto storage = INvStorage::newStorage(conf.storage);
-    auto sig = std::make_shared<boost::signals2::signal<void(std::shared_ptr<event::BaseEvent>)>>();
-    auto up = SotaUptaneClient::newTestClient(conf, storage, http, sig);
-    Aktualizr aktualizr(conf, storage, up, sig);
+    Aktualizr aktualizr(conf, storage, http);
 
     aktualizr.Initialize();
     aktualizr.UptaneCycle();
@@ -351,9 +345,7 @@ TEST(Aktualizr, FullWithUpdatesNeedReboot) {
   {
     // second run: before reboot, re-use the storage
     auto storage = INvStorage::newStorage(conf.storage);
-    auto sig = std::make_shared<boost::signals2::signal<void(std::shared_ptr<event::BaseEvent>)>>();
-    auto up = SotaUptaneClient::newTestClient(conf, storage, http, sig);
-    Aktualizr aktualizr(conf, storage, up, sig);
+    Aktualizr aktualizr(conf, storage, http);
 
     aktualizr.Initialize();
 
@@ -377,9 +369,7 @@ TEST(Aktualizr, FullWithUpdatesNeedReboot) {
   {
     // third run: after reboot, re-use the storage
     auto storage = INvStorage::newStorage(conf.storage);
-    auto sig = std::make_shared<boost::signals2::signal<void(std::shared_ptr<event::BaseEvent>)>>();
-    auto up = SotaUptaneClient::newTestClient(conf, storage, http, sig);
-    Aktualizr aktualizr(conf, storage, up, sig);
+    Aktualizr aktualizr(conf, storage, http);
 
     aktualizr.Initialize();
 
@@ -460,9 +450,7 @@ TEST(Aktualizr, FullMultipleSecondaries) {
   UptaneTestCommon::addDefaultSecondary(conf, temp_dir2, "sec_serial2", "sec_hwid2");
 
   auto storage = INvStorage::newStorage(conf.storage);
-  auto sig = std::make_shared<boost::signals2::signal<void(std::shared_ptr<event::BaseEvent>)>>();
-  auto up = SotaUptaneClient::newTestClient(conf, storage, http, sig);
-  Aktualizr aktualizr(conf, storage, up, sig);
+  Aktualizr aktualizr(conf, storage, http);
   std::function<void(std::shared_ptr<event::BaseEvent> event)> f_cb = process_events_FullMultipleSecondaries;
   boost::signals2::connection conn = aktualizr.SetSignalHandler(f_cb);
 
@@ -476,7 +464,7 @@ TEST(Aktualizr, FullMultipleSecondaries) {
 
   EXPECT_EQ(started_FullMultipleSecondaries, 2);
   EXPECT_EQ(complete_FullMultipleSecondaries, 2);
-  const Json::Value manifest = up->AssembleManifest();
+  const Json::Value manifest = aktualizr.uptane_client_->AssembleManifest();
   // Make sure filepath were correctly written and formatted.
   // installation_result has not been implemented for secondaries yet.
   EXPECT_EQ(manifest["sec_serial1"]["signed"]["installed_image"]["filepath"].asString(), "secondary_firmware.txt");
@@ -528,9 +516,7 @@ TEST(Aktualizr, CheckWithUpdates) {
   conf.uptane.running_mode = RunningMode::kCheck;
 
   auto storage = INvStorage::newStorage(conf.storage);
-  auto sig = std::make_shared<boost::signals2::signal<void(std::shared_ptr<event::BaseEvent>)>>();
-  auto up = SotaUptaneClient::newTestClient(conf, storage, http, sig);
-  Aktualizr aktualizr(conf, storage, up, sig);
+  Aktualizr aktualizr(conf, storage, http);
   std::function<void(std::shared_ptr<event::BaseEvent> event)> f_cb = process_events_CheckWithUpdates;
   boost::signals2::connection conn = aktualizr.SetSignalHandler(f_cb);
 
@@ -541,7 +527,7 @@ TEST(Aktualizr, CheckWithUpdates) {
     FAIL() << "Timed out waiting for metadata to be fetched.";
   }
 
-  verifyNothingInstalled(up->AssembleManifest());
+  verifyNothingInstalled(aktualizr.uptane_client_->AssembleManifest());
 }
 
 int num_events_DownloadWithUpdates = 0;
@@ -615,9 +601,7 @@ TEST(Aktualizr, DownloadWithUpdates) {
   conf.uptane.running_mode = RunningMode::kDownload;
 
   auto storage = INvStorage::newStorage(conf.storage);
-  auto sig = std::make_shared<boost::signals2::signal<void(std::shared_ptr<event::BaseEvent>)>>();
-  auto up = SotaUptaneClient::newTestClient(conf, storage, http, sig);
-  Aktualizr aktualizr(conf, storage, up, sig);
+  Aktualizr aktualizr(conf, storage, http);
   std::function<void(std::shared_ptr<event::BaseEvent> event)> f_cb = process_events_DownloadWithUpdates;
   boost::signals2::connection conn = aktualizr.SetSignalHandler(f_cb);
 
@@ -635,7 +619,7 @@ TEST(Aktualizr, DownloadWithUpdates) {
     FAIL() << "Timed out waiting for downloads to complete.";
   }
 
-  verifyNothingInstalled(up->AssembleManifest());
+  verifyNothingInstalled(aktualizr.uptane_client_->AssembleManifest());
 }
 
 int num_events_InstallWithUpdates = 0;
@@ -757,9 +741,7 @@ TEST(Aktualizr, InstallWithUpdates) {
   conf.uptane.running_mode = RunningMode::kInstall;
 
   auto storage = INvStorage::newStorage(conf.storage);
-  auto sig = std::make_shared<boost::signals2::signal<void(std::shared_ptr<event::BaseEvent>)>>();
-  auto up = SotaUptaneClient::newTestClient(conf, storage, http, sig);
-  Aktualizr aktualizr(conf, storage, up, sig);
+  Aktualizr aktualizr(conf, storage, http);
   std::function<void(std::shared_ptr<event::BaseEvent> event)> f_cb = process_events_InstallWithUpdates;
   boost::signals2::connection conn = aktualizr.SetSignalHandler(f_cb);
 
@@ -831,9 +813,7 @@ TEST(Aktualizr, CampaignCheck) {
   Config conf = makeTestConfig(temp_dir, http->tls_server);
 
   auto storage = INvStorage::newStorage(conf.storage);
-  auto sig = std::make_shared<boost::signals2::signal<void(std::shared_ptr<event::BaseEvent>)>>();
-  auto up = SotaUptaneClient::newTestClient(conf, storage, http, sig);
-  Aktualizr aktualizr(conf, storage, up, sig);
+  Aktualizr aktualizr(conf, storage, http);
 
   aktualizr.Initialize();
   auto result = aktualizr.CampaignCheck().get();
@@ -868,9 +848,7 @@ TEST(Aktualizr, FullNoCorrelationId) {
     Config conf = makeTestConfig(temp_dir, http->tls_server);
 
     auto storage = INvStorage::newStorage(conf.storage);
-    auto sig = std::make_shared<boost::signals2::signal<void(std::shared_ptr<event::BaseEvent>)>>();
-    auto up = SotaUptaneClient::newTestClient(conf, storage, http, sig);
-    Aktualizr aktualizr(conf, storage, up, sig);
+    Aktualizr aktualizr(conf, storage, http);
 
     aktualizr.Initialize();
     result::UpdateCheck update_result = aktualizr.CheckUpdates().get();
@@ -903,12 +881,10 @@ TEST(Aktualizr, APICheck) {
   Config conf = makeTestConfig(temp_dir, http->tls_server);
 
   auto storage = INvStorage::newStorage(conf.storage);
-  auto sig = std::make_shared<boost::signals2::signal<void(std::shared_ptr<event::BaseEvent>)>>();
-  auto up = SotaUptaneClient::newTestClient(conf, storage, http, sig);
   std::function<void(std::shared_ptr<event::BaseEvent> event)> f_cb = process_events_UpdateCheck;
 
   {
-    Aktualizr aktualizr(conf, storage, up, sig);
+    Aktualizr aktualizr(conf, storage, http);
     boost::signals2::connection conn = aktualizr.SetSignalHandler(f_cb);
     aktualizr.Initialize();
     for (int i = 0; i < 5; ++i) {
@@ -923,7 +899,7 @@ TEST(Aktualizr, APICheck) {
   num_events_UpdateCheck = 0;
   // try again, but shutdown before it finished all calls
   {
-    Aktualizr aktualizr(conf, storage, up, sig);
+    Aktualizr aktualizr(conf, storage, http);
     boost::signals2::connection conn = aktualizr.SetSignalHandler(f_cb);
     aktualizr.Initialize();
     for (int i = 0; i < 100; ++i) {
@@ -952,12 +928,10 @@ TEST(Aktualizr, PutManifestError) {
   Config conf = makeTestConfig(temp_dir, "http://putmanifesterror");
 
   auto storage = INvStorage::newStorage(conf.storage);
-  auto sig = std::make_shared<boost::signals2::signal<void(std::shared_ptr<event::BaseEvent>)>>();
-  auto up = SotaUptaneClient::newTestClient(conf, storage, http, sig);
   std::function<void(std::shared_ptr<event::BaseEvent> event)> f_cb = process_events_UpdateCheck;
 
   num_events_UpdateCheck = 0;
-  Aktualizr aktualizr(conf, storage, up, sig);
+  Aktualizr aktualizr(conf, storage, http);
   boost::signals2::connection conn = aktualizr.SetSignalHandler(f_cb);
   aktualizr.Initialize();
   auto result = aktualizr.CheckUpdates().get();
@@ -972,9 +946,7 @@ TEST(Aktualizr, PauseResumeEvents) {
   Config conf = makeTestConfig(temp_dir, http->tls_server);
 
   auto storage = INvStorage::newStorage(conf.storage);
-  auto sig = std::make_shared<boost::signals2::signal<void(std::shared_ptr<event::BaseEvent>)>>();
-  auto up = SotaUptaneClient::newTestClient(conf, storage, http, sig);
-  Aktualizr aktualizr(conf, storage, up, sig);
+  Aktualizr aktualizr(conf, storage, http);
 
   std::promise<void> end_promise{};
   size_t n_events = 0;


### PR DESCRIPTION
It's too easy to misuse it

Signed-off-by: Anton Gerasimov <anton.gerasimov@here.com>