### PR TITLE
Get rid of running modes.

### DIFF
--- a/actions.md
+++ b/actions.md
@@ -256,11 +256,11 @@ These are internal requirements that are relatively opaque to the user and/or co
 
 This is just the list of sequences currently covered. It is likely that there are more worth testing, but these tests are expensive.
 
-- [x] Initialize -> CheckUpdates -> no updates -> no further action or events (aktualizr_test.cc)
+- [x] Initialize -> UptaneCycle -> no updates -> no further action or events (aktualizr_test.cc)
 - [x] Initialize -> UptaneCycle -> updates downloaded and installed for primary and secondary (aktualizr_test.cc)
 - [x] Initialize -> UptaneCycle -> updates downloaded and installed for primary (after reboot) and secondary (aktualizr_test.cc)
 - [x] Initialize -> UptaneCycle -> updates downloaded and installed for secondaries without changing the primary (aktualizr_test.cc)
-- [x] Initialize -> CheckUpdates -> updates found but not downloaded (aktualizr_test.cc)
+- [x] Initialize -> CheckUpdates -> no updates -> no further action or events (aktualizr_test.cc)
 - [x] Initialize -> Download -> nothing to download (aktualizr_test.cc)
 - [x] Initialize -> CheckUpdates -> Download -> updates downloaded but not installed (aktualizr_test.cc)
 - [x] Initialize -> Install -> nothing to install (aktualizr_test.cc)

--- a/actions.md
+++ b/actions.md
@@ -256,19 +256,18 @@ These are internal requirements that are relatively opaque to the user and/or co
 
 This is just the list of sequences currently covered. It is likely that there are more worth testing, but these tests are expensive.
 
-- [x] Automatic control. Initialize -> CheckUpdates -> no updates -> no further action or events (aktualizr_test.cc)
-- [x] Automatic control. Initialize -> UptaneCycle -> updates downloaded and installed for primary and secondary (aktualizr_test.cc)
-- [x] Automatic control. Initialize -> UptaneCycle -> updates downloaded and installed for primary (after reboot) and secondary (aktualizr_test.cc)
-- [x] Automatic control. Initialize -> UptaneCycle -> updates downloaded and installed for secondaries without changing the primary (aktualizr_test.cc)
-- [x] kCheck running mode. Initialize -> UptaneCycle -> updates found but not downloaded (aktualizr_test.cc)
-- [x] kDownload running mode. Initialize -> UptaneCycle -> updates downloaded but not downloaded (aktualizr_test.cc)
-- [x] kDownload running mode. Initialize -> Download -> nothing to download (aktualizr_test.cc)
-- [x] kInstall running mode. Updates downloaded -> UptaneCycle -> updates installed (aktualizr_test.cc)
-- [x] kInstall running mode. Initialize -> Install -> nothing to install (aktualizr_test.cc)
-- [x] kInstall running mode. Initialize -> Install -> nothing to install (aktualizr_test.cc)
-- [x] Automatic control, autoprovision with real server. Initialize -> CheckUpdates -> verify state with aktualizr-info (auto_prov_test.py)
-- [x] Automatic control, implicitly provision with real server. Initialize -> verify not provisioned with aktualizr-info -> run aktualizr-cert-provider -> Initialize -> CheckUpdates -> verify state with aktualizr-info (implicit_prov_test.py)
-- [x] Automatic control, implicitly provision with HSM with real server. Initialize -> verify not provisioned with aktualizr-info -> run aktualizr-cert-provider -> Initialize -> CheckUpdates -> verify state with aktualizr-info (hsm_prov_test.py)
+- [x] Initialize -> CheckUpdates -> no updates -> no further action or events (aktualizr_test.cc)
+- [x] Initialize -> UptaneCycle -> updates downloaded and installed for primary and secondary (aktualizr_test.cc)
+- [x] Initialize -> UptaneCycle -> updates downloaded and installed for primary (after reboot) and secondary (aktualizr_test.cc)
+- [x] Initialize -> UptaneCycle -> updates downloaded and installed for secondaries without changing the primary (aktualizr_test.cc)
+- [x] Initialize -> CheckUpdates -> updates found but not downloaded (aktualizr_test.cc)
+- [x] Initialize -> Download -> nothing to download (aktualizr_test.cc)
+- [x] Initialize -> CheckUpdates -> Download -> updates downloaded but not installed (aktualizr_test.cc)
+- [x] Initialize -> Install -> nothing to install (aktualizr_test.cc)
+- [x] Initialize -> CheckUpdates -> Download -> Install -> updates installed (aktualizr_test.cc)
+- [x] Autoprovision with real server. Initialize -> CheckUpdates -> verify state with aktualizr-info (auto_prov_test.py)
+- [x] Implicitly provision with real server. Initialize -> verify not provisioned with aktualizr-info -> run aktualizr-cert-provider -> Initialize -> CheckUpdates -> verify state with aktualizr-info (implicit_prov_test.py)
+- [x] Implicitly provision with HSM with real server. Initialize -> verify not provisioned with aktualizr-info -> run aktualizr-cert-provider -> Initialize -> CheckUpdates -> verify state with aktualizr-info (hsm_prov_test.py)
 
 
 ## aktualizr tools

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -95,7 +95,6 @@ Options for Uptane.
 [options="header"]
 |==========================================================================================
 | Name                      | Default      | Description
-| `running_mode`            | `full`       | Continuously poll the server (`full`), perform a full update cycle once and exit (`once`), only check for updates (`check`), only download updates (`download`) or only install updates (`install`).
 | `polling_sec`             | `10`         | Interval between polls (in seconds).
 | `director_server`         |              | Director server URL. If empty, set to `tls.server` with `/director` appended.
 | `repo_server`             |              | Image repository server URL. If empty, set to `tls.server` with `/repo` appended.

--- a/docs/selectively-triggering-aktualizr.adoc
+++ b/docs/selectively-triggering-aktualizr.adoc
@@ -2,7 +2,7 @@
 
 Aktualizr normally runs as a `systemd` service and regularly polls for updates. The default polling interval is set at 10s, and this should be increased by a few orders of magnitude in a production system.
 
-It is also possible to trigger the update cycle, or individual parts of the update cycle, manually or programmatically. This is done by using aktualizr's `--running-mode` option, or just supplying the operation name as a subcommand.
+It is also possible to trigger the update cycle, or individual parts of the update cycle, manually or programmatically. This is done by using aktualizr's `--run-mode` option, or just supplying the operation name as a subcommand.
 
 [NOTE]
 ====
@@ -16,8 +16,6 @@ Assuming aktualizr is being built using Yocto and meta-updater, the `systemd` se
 
     SYSTEMD_AUTO_ENABLE_aktualizr = "disable"
 ====
-
-WARNING: This interface may change in the future, possibly to a socket- or dbus-based system.
 
 == Triggering an entire update cycle
 
@@ -54,7 +52,7 @@ Download an update:
 
 === Reporting installation results
 
-Installation reports are sent when aktualizr polls the server for updates, so the `check` running-mode should be used again after installing:
+Installation reports are sent when aktualizr polls the server for updates, so the `check` run-mode should be used again after installing:
 
     aktualizr check
 
@@ -68,7 +66,7 @@ If the device is targeted by one or more campaigns, aktualizr prints details of 
 
 === Accept campaigns that target the device
 
-This running mode works together with the `campaign_check` mode. After you have received a list of applicable campaigns, you can accept the campaigns so that they are included in the software update process.
+This run mode works together with the `campaign_check` mode. After you have received a list of applicable campaigns, you can accept the campaigns so that they are included in the software update process.
 
     aktualizr campaign_accept --campaign-id=<CAMPAIGN_ID>
 

--- a/scripts/test_aktualizr_repo.sh
+++ b/scripts/test_aktualizr_repo.sh
@@ -10,7 +10,7 @@ TMPDIR=$(mktemp -u)
 create_repo.sh $TMPDIR 127.0.0.1
 serve_repo.py 9000 "$TMPDIR" &
 
-aktualizr --config "${TMPDIR}/sota.toml" --running-mode once
+aktualizr --config "${TMPDIR}/sota.toml" --run-mode once
 
 aktualizr-info --config "${TMPDIR}/sota.toml" | grep "Fetched metadata: yes" || exit 1
 

--- a/scripts/test_install_aktualizr_and_update.sh
+++ b/scripts/test_install_aktualizr_and_update.sh
@@ -12,7 +12,7 @@ TEMP_DIR=$(mktemp -d)
 mkdir -m 700 -p "$TEMP_DIR/import"
 cp /persistent/prov_selfupdate/* "$TEMP_DIR/import"
 echo -e "[storage]\\npath = \"$TEMP_DIR\"\\n[import]\\nbase_path = \"$TEMP_DIR/import\"" > "$TEMP_DIR/conf.toml"
-aktualizr -c /persistent/selfupdate.toml -c "$TEMP_DIR/conf.toml" --running-mode=once
+aktualizr -c /persistent/selfupdate.toml -c "$TEMP_DIR/conf.toml" --run-mode=once
 
 # check that the version was updated
 akt_version=$(aktualizr --version)

--- a/src/libaktualizr/config/config.cc
+++ b/src/libaktualizr/config/config.cc
@@ -65,7 +65,6 @@ void ProvisionConfig::writeToStream(std::ostream& out_stream) const {
 }
 
 void UptaneConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt) {
-  CopyFromConfig(running_mode, "running_mode", pt);
   CopyFromConfig(polling_sec, "polling_sec", pt);
   CopyFromConfig(director_server, "director_server", pt);
   CopyFromConfig(repo_server, "repo_server", pt);
@@ -76,7 +75,6 @@ void UptaneConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt)
 }
 
 void UptaneConfig::writeToStream(std::ostream& out_stream) const {
-  writeOption(out_stream, StringFromRunningMode(running_mode), "running_mode");
   writeOption(out_stream, polling_sec, "polling_sec");
   writeOption(out_stream, director_server, "director_server");
   writeOption(out_stream, repo_server, "repo_server");
@@ -226,9 +224,6 @@ void Config::updateFromCommandLine(const boost::program_options::variables_map& 
   // Try to keep these options in the same order as parse_options() in main.cc.
   if (cmd.count("loglevel") != 0) {
     logger.loglevel = cmd["loglevel"].as<int>();
-  }
-  if (cmd.count("running-mode") != 0) {
-    uptane.running_mode = RunningModeFromString(cmd["running-mode"].as<std::string>());
   }
   if (cmd.count("tls-server") != 0) {
     tls.server = cmd["tls-server"].as<std::string>();

--- a/src/libaktualizr/config/config.h
+++ b/src/libaktualizr/config/config.h
@@ -67,7 +67,6 @@ struct ProvisionConfig {
 };
 
 struct UptaneConfig {
-  RunningMode running_mode{RunningMode::kFull};
   uint64_t polling_sec{10u};
   std::string director_server;
   std::string repo_server;

--- a/src/libaktualizr/config/config_test.cc
+++ b/src/libaktualizr/config/config_test.cc
@@ -18,7 +18,7 @@ boost::filesystem::path build_dir;
 
 TEST(config, DefaultValues) {
   Config conf;
-  EXPECT_EQ(conf.uptane.running_mode, RunningMode::kFull);
+  EXPECT_EQ(conf.uptane.key_type, KeyType::kRSA2048);
   EXPECT_EQ(conf.uptane.polling_sec, 10u);
 }
 
@@ -30,14 +30,14 @@ TEST(config, TomlBasic) {
 TEST(config, TomlEmpty) {
   Config conf;
   conf.updateFromTomlString("");
-  EXPECT_EQ(conf.uptane.running_mode, RunningMode::kFull);
+  EXPECT_EQ(conf.uptane.key_type, KeyType::kRSA2048);
   EXPECT_EQ(conf.uptane.polling_sec, 10u);
 }
 
 TEST(config, TomlInt) {
   Config conf;
-  conf.updateFromTomlString("[uptane]\nrunning_mode = once\npolling_sec = 99\n");
-  EXPECT_EQ(conf.uptane.running_mode, RunningMode::kOnce);
+  conf.updateFromTomlString("[uptane]\nkey_type = ED25519\npolling_sec = 99\n");
+  EXPECT_EQ(conf.uptane.key_type, KeyType::kED25519);
   EXPECT_EQ(conf.uptane.polling_sec, 99u);
 }
 
@@ -200,7 +200,6 @@ void checkConfigExpectations(const Config &conf) {
   EXPECT_EQ(conf.tls.ca_source, CryptoSource::kPkcs11);
   EXPECT_EQ(conf.tls.pkey_source, CryptoSource::kPkcs11);
   EXPECT_EQ(conf.tls.cert_source, CryptoSource::kPkcs11);
-  EXPECT_EQ(conf.uptane.running_mode, RunningMode::kCheck);
   EXPECT_EQ(conf.uptane.key_source, CryptoSource::kPkcs11);
   EXPECT_EQ(conf.uptane.key_type, KeyType::kED25519);
   EXPECT_EQ(conf.bootloader.rollback_mode, RollbackMode::kUbootMasked);
@@ -226,7 +225,6 @@ TEST(config, TwoTomlCorrectness) {
     cs << "cert_source = \"pkcs11\"\n";
     cs << "\n";
     cs << "[uptane]\n";
-    cs << "running_mode = \"check\"\n";
     cs << "key_source = \"pkcs11\"\n";
     cs << "key_type = \"ED25519\"\n";
     cs << "\n";

--- a/src/libaktualizr/primary/aktualizr.cc
+++ b/src/libaktualizr/primary/aktualizr.cc
@@ -56,19 +56,13 @@ void Aktualizr::Initialize() {
 }
 
 void Aktualizr::UptaneCycle() {
-  RunningMode running_mode = config_.uptane.running_mode;
   result::UpdateCheck update_result = CheckUpdates().get();
-  if (running_mode == RunningMode::kCheck || update_result.updates.size() == 0) {
-    return;
-  } else if (running_mode == RunningMode::kInstall) {
-    uptane_client_->uptaneInstall(update_result.updates);
-    uptane_client_->putManifest();
+  if (update_result.updates.size() == 0) {
     return;
   }
 
   result::Download download_result = Download(update_result.updates).get();
-  if (running_mode == RunningMode::kDownload || download_result.status != result::DownloadStatus::kSuccess ||
-      download_result.updates.size() == 0) {
+  if (download_result.status != result::DownloadStatus::kSuccess || download_result.updates.size() == 0) {
     return;
   }
 

--- a/src/libaktualizr/primary/aktualizr.h
+++ b/src/libaktualizr/primary/aktualizr.h
@@ -173,7 +173,7 @@ class Aktualizr {
   FRIEND_TEST(Aktualizr, FullWithUpdates);
   FRIEND_TEST(Aktualizr, FullWithUpdatesNeedReboot);
   FRIEND_TEST(Aktualizr, FullMultipleSecondaries);
-  FRIEND_TEST(Aktualizr, CheckWithUpdates);
+  FRIEND_TEST(Aktualizr, CheckNoUpdates);
   FRIEND_TEST(Aktualizr, DownloadWithUpdates);
   FRIEND_TEST(Aktualizr, InstallWithUpdates);
   FRIEND_TEST(Aktualizr, CampaignCheck);

--- a/src/libaktualizr/primary/aktualizr.h
+++ b/src/libaktualizr/primary/aktualizr.h
@@ -72,14 +72,12 @@ class Aktualizr {
 
   /**
    * Asynchronously run aktualizr indefinitely until Shutdown is called.
-   * Intended to be used with the Full \ref RunningMode setting.
    * @return Empty std::future object
    */
   std::future<void> RunForever();
 
   /**
-   * Asynchronously shut aktualizr down if it is running indefinitely with the
-   * Full \ref RunningMode.
+   * Asynchronously shut aktualizr down.
    */
   void Shutdown();
 
@@ -152,10 +150,8 @@ class Aktualizr {
   result::Pause Resume();
 
   /**
-   * Synchronously run an uptane cycle.
-   *
-   * Behaviour depends on the configured running mode (full cycle, check and
-   * download or check and install)
+   * Synchronously run an uptane cycle: check for updates, download any new
+   * targets, install them, and send a manifest back to the server.
    */
   void UptaneCycle();
 

--- a/src/libaktualizr/primary/aktualizr_test.cc
+++ b/src/libaktualizr/primary/aktualizr_test.cc
@@ -70,7 +70,7 @@ void process_events_FullNoUpdates(const std::shared_ptr<event::BaseEvent>& event
     }
     case 5:
       // Don't let the test run indefinitely!
-      FAIL();
+      FAIL() << "Unexpected events!";
     default:
       std::cout << "event #" << num_events_FullNoUpdates << " is: " << event->variant << "\n";
       EXPECT_EQ(event->variant, "");
@@ -227,7 +227,7 @@ void process_events_FullWithUpdates(const std::shared_ptr<event::BaseEvent>& eve
     }
     case 12:
       // Don't let the test run indefinitely!
-      FAIL();
+      FAIL() << "Unexpected events!";
     default:
       std::cout << "event #" << num_events_FullWithUpdates << " is: " << event->variant << "\n";
       EXPECT_EQ(event->variant, "");
@@ -492,7 +492,7 @@ void process_events_CheckWithUpdates(const std::shared_ptr<event::BaseEvent>& ev
     }
     case 5:
       // Don't let the test run indefinitely!
-      FAIL();
+      FAIL() << "Unexpected events!";
     default:
       std::cout << "event #" << num_events_CheckWithUpdates << " is: " << event->variant << "\n";
       EXPECT_EQ(event->variant, "");
@@ -573,7 +573,7 @@ void process_events_DownloadWithUpdates(const std::shared_ptr<event::BaseEvent>&
     }
     case 8:
       // Don't let the test run indefinitely!
-      FAIL();
+      FAIL() << "Unexpected events!";
     default:
       std::cout << "event #" << num_events_DownloadWithUpdates << " is: " << event->variant << "\n";
       EXPECT_EQ(event->variant, "");
@@ -704,7 +704,7 @@ void process_events_InstallWithUpdates(const std::shared_ptr<event::BaseEvent>& 
     }
     case 12:
       // Don't let the test run indefinitely!
-      FAIL();
+      FAIL() << "Unexpected events!";
     default:
       std::cout << "event #" << num_events_InstallWithUpdates << " is: " << event->variant << "\n";
       EXPECT_EQ(event->variant, "");

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -58,7 +58,7 @@ class SotaUptaneClient {
  private:
   FRIEND_TEST(Aktualizr, FullNoUpdates);
   FRIEND_TEST(Aktualizr, FullMultipleSecondaries);
-  FRIEND_TEST(Aktualizr, CheckWithUpdates);
+  FRIEND_TEST(Aktualizr, CheckNoUpdates);
   FRIEND_TEST(Aktualizr, DownloadWithUpdates);
   FRIEND_TEST(Uptane, AssembleManifestGood);
   FRIEND_TEST(Uptane, AssembleManifestBad);

--- a/src/libaktualizr/uptane/uptane_test.cc
+++ b/src/libaktualizr/uptane/uptane_test.cc
@@ -524,7 +524,6 @@ TEST(Uptane, ProvisionOnServer) {
   config.provision.device_id = "tst149_device_id";
   config.provision.primary_ecu_hardware_id = "tst149_hardware_identifier";
   config.provision.primary_ecu_serial = "tst149_ecu_serial";
-  config.uptane.running_mode = RunningMode::kManual;
   config.storage.path = temp_dir.Path();
 
   auto storage = INvStorage::newStorage(config.storage);

--- a/src/libaktualizr/utilities/config_utils.h
+++ b/src/libaktualizr/utilities/config_utils.h
@@ -95,14 +95,6 @@ inline void CopyFromConfig(CryptoSource& dest, const std::string& option_name, c
 }
 
 template <>
-inline void CopyFromConfig(RunningMode& dest, const std::string& option_name, const boost::property_tree::ptree& pt) {
-  boost::optional<std::string> value = pt.get_optional<std::string>(option_name);
-  if (value.is_initialized()) {
-    dest = RunningModeFromString(StripQuotesFromStrings(value.get()));
-  }
-}
-
-template <>
 inline void CopyFromConfig(BasedPath& dest, const std::string& option_name, const boost::property_tree::ptree& pt) {
   boost::optional<std::string> value = pt.get_optional<std::string>(option_name);
   if (value.is_initialized()) {

--- a/src/libaktualizr/utilities/types.cc
+++ b/src/libaktualizr/utilities/types.cc
@@ -93,44 +93,4 @@ OperationResult OperationResult::fromOutcome(const std::string &id, const Instal
 
 }  // namespace data
 
-RunningMode RunningModeFromString(const std::string &mode) {
-  if (mode == "full" || mode.empty()) {
-    return RunningMode::kFull;
-  } else if (mode == "once") {
-    return RunningMode::kOnce;
-  } else if (mode == "check") {
-    return RunningMode::kCheck;
-  } else if (mode == "download") {
-    return RunningMode::kDownload;
-  } else if (mode == "install") {
-    return RunningMode::kInstall;
-  } else if (mode == "campaign_check") {
-    return RunningMode::kCampaignCheck;
-  } else if (mode == "campaign_accept") {
-    return RunningMode::kCampaignAccept;
-  } else {
-    throw std::runtime_error(std::string("Incorrect running mode: ") + mode);
-  }
-}
-
-std::string StringFromRunningMode(RunningMode mode) {
-  std::string mode_str = "full";
-  if (mode == RunningMode::kFull) {
-    mode_str = "full";
-  } else if (mode == RunningMode::kOnce) {
-    mode_str = "once";
-  } else if (mode == RunningMode::kCheck) {
-    mode_str = "check";
-  } else if (mode == RunningMode::kDownload) {
-    mode_str = "download";
-  } else if (mode == RunningMode::kInstall) {
-    mode_str = "install";
-  } else if (mode == RunningMode::kCampaignCheck) {
-    return "campaign_check";
-  } else if (mode == RunningMode::kCampaignAccept) {
-    return "campaign_accept";
-  }
-  return mode_str;
-}
-
 // vim: set tabstop=2 shiftwidth=2 expandtab:

--- a/src/libaktualizr/utilities/types.h
+++ b/src/libaktualizr/utilities/types.h
@@ -59,36 +59,6 @@ inline std::istream& operator>>(std::istream& is, KeyType& kt) {
   return is;
 }
 
-/** Execution mode to run aktualizr in. */
-enum class RunningMode {
-  /** Fully automated mode. Regularly checks for updates and downloads and
-   *  installs automatically. Runs indefinitely. */
-  kFull = 0,
-  /** One complete cycle. Checks once for updates, downloads and installs
-   *  anything found, and then shuts down. */
-  kOnce,
-  /** Only check for an existing campaign related to the device */
-  kCampaignCheck,
-  /** Only accept an existing campaign */
-  kCampaignAccept,
-  /** Only reject an existing campaign */
-  kCampaignReject,
-  /** Only check for updates. Sends a manifest and device data, checks for
-   *  updates, and then shuts down. */
-  kCheck,
-  /** Download any available updates and then shut down. */
-  kDownload,
-  /** Install any available updates and then shut down. Does not requite network
-   *  connectivity. */
-  kInstall,
-  /** Completely manual operation. Send commands via the aktualizr class's API.
-   *  Runs indefinitely until a Shutdown command is received. */
-  kManual,
-};
-
-RunningMode RunningModeFromString(const std::string& mode);
-std::string StringFromRunningMode(RunningMode mode);
-
 enum class CryptoSource { kFile = 0, kPkcs11 };
 
 inline std::ostream& operator<<(std::ostream& os, CryptoSource cs) {

--- a/tests/auto_prov_test.py
+++ b/tests/auto_prov_test.py
@@ -7,7 +7,7 @@ import tempfile
 
 from pathlib import Path
 
-from prov_test_common import verify_provisioned
+from prov_test_common import popen_subprocess, verify_provisioned
 
 
 def main():
@@ -44,7 +44,7 @@ def provision(tmp_dir, build_dir, creds):
     akt = build_dir / 'src/aktualizr_primary/aktualizr'
     akt_info = build_dir / 'src/aktualizr_info/aktualizr-info'
 
-    subprocess.Popen([str(akt), '--config', str(conf), '--running-mode', 'once'])
+    popen_subprocess([str(akt), '--config', str(conf), '--run-mode', 'once'])
     return verify_provisioned(akt_info, conf)
 
 

--- a/tests/hsm_prov_test.py
+++ b/tests/hsm_prov_test.py
@@ -79,7 +79,8 @@ def provision(tmp_dir, build_dir, src_dir, creds, pkcs11_module):
     os.environ['CERTS_DIR'] = str(certs_dir)
     shutil.copyfile(str(src_dir / "tests/test_data/softhsm2.conf"), str(hsm_conf))
 
-    popen_subprocess([str(akt), '--config', str(conf_dir), '--loglevel', '0', '--running-mode', 'once'])
+    akt_input = [str(akt), '--config', str(conf_dir), '--loglevel', '0', '--run-mode', 'once']
+    popen_subprocess(akt_input)
     # Verify that device has NOT yet provisioned.
     for delay in [1, 2, 5, 10, 15]:
         sleep(delay)
@@ -148,7 +149,7 @@ def provision(tmp_dir, build_dir, src_dir, creds, pkcs11_module):
         return 1
 
     (tmp_dir / 'sql.db').unlink()
-    popen_subprocess([str(akt), '--config', str(conf_dir), '--loglevel', '0', '--running-mode', 'once'])
+    popen_subprocess(akt_input)
     return verify_provisioned(akt_info, conf_dir)
 
 

--- a/tests/implicit_prov_test.py
+++ b/tests/implicit_prov_test.py
@@ -53,7 +53,8 @@ def provision(tmp_dir, build_dir, creds):
     akt_info = build_dir / 'src/aktualizr_info/aktualizr-info'
     akt_cp = build_dir / 'src/cert_provider/aktualizr-cert-provider'
 
-    popen_subprocess([str(akt), '--config', str(conf_dir), '--running-mode', 'once'])
+    akt_input = [str(akt), '--config', str(conf_dir), '--run-mode', 'once']
+    popen_subprocess(akt_input)
     # Verify that device has NOT yet provisioned.
     for delay in [1, 2, 5, 10, 15]:
         sleep(delay)
@@ -77,7 +78,7 @@ def provision(tmp_dir, build_dir, creds):
               stderr.decode() + stdout.decode())
         return retcode
 
-    subprocess.Popen([str(akt), '--config', str(conf_dir), '--running-mode', 'once'])
+    popen_subprocess(akt_input)
     return verify_provisioned(akt_info, conf_dir)
 
 


### PR DESCRIPTION
aktualizr still has an input parameter (--run-mode) that does the same thing, but this is no longer wired directly into libaktualizr; it exists purely in the wrapper outside it. This should be much cleaner and simpler to use.

Note that once upon a time I advocated for all aktualizr commandline options to be also represented in the config. I no longer believe this to be a good idea for things that only matter outside of libaktualizr. An internal "run mode" for libaktualizr does not make sense. It should be driven by the code outside of the API.