### PR TITLE
Introduce LIBRARIES argument to add_aktualizr_test

### DIFF
--- a/cmake-modules/AddAktualizrTest.cmake
+++ b/cmake-modules/AddAktualizrTest.cmake
@@ -1,10 +1,13 @@
 function(add_aktualizr_test)
     set(options PROJECT_WORKING_DIRECTORY NO_VALGRIND)
     set(oneValueArgs NAME)
-    set(multiValueArgs SOURCES ARGS)
+    set(multiValueArgs SOURCES LIBRARIES ARGS)
     cmake_parse_arguments(AKTUALIZR_TEST "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
     add_executable(t_${AKTUALIZR_TEST_NAME} EXCLUDE_FROM_ALL ${AKTUALIZR_TEST_SOURCES} ${PROJECT_SOURCE_DIR}/tests/test_utils.cc)
-    target_link_libraries(t_${AKTUALIZR_TEST_NAME} aktualizr_static_lib ${TEST_LIBS})
+    target_link_libraries(t_${AKTUALIZR_TEST_NAME}
+        ${AKTUALIZR_TEST_LIBRARIES}
+        aktualizr_static_lib
+        ${TEST_LIBS})
     target_include_directories(t_${AKTUALIZR_TEST_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/tests)
 
     if(AKTUALIZR_TEST_PROJECT_WORKING_DIRECTORY)

--- a/partial/CMakeLists.txt
+++ b/partial/CMakeLists.txt
@@ -131,21 +131,33 @@ if(NOT LIBUPTINY_MACHINE)
 
         add_aktualizr_test(NAME tiny_base64 SOURCES libuptiny/base64.c tests/base64_test.cc)
 
-        add_aktualizr_test(NAME tiny_signatures SOURCES ${LIBUPTINY_TEST_ENVIRONMENT} tests/signatures_test.cc PROJECT_WORKING_DIRECTORY)
-	target_link_libraries(t_tiny_signatures uptiny)
+        add_aktualizr_test(NAME tiny_signatures
+                           SOURCES ${LIBUPTINY_TEST_ENVIRONMENT} tests/signatures_test.cc
+                           LIBRARIES uptiny
+                           PROJECT_WORKING_DIRECTORY)
 
-        add_aktualizr_test(NAME tiny_signed_root SOURCES ${LIBUPTINY_TEST_ENVIRONMENT} tests/root_signed_test.cc PROJECT_WORKING_DIRECTORY)
-	target_link_libraries(t_tiny_signed_root uptiny)
+        add_aktualizr_test(NAME tiny_signed_root
+                           SOURCES ${LIBUPTINY_TEST_ENVIRONMENT} tests/root_signed_test.cc
+                           LIBRARIES uptiny
+                           PROJECT_WORKING_DIRECTORY)
 
-        add_aktualizr_test(NAME tiny_root SOURCES ${LIBUPTINY_TEST_ENVIRONMENT} tests/root_test.cc PROJECT_WORKING_DIRECTORY)
-	target_link_libraries(t_tiny_root uptiny)
+        add_aktualizr_test(NAME tiny_root
+                           SOURCES ${LIBUPTINY_TEST_ENVIRONMENT} tests/root_test.cc
+                           LIBRARIES uptiny
+                           PROJECT_WORKING_DIRECTORY)
 
-        add_aktualizr_test(NAME tiny_targets SOURCES ${LIBUPTINY_TEST_ENVIRONMENT} tests/targets_test.cc PROJECT_WORKING_DIRECTORY)
-	target_link_libraries(t_tiny_targets uptiny)
+        add_aktualizr_test(NAME tiny_targets
+                           SOURCES ${LIBUPTINY_TEST_ENVIRONMENT} tests/targets_test.cc
+                           LIBRARIES uptiny
+                           PROJECT_WORKING_DIRECTORY)
 
-        add_aktualizr_test(NAME tiny_firmware SOURCES ${LIBUPTINY_TEST_ENVIRONMENT} tests/firmware_test.cc PROJECT_WORKING_DIRECTORY)
-	target_link_libraries(t_tiny_firmware uptiny)
+        add_aktualizr_test(NAME tiny_firmware
+                           SOURCES ${LIBUPTINY_TEST_ENVIRONMENT} tests/firmware_test.cc
+                           LIBRARIES uptiny
+                           PROJECT_WORKING_DIRECTORY)
 
-        add_aktualizr_test(NAME tiny_update SOURCES ${LIBUPTINY_TEST_ENVIRONMENT} tests/update_test.cc PROJECT_WORKING_DIRECTORY)
-	target_link_libraries(t_tiny_update uptiny)
+        add_aktualizr_test(NAME tiny_update
+                           SOURCES ${LIBUPTINY_TEST_ENVIRONMENT} tests/update_test.cc
+                           LIBRARIES uptiny
+                           PROJECT_WORKING_DIRECTORY)
 endif()

--- a/src/aktualizr_repo/CMakeLists.txt
+++ b/src/aktualizr_repo/CMakeLists.txt
@@ -15,9 +15,11 @@ install(TARGETS aktualizr-repo
         RUNTIME DESTINATION bin)
 
 aktualizr_source_file_checks(${AKTUALIZR_REPO_SRC} ${AKTUALIZR_REPO_HDR})
-list(APPEND TEST_LIBS ${AKTUALIZR_REPO_LIBS} aktualizr_repo_lib)
-add_aktualizr_test(NAME aktualizr_repo SOURCES repo_test.cc PROJECT_WORKING_DIRECTORY ARGS $<TARGET_FILE:aktualizr-repo>)
-target_link_libraries(t_aktualizr_repo ${TEST_LIBS} aktualizr_repo_lib)
+add_aktualizr_test(NAME aktualizr_repo
+                   SOURCES repo_test.cc
+                   LIBRARIES aktualizr_repo_lib
+                   ARGS $<TARGET_FILE:aktualizr-repo>
+                   PROJECT_WORKING_DIRECTORY)
 
 aktualizr_source_file_checks(${TEST_SOURCES} main.cc)
 

--- a/src/aktualizr_secondary/CMakeLists.txt
+++ b/src/aktualizr_secondary/CMakeLists.txt
@@ -71,8 +71,8 @@ add_aktualizr_test(NAME aktualizr_secondary_config
 
 add_aktualizr_test(NAME aktualizr_secondary_update
                    SOURCES update_test.cc
+                   LIBRARIES aktualizr_secondary_static_lib
                    ARGS ${PROJECT_BINARY_DIR}/ostree_repo PROJECT_WORKING_DIRECTORY)
-target_link_libraries(t_aktualizr_secondary_update aktualizr_secondary_static_lib aktualizr_static_lib)
 
 if(BUILD_OSTREE)
     add_aktualizr_test(NAME aktualizr_secondary_discovery
@@ -81,8 +81,8 @@ if(BUILD_OSTREE)
 
     add_aktualizr_test(NAME aktualizr_secondary_uptane
                        SOURCES uptane_test.cc
+                       LIBRARIES aktualizr_secondary_static_lib
                        ARGS ${PROJECT_BINARY_DIR}/ostree_repo PROJECT_WORKING_DIRECTORY)
-    target_link_libraries(t_aktualizr_secondary_uptane aktualizr_secondary_static_lib aktualizr_static_lib)
 else(BUILD_OSTREE)
     list(APPEND TEST_SOURCES aktualizr_secondary_discovery_test.cc uptane_test.cc)
 endif(BUILD_OSTREE)

--- a/src/sota_tools/CMakeLists.txt
+++ b/src/sota_tools/CMakeLists.txt
@@ -121,26 +121,43 @@ endif(NOT BUILD_SOTA_TOOLS)
 ##### tests
 if (BUILD_SOTA_TOOLS)
     ### common tests
-    add_aktualizr_test(NAME sota_tools_auth_test SOURCES authenticate_test.cc
+    add_aktualizr_test(NAME sota_tools_auth_test
+                       SOURCES authenticate_test.cc
+                       LIBRARIES sota_tools_static_lib aktualizr_static_lib ${TEST_LIBS}
                        PROJECT_WORKING_DIRECTORY NO_VALGRIND)
-    target_link_libraries(t_sota_tools_auth_test sota_tools_static_lib aktualizr_static_lib ${TEST_LIBS})
 
-    add_aktualizr_test(NAME ostree_hash SOURCES ostree_hash_test.cc)
-    target_link_libraries(t_ostree_hash sota_tools_static_lib)
-    target_include_directories(t_ostree_hash
-                               PUBLIC ${PROJECT_SOURCE_DIR}/src/sota_tools ${GLIB2_INCLUDE_DIRS})
+    add_aktualizr_test(NAME ostree_hash
+                       LIBRARIES sota_tools_static_lib
+                       SOURCES ostree_hash_test.cc)
 
-    add_aktualizr_test(NAME rate_controller SOURCES rate_controller_test.cc)
-    target_link_libraries(t_rate_controller
-                          sota_tools_static_lib
-                          ${Boost_LIBRARIES})
+    add_aktualizr_test(NAME rate_controller
+                       LIBRARIES sota_tools_static_lib
+                       SOURCES rate_controller_test.cc)
 
-    add_aktualizr_test(NAME ostree_dir_repo SOURCES ostree_dir_repo_test.cc ${SOTA_TOOLS_LIB_SRC} PROJECT_WORKING_DIRECTORY)
-    add_aktualizr_test(NAME ostree_http_repo SOURCES ostree_http_repo_test.cc ${SOTA_TOOLS_LIB_SRC} PROJECT_WORKING_DIRECTORY)
-    add_aktualizr_test(NAME treehub_server SOURCES treehub_server_test.cc ${SOTA_TOOLS_LIB_SRC} PROJECT_WORKING_DIRECTORY)
-    add_aktualizr_test(NAME deploy SOURCES deploy_test.cc ${SOTA_TOOLS_LIB_SRC} PROJECT_WORKING_DIRECTORY)
-    add_aktualizr_test(NAME ostree_object SOURCES ostree_object_test.cc ${SOTA_TOOLS_LIB_SRC} PROJECT_WORKING_DIRECTORY)
+    add_aktualizr_test(NAME ostree_dir_repo
+                       SOURCES ostree_dir_repo_test.cc
+                       LIBRARIES sota_tools_static_lib
+                       PROJECT_WORKING_DIRECTORY)
 
+    add_aktualizr_test(NAME ostree_http_repo
+                       SOURCES ostree_http_repo_test.cc
+                       LIBRARIES sota_tools_static_lib
+                       PROJECT_WORKING_DIRECTORY)
+
+    add_aktualizr_test(NAME treehub_server
+                       SOURCES treehub_server_test.cc
+                       LIBRARIES sota_tools_static_lib
+                       PROJECT_WORKING_DIRECTORY)
+
+    add_aktualizr_test(NAME deploy
+                       SOURCES deploy_test.cc
+                       LIBRARIES sota_tools_static_lib
+                       PROJECT_WORKING_DIRECTORY)
+
+    add_aktualizr_test(NAME ostree_object
+                       SOURCES ostree_object_test.cc
+                       LIBRARIES sota_tools_static_lib
+                       PROJECT_WORKING_DIRECTORY)
 
     ### garage-check tests
     # Verify that a commit exists in a remote repo.


### PR DESCRIPTION
Make it possible to directly specify libraries that should be linked to a test.
This makes it easy to avoid recompiling SOTA_TOOLS_LIB_SRC for multiple tests,
and makes the add_aktualizr_test invocation more explicit. It also avoids
explicitly specifying target_include_directories, because cmake knows about any
public include dependencies for libraries.

Signed-off-by: Phil Wise <phil@phil-wise.com>