### PR TITLE
Move non-trivial SecondaryConfig ctor out of header

### DIFF
--- a/src/libaktualizr/uptane/CMakeLists.txt
+++ b/src/libaktualizr/uptane/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES fetcher.cc
     partialverificationsecondary.cc
     role.cc
     root.cc
+    secondaryconfig.cc
     tuf.cc
     uptanerepository.cc
     directorrepository.cc

--- a/src/libaktualizr/uptane/secondaryconfig.cc
+++ b/src/libaktualizr/uptane/secondaryconfig.cc
@@ -1,0 +1,46 @@
+#include "uptane/secondaryconfig.h"
+
+namespace Uptane {
+SecondaryConfig::SecondaryConfig(const boost::filesystem::path &config_file) {
+  if (!boost::filesystem::exists(config_file)) {
+    throw FatalException(config_file.string() + " does not exist!");
+  }
+  Json::Value config_json = Utils::parseJSONFile(config_file);
+
+  std::string stype = config_json["secondary_type"].asString();
+  if (stype == "virtual") {
+    secondary_type = Uptane::SecondaryType::kVirtual;
+  } else if (stype == "legacy") {
+    throw FatalException("Legacy secondaries are deprecated.");
+  } else if (stype == "ip_uptane") {
+    secondary_type = Uptane::SecondaryType::kIpUptane;
+  } else if (stype == "opcua_uptane") {
+    secondary_type = Uptane::SecondaryType::kOpcuaUptane;
+  } else {
+    LOG_ERROR << "Unrecognized secondary type: " << stype;
+  }
+  ecu_serial = config_json["ecu_serial"].asString();
+  ecu_hardware_id = config_json["ecu_hardware_id"].asString();
+  partial_verifying = config_json["partial_verifying"].asBool();
+  ecu_private_key = config_json["ecu_private_key"].asString();
+  ecu_public_key = config_json["ecu_public_key"].asString();
+
+  full_client_dir = boost::filesystem::path(config_json["full_client_dir"].asString());
+  firmware_path = boost::filesystem::path(config_json["firmware_path"].asString());
+  metadata_path = boost::filesystem::path(config_json["metadata_path"].asString());
+  target_name_path = boost::filesystem::path(config_json["target_name_path"].asString());
+
+  std::string key_type_str = config_json["key_type"].asString();
+  if (key_type_str.size() != 0u) {
+    if (key_type_str == "RSA2048") {
+      key_type = KeyType::kRSA2048;
+    } else if (key_type_str == "RSA3072") {
+      key_type = KeyType::kRSA3072;
+    } else if (key_type_str == "RSA4096") {
+      key_type = KeyType::kRSA4096;
+    } else if (key_type_str == "ED25519") {
+      key_type = KeyType::kED25519;
+    }
+  }
+}
+}  // namespace Uptane

--- a/src/libaktualizr/uptane/secondaryconfig.h
+++ b/src/libaktualizr/uptane/secondaryconfig.h
@@ -28,48 +28,7 @@ enum class SecondaryType {
 class SecondaryConfig {
  public:
   SecondaryConfig() = default;
-  SecondaryConfig(const boost::filesystem::path &config_file) {
-    if (!boost::filesystem::exists(config_file)) {
-      throw FatalException(config_file.string() + " does not exist!");
-    }
-    Json::Value config_json = Utils::parseJSONFile(config_file);
-
-    std::string stype = config_json["secondary_type"].asString();
-    if (stype == "virtual") {
-      secondary_type = Uptane::SecondaryType::kVirtual;
-    } else if (stype == "legacy") {
-      throw FatalException("Legacy secondaries are deprecated.");
-    } else if (stype == "ip_uptane") {
-      secondary_type = Uptane::SecondaryType::kIpUptane;
-    } else if (stype == "opcua_uptane") {
-      secondary_type = Uptane::SecondaryType::kOpcuaUptane;
-    } else {
-      LOG_ERROR << "Unrecognized secondary type: " << stype;
-    }
-    ecu_serial = config_json["ecu_serial"].asString();
-    ecu_hardware_id = config_json["ecu_hardware_id"].asString();
-    partial_verifying = config_json["partial_verifying"].asBool();
-    ecu_private_key = config_json["ecu_private_key"].asString();
-    ecu_public_key = config_json["ecu_public_key"].asString();
-
-    full_client_dir = boost::filesystem::path(config_json["full_client_dir"].asString());
-    firmware_path = boost::filesystem::path(config_json["firmware_path"].asString());
-    metadata_path = boost::filesystem::path(config_json["metadata_path"].asString());
-    target_name_path = boost::filesystem::path(config_json["target_name_path"].asString());
-
-    std::string key_type_str = config_json["key_type"].asString();
-    if (key_type_str.size() != 0u) {
-      if (key_type_str == "RSA2048") {
-        key_type = KeyType::kRSA2048;
-      } else if (key_type_str == "RSA3072") {
-        key_type = KeyType::kRSA3072;
-      } else if (key_type_str == "RSA4096") {
-        key_type = KeyType::kRSA4096;
-      } else if (key_type_str == "ED25519") {
-        key_type = KeyType::kED25519;
-      }
-    }
-  }
+  SecondaryConfig(const boost::filesystem::path &config_file);
   SecondaryType secondary_type{};
   std::string ecu_serial;
   std::string ecu_hardware_id;


### PR DESCRIPTION
I think this code will get more complex when adding Docker support, and now
seems like a good time to get the definition out of the header file.

Signed-off-by: Phil Wise <phil@phil-wise.com>