### PR TITLE
Add PoC fault injection in fake installer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ option(BUILD_SOTA_TOOLS "Set to ON to build SOTA tools" OFF)
 option(BUILD_OPCUA "Set to ON to compile with OPC-UA protocol support" OFF)
 option(BUILD_SYSTEMD "Set to ON to compile with systemd additional support" ${BUILD_SYSTEMD_DEFAULT})
 option(BUILD_LOAD_TESTS "Set to ON to build load tests" OFF)
+option(FAULT_INJECTION "Set to ON to enable fault injection" OFF)
 option(INSTALL_LIB "Set to ON to install library and headers" OFF)
 
 set(SOTA_PACKED_CREDENTIALS "" CACHE STRING "Credentials.zip for tests involving the server")
@@ -126,6 +127,12 @@ if(BUILD_SYSTEMD)
 else(BUILD_SYSTEMD)
     unset(SYSTEMD_LIBRARY CACHE)
 endif(BUILD_SYSTEMD)
+
+if(FAULT_INJECTION)
+    find_package(Libfiu REQUIRED)
+    add_definitions(-DFIU_ENABLE)
+    link_libraries(fiu)
+endif(FAULT_INJECTION)
 
 # set symbols used when compiling
 #add_definitions(-DBOOST_LOG_DYN_LINK)

--- a/cmake-modules/FindLibfiu.cmake
+++ b/cmake-modules/FindLibfiu.cmake
@@ -1,0 +1,19 @@
+if (LIBFIU_LIBRARY AND LIBFIU_INCLUDE_DIR)
+  # in cache already
+  set(LIBFIU_FOUND TRUE)
+else (LIBFIU_LIBRARY AND LIBFIU_INCLUDE_DIR)
+  find_package(PkgConfig QUIET)
+  if (PKG_CONFIG_FOUND)
+      pkg_check_modules(libfiu_PKG QUIET fiu)
+      set(XPREFIX libfiu_PKG)
+  endif()
+
+  find_path(LIBFIU_INCLUDE_DIR
+    NAMES sd-daemon.h
+    HINTS ${${XPREFIX}_INCLUDE_DIRS}
+    PATH_SUFFIXES fiu)
+  find_library(LIBFIU_LIBRARY
+    NAMES ${${XPREFIX}_LIBRARIES} fiu
+    HINTS ${${XPREFIX}_LIBRARY_DIRS}}
+    PATH_SUFFIXES fiu)
+endif()

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -12,6 +12,8 @@ link:./deb-package-install.adoc[deb-package-install.adoc] - The https://github.c
 
 link:./debugging-tips.adoc[debugging-tips.adoc] - Useful debugging info, mostly targeted at people contributing to the development of aktualizr.
 
+link:./fault-injection.adoc[fault-injection.adoc] - How to inject faults during aktualizr runs, to help test failure cases of the system.
+
 link:./hsm-provisioning.adoc[hsm-provisioning.adoc] - An explanation of aktualizr's approach to using a hardware security module for provisioning.
 
 link:./implicit-provisioning.adoc[implicit-provisioning.adoc] - Implicit provisioning an alternative to automatic provisioning. It's distinct from automatic provisioning in that it requires each image to have some unique credentials side-loaded.

--- a/docs/debugging-tips.adoc
+++ b/docs/debugging-tips.adoc
@@ -172,3 +172,7 @@ server {
     root repo_dir/repo;
 }
 ```
+
+== Inject faults
+
+See link:./fault-injection.adoc[fault-injection.adoc]

--- a/docs/fault-injection.adoc
+++ b/docs/fault-injection.adoc
@@ -1,0 +1,29 @@
+= Running aktualizr with fault injection
+
+To test the system in adverse conditions, it can be useful to make aktualizr fail in a controlled fashion.
+
+link:https://blitiri.com.ar/p/libfiu/[libfiu] provides a framework to do that, and aktualizr supports a number of controllable fail points.
+
+== Setup
+
+libfiu needs to be installed on the target machine. For local compilation on a Debian-derived system, the distribution package can be used:
+
+    apt install fiu-utils libfiu-dev
+
+Fault injection must then be enabled at CMake configure time with the `-DFAULT_INJECTION=on` option (refer to general building instructions for more details).
+
+`fiu-run` and `fiu-ctrl` can now be used on the newly compiled aktualizr binary to inject faults (refer to corresponding man pages).
+
+For example, when using the fake package manager:
+
+    fiu-run -c 'enable name=fake_package_install' aktualizr -c . once
+
+== List of fail points
+
+Please try to keep this list up-to-date when inserting/removing fail points.
+
+- `fake_package_install`: make the fake package manager installation to fail with a generic error code
+
+== Use in unit tests
+
+It is encouraged to use fail points to help unit testing sad paths. Tests that require fault injection should only be run if the `FIU_ENABLE` macro is defined.

--- a/src/libaktualizr/package_manager/packagemanagerfake.cc
+++ b/src/libaktualizr/package_manager/packagemanagerfake.cc
@@ -1,7 +1,6 @@
 #include "packagemanagerfake.h"
 
-// fault injection
-#include "utilities/fiu-local.h"
+#include "utilities/fault_injection.h"
 
 Json::Value PackageManagerFake::getInstalledPackages() const {
   Json::Value packages(Json::arrayValue);

--- a/src/libaktualizr/package_manager/packagemanagerfake.cc
+++ b/src/libaktualizr/package_manager/packagemanagerfake.cc
@@ -1,5 +1,8 @@
 #include "packagemanagerfake.h"
 
+// fault injection
+#include "utilities/fiu-local.h"
+
 Json::Value PackageManagerFake::getInstalledPackages() const {
   Json::Value packages(Json::arrayValue);
   Json::Value package;
@@ -22,6 +25,10 @@ Uptane::Target PackageManagerFake::getCurrent() const {
 }
 
 data::InstallOutcome PackageManagerFake::install(const Uptane::Target &target) const {
+  if (fiu_fail("fake_package_install")) {
+    return data::InstallOutcome(data::UpdateResultCode::kInstallFailed, "Installation failed");
+  }
+
   if (config.fake_need_reboot) {
     storage_->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kPending);
 

--- a/src/libaktualizr/utilities/CMakeLists.txt
+++ b/src/libaktualizr/utilities/CMakeLists.txt
@@ -7,7 +7,7 @@ set(SOURCES dequeue_buffer.cc
 set(HEADERS config_utils.h
             dequeue_buffer.h
             exceptions.h
-            fiu-local.h
+            fault_injection.h
             sockaddr_io.h
             timer.h
             types.h

--- a/src/libaktualizr/utilities/CMakeLists.txt
+++ b/src/libaktualizr/utilities/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES dequeue_buffer.cc
 set(HEADERS config_utils.h
             dequeue_buffer.h
             exceptions.h
+            fiu-local.h
             sockaddr_io.h
             timer.h
             types.h
@@ -22,4 +23,3 @@ add_aktualizr_test(NAME types SOURCES types_test.cc)
 add_aktualizr_test(NAME utils SOURCES utils_test.cc PROJECT_WORKING_DIRECTORY)
 
 aktualizr_source_file_checks(${SOURCES} ${HEADERS} ${TEST_SOURCES})
-

--- a/src/libaktualizr/utilities/fault_injection.h
+++ b/src/libaktualizr/utilities/fault_injection.h
@@ -1,3 +1,4 @@
+// This file is a modified version of fiu-local.h, adapted to fit our style conventions
 
 /* libfiu - Fault Injection in Userspace
  *
@@ -13,8 +14,8 @@
  * http://blitiri.com.ar/p/libfiu.
  */
 
-#ifndef _FIU_LOCAL_H
-#define _FIU_LOCAL_H
+#ifndef _FAULT_INJECTION_H
+#define _FAULT_INJECTION_H
 
 /* Only define the stubs when fiu is disabled, otherwise use the real fiu.h
  * header */
@@ -33,4 +34,4 @@
 
 #endif /* FIU_ENABLE */
 
-#endif /* _FIU_LOCAL_H */
+#endif /* _FAULT_INJECTION_H */

--- a/src/libaktualizr/utilities/fiu-local.h
+++ b/src/libaktualizr/utilities/fiu-local.h
@@ -1,0 +1,36 @@
+
+/* libfiu - Fault Injection in Userspace
+ *
+ * This header, part of libfiu, is meant to be included in your project to
+ * avoid having libfiu as a mandatory build-time dependency.
+ *
+ * You can add it to your project, and #include it instead of fiu.h.
+ * The real fiu.h will be used only when FIU_ENABLE is defined.
+ *
+ * This header, as the rest of libfiu, is in the public domain.
+ *
+ * You can find more information about libfiu at
+ * http://blitiri.com.ar/p/libfiu.
+ */
+
+#ifndef _FIU_LOCAL_H
+#define _FIU_LOCAL_H
+
+/* Only define the stubs when fiu is disabled, otherwise use the real fiu.h
+ * header */
+#ifndef FIU_ENABLE
+
+#define fiu_init(flags) 0
+#define fiu_fail(name) 0
+#define fiu_failinfo() NULL
+#define fiu_do_on(name, action)
+#define fiu_exit_on(name)
+#define fiu_return_on(name, retval)
+
+#else
+
+#include <fiu.h>
+
+#endif /* FIU_ENABLE */
+
+#endif /* _FIU_LOCAL_H */


### PR DESCRIPTION
Requires libfiu-dev on Debian derived distros.

Then:

```
cmake .. -DFAULT_INJECTION=on
make aktualizr
fiu-run -c 'enable name=fake_package_install' aktualizr -c . once
```
