### PR TITLE
Test: fetcher death

### DIFF
--- a/cmake-modules/AddAktualizrTest.cmake
+++ b/cmake-modules/AddAktualizrTest.cmake
@@ -17,7 +17,7 @@ function(add_aktualizr_test)
     endif()
 
     # run tests under valgrind if the correct CMAKE_BUILD_TYPE is set
-    if(CMAKE_BUILD_TYPE MATCHES "Valgrind")
+    if((CMAKE_BUILD_TYPE MATCHES "Valgrind") AND (NOT AKTUALIZR_TEST_NO_VALGRIND))
         add_test(NAME test_${AKTUALIZR_TEST_NAME}
                  COMMAND ${RUN_VALGRIND} ${CMAKE_CURRENT_BINARY_DIR}/t_${AKTUALIZR_TEST_NAME} ${AKTUALIZR_TEST_ARGS} ${GOOGLE_TEST_OUTPUT}
                  ${WD})

--- a/src/libaktualizr/uptane/CMakeLists.txt
+++ b/src/libaktualizr/uptane/CMakeLists.txt
@@ -72,4 +72,6 @@ add_aktualizr_test(NAME uptane_init SOURCES uptane_init_test.cc PROJECT_WORKING_
 
 add_aktualizr_test(NAME fetcher SOURCES fetcher_test.cc ARGS ${PROJECT_BINARY_DIR}/ostree_repo PROJECT_WORKING_DIRECTORY)
 
+add_aktualizr_test(NAME fetcher_death SOURCES fetcher_death_test.cc ARGS PROJECT_WORKING_DIRECTORY)
+
 aktualizr_source_file_checks(${SOURCES} ${HEADERS} opcuasecondary.cc opcuasecondary.h ${TEST_SOURCES})

--- a/src/libaktualizr/uptane/CMakeLists.txt
+++ b/src/libaktualizr/uptane/CMakeLists.txt
@@ -72,6 +72,6 @@ add_aktualizr_test(NAME uptane_init SOURCES uptane_init_test.cc PROJECT_WORKING_
 
 add_aktualizr_test(NAME fetcher SOURCES fetcher_test.cc ARGS ${PROJECT_BINARY_DIR}/ostree_repo PROJECT_WORKING_DIRECTORY)
 
-add_aktualizr_test(NAME fetcher_death SOURCES fetcher_death_test.cc ARGS PROJECT_WORKING_DIRECTORY)
+add_aktualizr_test(NAME fetcher_death SOURCES fetcher_death_test.cc NO_VALGRIND ARGS PROJECT_WORKING_DIRECTORY)
 
 aktualizr_source_file_checks(${SOURCES} ${HEADERS} opcuasecondary.cc opcuasecondary.h ${TEST_SOURCES})

--- a/src/libaktualizr/uptane/fetcher.h
+++ b/src/libaktualizr/uptane/fetcher.h
@@ -40,6 +40,7 @@ class Fetcher {
   bool fetchLatestRole(std::string* result, int64_t maxsize, RepositoryType repo, Uptane::Role role) {
     return fetchRole(result, maxsize, repo, role, Version());
   }
+  void restoreHasherState(MultiPartHasher& hasher, StorageTargetRHandle* data);
   bool isPaused() {
     std::lock_guard<std::mutex> guard(mutex_);
     return pause_;
@@ -82,7 +83,7 @@ struct DownloadMetaStruct {
         target{std::move(target_in)},
         fetcher{nullptr},
         progress_cb{std::move(progress_cb_in)} {}
-  uint64_t downloaded_length{};
+  uint64_t downloaded_length{0};
   unsigned int last_progress{0};
   std::unique_ptr<StorageTargetWHandle> fhandle;
   const Hash::Type hash_type;

--- a/src/libaktualizr/uptane/fetcher_death_test.cc
+++ b/src/libaktualizr/uptane/fetcher_death_test.cc
@@ -1,0 +1,102 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <csignal>
+#include <future>
+#include <iostream>
+#include <string>
+#include <thread>
+#include "fetcher.h"
+#include "http/httpclient.h"
+#include "logging/logging.h"
+#include "storage/sqlstorage.h"
+#include "test_utils.h"
+#include "tuf.h"
+
+static const int die_after = 50;       // percent
+static const int pause_duration = 20;  // seconds
+
+std::string server;
+
+static std::mutex pause_m;
+static std::condition_variable cv;
+static bool die = false;
+static bool resumed = false;
+
+Config config;
+
+static void progress_cb(const Uptane::Target& target, const std::string& description, unsigned int progress) {
+  (void)target;
+  (void)description;
+  std::cout << "progress: " << progress << std::endl;
+  if (progress >= die_after) {
+    std::lock_guard<std::mutex> lk(pause_m);
+    die = true;
+    cv.notify_all();
+  }
+  if (resumed) {
+    EXPECT_GE(progress, die_after);
+  }
+}
+
+void resume(const Uptane::Target& target) {
+  std::shared_ptr<INvStorage> storage(new SQLStorage(config.storage, false));
+  auto http = std::make_shared<HttpClient>();
+  Uptane::Fetcher f(config, storage, http, progress_cb);
+
+  resumed = true;
+  bool res = f.fetchVerifyTarget(target);
+
+  EXPECT_TRUE(res);
+}
+
+void pause_and_die(const Uptane::Target& target) {
+  std::shared_ptr<INvStorage> storage(new SQLStorage(config.storage, false));
+  auto http = std::make_shared<HttpClient>();
+  Uptane::Fetcher f(config, storage, http, progress_cb);
+
+  std::promise<bool> download_promise;
+  auto result = download_promise.get_future();
+
+  std::thread([&f, &target, &download_promise]() {
+    bool res = f.fetchVerifyTarget(target);
+    download_promise.set_value(res);
+  })
+      .detach();
+
+  std::unique_lock<std::mutex> lk(pause_m);
+  cv.wait(lk, [] { return die; });
+  f.setPause(true);
+  std::this_thread::sleep_for(std::chrono::seconds(pause_duration));
+  std::raise(SIGKILL);
+}
+
+TEST(FetcherDeathTest, TestResumeBinary) {
+  TemporaryDirectory temp_dir;
+  config.storage.path = temp_dir.Path();
+
+  Json::Value target_json;
+  target_json["hashes"]["sha256"] = "dd7bd1c37a3226e520b8d6939c30991b1c08772d5dab62b381c3a63541dc629a";
+  target_json["length"] = 100 * (1 << 20);
+
+  Uptane::Target target("large_file", target_json);
+  ASSERT_DEATH(pause_and_die(target), "");
+  std::cout << "Fetcher died, retrying" << std::endl;
+  resume(target);
+}
+
+#ifndef __NO_MAIN__
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+  logger_init();
+  logger_set_threshold(boost::log::trivial::trace);
+
+  std::string port = TestUtils::getFreePort();
+  server = "http://127.0.0.1:" + port;
+  config.uptane.repo_server = server;
+  TestHelperProcess http_server_process("tests/fake_http_server/fake_http_server.py", port);
+  TestUtils::waitForServer(server + "/");
+  return RUN_ALL_TESTS();
+}
+#endif  // __NO_MAIN__

--- a/src/libaktualizr/uptane/fetcher_test.cc
+++ b/src/libaktualizr/uptane/fetcher_test.cc
@@ -14,7 +14,7 @@
 
 static const int pause_after = 50;        // percent
 static const int pause_duration = 1;      // seconds
-static const int download_timeout = 200;  // seconds.
+static const int download_timeout = 200;  // seconds
 
 static std::string server = "http://127.0.0.1:";
 static std::string treehub_server = "http://127.0.0.1:";
@@ -27,7 +27,6 @@ static bool do_pause = false;
 Config config;
 
 static void progress_cb(const Uptane::Target& target, const std::string& description, unsigned int progress) {
-  (void)target;
   (void)description;
   std::cout << "progress callback: " << progress << std::endl;
   if (!target.IsOstree() && !do_pause) {

--- a/tests/test_utils.cc
+++ b/tests/test_utils.cc
@@ -2,7 +2,7 @@
 
 #include <signal.h>
 
-#if defined(OS_LINUX)
+#if __linux__
 #include <sys/prctl.h>
 #endif
 #include <chrono>
@@ -85,7 +85,7 @@ void TestHelperProcess::run(const char *argv0, const char *args[]) {
     throw std::runtime_error("Failed to execute process:" + std::string(argv0));
   }
   if (pid_ == 0) {
-#if defined(OS_LINUX)
+#if __linux__
     prctl(PR_SET_PDEATHSIG, SIGTERM);
 #endif
     execvp(argv0, const_cast<char *const *>(args));


### PR DESCRIPTION
A test scenario for the use-case when aktualizr process gets killed while being in a `pause` state. When the fetcher is called again, it's expected to start the download from the point it was paused on.
Currently, a delay of 15 seconds between `pause` call and killing the process is needed, as we have no reliable way to know when all background operations are completed, so we can resume later.
The PR also includes a fix for a stack overflow issue, that is triggered by this test on `resume`.
