### PR TITLE
sotauptaneclient: Provide access to image-repository targets

### DIFF
--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -1250,3 +1250,10 @@ std::string SotaUptaneClient::secondaryTreehubCredentials() const {
     return "";
   }
 }
+
+const std::vector<Uptane::Target> SotaUptaneClient::GetRepoTargets() {
+  if (!updateImagesMeta()) {
+    LOG_ERROR << "Unable to get latest repo data";
+  }
+  return images_repo.getTargets();
+}

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -55,6 +55,8 @@ class SotaUptaneClient {
   result::CampaignCheck campaignCheck();
   void campaignAccept(const std::string &campaign_id);
 
+  const std::vector<Uptane::Target> GetRepoTargets();
+
  private:
   FRIEND_TEST(Aktualizr, FullNoUpdates);
   FRIEND_TEST(Aktualizr, FullMultipleSecondaries);

--- a/src/libaktualizr/uptane/imagesrepository.h
+++ b/src/libaktualizr/uptane/imagesrepository.h
@@ -23,6 +23,8 @@ class ImagesRepository : public RepositoryCommon {
   bool snapshotExpired() { return snapshot.isExpired(TimeStamp::Now()); }
   int64_t snapshotSize() { return timestamp.snapshot_size(); }
 
+  const std::vector<Target> getTargets() { return targets.targets; }
+
   Exception getLastException() const { return last_exception; }
 
  private:


### PR DESCRIPTION
This is related to issue:
  https://github.com/advancedtelematic/aktualizr/issues/1056

In order for an application to find the latest target, it will need
access to the list of targets found in the image repository.

Signed-off-by: Andy Doan <andy@foundries.io>