### PR TITLE
Fixes for ReportQueue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,8 +137,8 @@ endif(FAULT_INJECTION)
 #add_definitions(-DBOOST_LOG_DYN_LINK)
 
 if(NOT CMAKE_BUILD_TYPE)
-    message(STATUS "No CMAKE_BUILD_TYPE specified, defaulting to Valgrind")
-    set(CMAKE_BUILD_TYPE Valgrind)
+    set(CMAKE_BUILD_TYPE "Release")
+    message(STATUS "No CMAKE_BUILD_TYPE specified, defaulting to ${CMAKE_BUILD_TYPE}")
 endif(NOT CMAKE_BUILD_TYPE)
 
 set(CMAKE_CXX_FLAGS_DEBUG "-Og -g")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,14 @@ set(CMAKE_CXX_FLAGS_DEBUG "-Og -g")
 SET(CMAKE_CXX_FLAGS_VALGRIND "-O1 -g")
 SET(CMAKE_C_FLAGS_VALGRIND "-O1 -g")
 
+SET(CMAKE_CXX_FLAGS_ASAN "-O1 -g -fsanitize=address -fsanitize=leak -fsanitize=undefined -fno-omit-frame-pointer")
+SET(CMAKE_C_FLAGS_ASAN "-O1 -g -fsanitize=address -fsanitize=leak -fsanitize=undefined -fno-omit-frame-pointer")
+SET(CMAKE_EXE_LINKER_FLAGS_ASAN "-O1 -g -fsanitize=address -fsanitize=leak -fsanitize=undefined -fno-omit-frame-pointer")
+
+SET(CMAKE_CXX_FLAGS_TSAN "-O1 -g -fsanitize=thread -fno-omit-frame-pointer")
+SET(CMAKE_C_FLAGS_TSAN "-O1 -g -fsanitize=thread -fno-omit-frame-pointer")
+SET(CMAKE_EXE_LINKER_FLAGS_TSAN "-O1 -g -fsanitize=thread -fno-omit-frame-pointer")
+
 # prevent visibility warnings from the linker
 if (APPLE)
   link_libraries("-Wl,-w")

--- a/src/libaktualizr/primary/reportqueue.cc
+++ b/src/libaktualizr/primary/reportqueue.cc
@@ -5,16 +5,16 @@
 #include "config/config.h"
 
 ReportQueue::ReportQueue(const Config& config_in, std::shared_ptr<HttpInterface> http_client)
-    : config(config_in), http(std::move(http_client)), shutdown_(false) {
+    : config(config_in), http(std::move(http_client)) {
   thread_ = std::thread(std::bind(&ReportQueue::run, this));
 }
 
 ReportQueue::~ReportQueue() {
-  shutdown_ = true;
   {
-    std::unique_lock<std::mutex> thread_lock(thread_mutex_);
-    cv_.notify_all();
+    std::lock_guard<std::mutex> lock(m_);
+    shutdown_ = true;
   }
+  cv_.notify_all();
   thread_.join();
 
   LOG_DEBUG << "Flushing report queue";
@@ -25,31 +25,28 @@ void ReportQueue::run() {
   // Check if queue is nonempty. If so, move any reports to the Json array and
   // try to send it to the server. Clear the Json array only if the send
   // succeeds.
+  std::unique_lock<std::mutex> lock(m_);
   while (!shutdown_) {
-    std::unique_lock<std::mutex> thread_lock(thread_mutex_);
     flushQueue();
-    cv_.wait_for(thread_lock, std::chrono::seconds(10));
+    cv_.wait_for(lock, std::chrono::seconds(10));
   }
 }
 
 void ReportQueue::enqueue(std::unique_ptr<ReportEvent> event) {
   {
-    std::lock_guard<std::mutex> queue_lock(queue_mutex_);
+    std::lock_guard<std::mutex> lock(m_);
     report_queue_.push(std::move(event));
   }
   cv_.notify_all();
 }
 
 void ReportQueue::flushQueue() {
-  if (!report_queue_.empty()) {
-    std::lock_guard<std::mutex> queue_lock(queue_mutex_);
-    while (!report_queue_.empty()) {
-      report_array.append(report_queue_.front()->toJson());
-      report_queue_.pop();
-    }
+  while (!report_queue_.empty()) {
+    report_array.append(report_queue_.front()->toJson());
+    report_queue_.pop();
   }
 
-  if (report_array.size() > 0) {
+  if (!report_array.empty()) {
     HttpResponse response = http->post(config.tls.server + "/events", report_array);
     // 404 implies the server does not support this feature. Nothing we can
     // do, just move along.

--- a/src/libaktualizr/primary/reportqueue.h
+++ b/src/libaktualizr/primary/reportqueue.h
@@ -76,11 +76,10 @@ class ReportQueue {
   std::shared_ptr<HttpInterface> http;
   std::thread thread_;
   std::condition_variable cv_;
-  std::mutex thread_mutex_;
-  std::mutex queue_mutex_;
+  std::mutex m_;
   std::queue<std::unique_ptr<ReportEvent>> report_queue_;
   Json::Value report_array{Json::arrayValue};
-  bool shutdown_;
+  bool shutdown_{false};
 };
 
 #endif  // REPORTQUEUE_H_


### PR DESCRIPTION
I've played a bit with a [ThreadSanitizer](https://github.com/google/sanitizers/wiki/ThreadSanitizerCppManual). There is a considerable amount of false positives, as ThreadSanitizer requires all libraries to be rebuild, and I didn't do that. But it still was able to find some interesting stuff. 
There are two issues with the current syncronization scheme of ReportQueue:
Member `shutdown_` is modified and checked out of the critical section, which may lead to various race conditions, e.g.:
```
      Run() checks that shutdown is false
      ~ReportQueue() sets shutdown_ to true
      ~ReportQueue() locks mutex and does cv.notify_all()
      Run() locks mutex and starts to wait on the CV
```
`flushQueue()` checks `report_queue_.empty()` out of the critical section and uses a different mutex, not the one than is used with CV. Consider:
```
      flushQueue() checks that report_queue_.empty() is true
      enqueue() locks, pushes and notifies
      flushQueue() starts to to wait on the CV
```