### PR TITLE
Do not run memory test if BUILD_DEB is off.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -103,9 +103,11 @@ if(SOTA_PACKED_CREDENTIALS)
     endif(BUILD_P11 AND TEST_PKCS11_MODULE_PATH)
 endif(SOTA_PACKED_CREDENTIALS)
 
+if(BUILD_DEB)
+    add_test(NAME memory_test COMMAND ${PROJECT_SOURCE_DIR}/tests/memory_usage_test.sh
+             ${PROJECT_BINARY_DIR} WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+endif(BUILD_DEB)
 
-add_test(NAME memory_test COMMAND ${PROJECT_SOURCE_DIR}/tests/memory_usage_test.sh ${PROJECT_BINARY_DIR}
-            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 ###############################################################################
 # The test feature of cmake checks the return value when the program
 # exits. If the return value is zero, the testcase passes.


### PR DESCRIPTION
It will fail, as it requires libdpkg support.