### PR TITLE
Build with shared boost libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,9 +42,12 @@ configure_file(CTestCustom.cmake CTestCustom.cmake)
 
 unset(AKTUALIZR_CHECKED_SRCS CACHE)
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # find all required libraries
-set(Boost_USE_STATIC_LIBS ON)
 set(BOOST_COMPONENTS log_setup log filesystem program_options)
+set(Boost_USE_STATIC_LIBS OFF)
+add_definitions(-DBOOST_LOG_DYN_LINK)
 
 if(BUILD_OPCUA)
     list(APPEND BOOST_COMPONENTS serialization iostreams)

--- a/docker/Dockerfile-test-install.ubuntu.bionic
+++ b/docker/Dockerfile-test-install.ubuntu.bionic
@@ -6,6 +6,12 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get -y install debian-archive-keyring
 RUN apt-get update && apt-get install -y \
   libarchive13 \
+  libboost-iostreams1.65.1 \
+  libboost-log1.65.1 \
+  libboost-program-options1.65.1 \
+  libboost-system1.65.1 \
+  libboost-test1.65.1 \
+  libboost-thread1.65.1 \
   libc6 \
   libcurl4 \
   libglib2.0-0 \

--- a/docker/Dockerfile-test-install.ubuntu.xenial
+++ b/docker/Dockerfile-test-install.ubuntu.xenial
@@ -6,6 +6,12 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get -y install debian-archive-keyring
 RUN apt-get update && apt-get install -y \
   libarchive13 \
+  libboost-iostreams1.58.0 \
+  libboost-log1.58.0 \
+  libboost-program-options1.58.0 \
+  libboost-system1.58.0 \
+  libboost-test1.58.0 \
+  libboost-thread1.58.0 \
   libc6 \
   libcurl3 \
   libglib2.0-0 \

--- a/docker/Dockerfile.debian.testing
+++ b/docker/Dockerfile.debian.testing
@@ -28,8 +28,6 @@ RUN apt-get update && apt-get -y install \
   libboost-iostreams-dev \
   libboost-log-dev \
   libboost-program-options-dev \
-  libboost-random-dev \
-  libboost-regex-dev \
   libboost-system-dev \
   libboost-test-dev \
   libboost-thread-dev \

--- a/docker/Dockerfile.ubuntu.bionic
+++ b/docker/Dockerfile.ubuntu.bionic
@@ -24,8 +24,6 @@ RUN apt-get update && apt-get -y install \
   libboost-iostreams-dev \
   libboost-log-dev \
   libboost-program-options-dev \
-  libboost-random-dev \
-  libboost-regex-dev \
   libboost-system-dev \
   libboost-test-dev \
   libboost-thread-dev \

--- a/docker/Dockerfile.ubuntu.xenial
+++ b/docker/Dockerfile.ubuntu.xenial
@@ -26,8 +26,6 @@ RUN apt-get update && apt-get -y install \
   libboost-iostreams-dev \
   libboost-log-dev \
   libboost-program-options-dev \
-  libboost-random-dev \
-  libboost-regex-dev \
   libboost-system-dev \
   libboost-test-dev \
   libboost-thread-dev \

--- a/src/libaktualizr/utilities/utils_test.cc
+++ b/src/libaktualizr/utilities/utils_test.cc
@@ -12,7 +12,6 @@
 
 #include <boost/algorithm/hex.hpp>
 #include <boost/archive/iterators/dataflow_exception.hpp>
-#include <boost/random/uniform_smallint.hpp>
 
 #include "utilities/utils.h"
 
@@ -122,9 +121,9 @@ TEST(Utils, FromBase64Wrong) {
 
 TEST(Utils, Base64RoundTrip) {
   std::mt19937 gen;
-  boost::random::uniform_smallint<char> chars(std::numeric_limits<char>::min(), std::numeric_limits<char>::max());
+  std::uniform_int_distribution<char> chars(std::numeric_limits<char>::min(), std::numeric_limits<char>::max());
 
-  boost::random::uniform_smallint<int> length(0, 20);
+  std::uniform_int_distribution<int> length(0, 20);
 
   for (int test = 0; test < 100; test++) {
     int len = length(gen);


### PR DESCRIPTION
I'm not sure if we should keep linking with static libraries for the debian case, or make it dynamic everywhere.
This might also break meta-updater due to changed run-time dependencies.
Otherwise, I see no benefits in linking boost statically.