### PR TITLE
Remove instances of popen_subprocess in prov tests

### DIFF
--- a/tests/auto_prov_test.py
+++ b/tests/auto_prov_test.py
@@ -7,7 +7,7 @@ import tempfile
 
 from pathlib import Path
 
-from prov_test_common import popen_subprocess, verify_provisioned
+from prov_test_common import run_subprocess, verify_provisioned
 
 
 def main():
@@ -44,7 +44,7 @@ def provision(tmp_dir, build_dir, creds):
     akt = build_dir / 'src/aktualizr_primary/aktualizr'
     akt_info = build_dir / 'src/aktualizr_info/aktualizr-info'
 
-    popen_subprocess([str(akt), '--config', str(conf), '--run-mode', 'once'])
+    run_subprocess([str(akt), '--config', str(conf), '--run-mode', 'once'])
     return verify_provisioned(akt_info, conf)
 
 

--- a/tests/hsm_prov_test.py
+++ b/tests/hsm_prov_test.py
@@ -8,9 +8,8 @@ import shutil
 import tempfile
 
 from pathlib import Path
-from time import sleep
 
-from prov_test_common import popen_subprocess, run_subprocess, verify_provisioned
+from prov_test_common import run_subprocess, verify_provisioned
 
 
 def main():
@@ -80,14 +79,9 @@ def provision(tmp_dir, build_dir, src_dir, creds, pkcs11_module):
     shutil.copyfile(str(src_dir / "tests/test_data/softhsm2.conf"), str(hsm_conf))
 
     akt_input = [str(akt), '--config', str(conf_dir), '--loglevel', '0', '--run-mode', 'once']
-    popen_subprocess(akt_input)
+    run_subprocess(akt_input)
     # Verify that device has NOT yet provisioned.
-    for delay in [1, 2, 5, 10, 15]:
-        sleep(delay)
-        stdout, stderr, retcode = run_subprocess([str(akt_info),
-                                                  '--config', str(conf_dir)])
-        if retcode == 0 and stderr == b'':
-            break
+    stdout, stderr, retcode = run_subprocess([str(akt_info), '--config', str(conf_dir)])
     if (b'Couldn\'t load device ID' not in stdout or
             b'Couldn\'t load ECU serials' not in stdout or
             b'Provisioned on server: no' not in stdout or
@@ -149,7 +143,7 @@ def provision(tmp_dir, build_dir, src_dir, creds, pkcs11_module):
         return 1
 
     (tmp_dir / 'sql.db').unlink()
-    popen_subprocess(akt_input)
+    run_subprocess(akt_input)
     return verify_provisioned(akt_info, conf_dir)
 
 

--- a/tests/implicit_prov_test.py
+++ b/tests/implicit_prov_test.py
@@ -2,14 +2,12 @@
 
 import argparse
 import os
-import subprocess
 import sys
 import tempfile
 
 from pathlib import Path
-from time import sleep
 
-from prov_test_common import popen_subprocess, run_subprocess, verify_provisioned
+from prov_test_common import run_subprocess, verify_provisioned
 
 
 def main():
@@ -54,14 +52,9 @@ def provision(tmp_dir, build_dir, creds):
     akt_cp = build_dir / 'src/cert_provider/aktualizr-cert-provider'
 
     akt_input = [str(akt), '--config', str(conf_dir), '--run-mode', 'once']
-    popen_subprocess(akt_input)
+    run_subprocess(akt_input)
     # Verify that device has NOT yet provisioned.
-    for delay in [1, 2, 5, 10, 15]:
-        sleep(delay)
-        stdout, stderr, retcode = run_subprocess([str(akt_info),
-                                                  '--config', str(conf_dir)])
-        if retcode == 0 and stderr == b'':
-            break
+    stdout, stderr, retcode = run_subprocess([str(akt_info), '--config', str(conf_dir)])
     if (b'Couldn\'t load device ID' not in stdout or
             b'Couldn\'t load ECU serials' not in stdout or
             b'Provisioned on server: no' not in stdout or
@@ -78,7 +71,7 @@ def provision(tmp_dir, build_dir, creds):
               stderr.decode() + stdout.decode())
         return retcode
 
-    popen_subprocess(akt_input)
+    run_subprocess(akt_input)
     return verify_provisioned(akt_info, conf_dir)
 
 

--- a/tests/prov_test_common.py
+++ b/tests/prov_test_common.py
@@ -30,7 +30,3 @@ def run_subprocess(command, **kwargs):
     print('> Running {}'.format(' '.join(command)))
     s = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False, **kwargs)
     return s.stdout, s.stderr, s.returncode
-
-def popen_subprocess(command, **kwargs):
-    print('> Running {}'.format(' '.join(command)))
-    return subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kwargs)


### PR DESCRIPTION
There is no need to launch `aktualizr once` as a background process before checking for provisioning as it should terminate by itself.

I'm not sure of the original intent but it should hopefully work this way.