### PR TITLE
Increase scope of pause api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Our versioning scheme is `YEAR.N` where `N` is incremented whenever a new releas
 - Basic first-order delegation support: [PR](https://github.com/advancedtelematic/aktualizr/pull/1074)
 - Backward migrations of the SQL storage is now supported. It should allow rollbacking updates up to versions containing the feature: [PR](https://github.com/advancedtelematic/aktualizr/pull/1072)
 
+### Changed
+
+- The Pause and Resume can now be called at any time and will also pause the internal event queue. API calls during the pause period will be queued up and resumed in order at the end.
+
 ## [2019.1] - 2019-01-10
 
 ### Changed

--- a/actions.md
+++ b/actions.md
@@ -93,6 +93,13 @@ These are the primary actions that a user of libaktualizr can perform through th
   - [x] Send UpdateCheckComplete event with available updates (aktualizr_test.cc)
   - [x] Send UpdateCheckComplete event after successful check with no available updates (aktualizr_test.cc)
   - [x] Send UpdateCheckComplete event after failure (aktualizr_test.cc)
+- [x] Pause and Resume the API
+  - [ ] Suspend API calls during pause
+  - [ ] Catch up with calls queue after resume
+  - [ ] Pause ongoing download
+  - [ ] Resume ongoing download
+  - [x] Send Paused event (aktualizr_test.cc)
+  - [x] Send Resumed event (aktualizr_test.cc)
 - [x] Download updates
   - [x] Find requested target
     - [x] Search first-order delegations (uptane_delegation_test.cc)
@@ -105,12 +112,10 @@ These are the primary actions that a user of libaktualizr can perform through th
   - [x] Pause downloading (fetcher_test.cc)
     - [x] Pausing while paused is ignored (fetcher_test.cc)
     - [x] Pausing while not downloading is ignored (fetcher_test.cc)
-    - [x] Send DownloadPaused event (aktualizr_test.cc)
   - [x] Resume downloading (fetcher_test.cc)
     - [x] Resuming while not paused is ignored (fetcher_test.cc)
     - [x] Resuming while not downloading is ignored (fetcher_test.cc)
     - [x] Resume download interrupted by restart (fetcher_test.cc)
-    - [x] Send DownloadResumed event (aktualizr_test.cc)
   - [x] Verify a downloaded update
     - [x] Verify an OSTree package (fetcher_test.cc)
     - [x] Verify a binary package (uptane_vector_tests.cc, aktualizr_test.cc)

--- a/actions.md
+++ b/actions.md
@@ -94,12 +94,10 @@ These are the primary actions that a user of libaktualizr can perform through th
   - [x] Send UpdateCheckComplete event after successful check with no available updates (aktualizr_test.cc)
   - [x] Send UpdateCheckComplete event after failure (aktualizr_test.cc)
 - [x] Pause and Resume the API
-  - [ ] Suspend API calls during pause
-  - [ ] Catch up with calls queue after resume
+  - [x] Suspend API calls during pause
+  - [x] Catch up with calls queue after resume
   - [ ] Pause ongoing download
   - [ ] Resume ongoing download
-  - [x] Send Paused event (aktualizr_test.cc)
-  - [x] Send Resumed event (aktualizr_test.cc)
 - [x] Download updates
   - [x] Find requested target
     - [x] Search first-order delegations (uptane_delegation_test.cc)

--- a/src/hmi_stub/main.cc
+++ b/src/hmi_stub/main.cc
@@ -83,6 +83,8 @@ bpo::variables_map parse_options(int argc, char *argv[]) {
   return vm;
 }
 
+static std::vector<Uptane::Target> current_updates;
+
 void process_event(const std::shared_ptr<event::BaseEvent> &event) {
   if (event->variant == "DownloadProgressReport") {
     const auto download_progress = dynamic_cast<event::DownloadProgressReport *>(event.get());
@@ -108,10 +110,12 @@ void process_event(const std::shared_ptr<event::BaseEvent> &event) {
     const auto install_complete = dynamic_cast<event::InstallTargetComplete *>(event.get());
     std::cout << "Installation complete for device " << install_complete->serial.ToString() << ": "
               << (install_complete->success ? "success" : "failure") << "\n";
-  } else if (event->variant == "DownloadPaused" || event->variant == "DownloadResumed") {
+  } else if (event->variant == "Paused" || event->variant == "Resumed") {
     // Do nothing.
   } else if (event->variant == "UpdateCheckComplete") {
-    // Do nothing; libaktualizr already logs it.
+    const auto check_complete = dynamic_cast<event::UpdateCheckComplete *>(event.get());
+    current_updates = check_complete->result.updates;
+    std::cout << current_updates.size() << " updates available\n";
   } else {
     std::cout << "Received " << event->variant << " event\n";
   }
@@ -141,8 +145,6 @@ int main(int argc, char *argv[]) {
 
     aktualizr.Initialize();
 
-    std::vector<Uptane::Target> updates;
-    result::Pause pause_result = result::Pause::kNotDownloading;
     std::string buffer;
     while (std::getline(std::cin, buffer)) {
       boost::algorithm::to_lower(buffer);
@@ -153,47 +155,17 @@ int main(int argc, char *argv[]) {
         aktualizr.SendDeviceData();
       } else if (buffer == "fetchmetadata" || buffer == "fetchmeta" || buffer == "checkupdates" || buffer == "check") {
         auto fut_result = aktualizr.CheckUpdates();
-        if (pause_result != result::Pause::kPaused && pause_result != result::Pause::kAlreadyPaused) {
-          result::UpdateCheck result = fut_result.get();
-          updates = result.updates;
-          std::cout << updates.size() << " updates available\n";
-        }
       } else if (buffer == "download" || buffer == "startdownload") {
-        aktualizr.Download(updates);
+        aktualizr.Download(current_updates);
       } else if (buffer == "install" || buffer == "uptaneinstall") {
-        aktualizr.Install(updates);
-        updates.clear();
+        aktualizr.Install(current_updates);
+        current_updates.clear();
       } else if (buffer == "campaigncheck") {
         aktualizr.CampaignCheck();
       } else if (buffer == "pause") {
-        pause_result = aktualizr.Pause();
-        switch (pause_result) {
-          case result::Pause::kPaused:
-            std::cout << "Download paused.\n";
-            break;
-          case result::Pause::kAlreadyPaused:
-            std::cout << "Download already paused.\n";
-            break;
-          case result::Pause::kNotDownloading:
-            std::cout << "Download is not in progress.\n";
-            break;
-          default:
-            std::cout << "Unrecognized pause result: " << static_cast<int>(pause_result) << "\n";
-            break;
-        }
+        aktualizr.Pause();
       } else if (buffer == "resume") {
-        pause_result = aktualizr.Resume();
-        switch (pause_result) {
-          case result::Pause::kResumed:
-            std::cout << "Download resumed.\n";
-            break;
-          case result::Pause::kNotPaused:
-            std::cout << "Download not paused.\n";
-            break;
-          default:
-            std::cout << "Unrecognized resume result: " << static_cast<int>(pause_result) << "\n";
-            break;
-        }
+        aktualizr.Resume();
       } else if (!buffer.empty()) {
         std::cout << "Unknown command.\n";
       }

--- a/src/hmi_stub/main.cc
+++ b/src/hmi_stub/main.cc
@@ -110,8 +110,6 @@ void process_event(const std::shared_ptr<event::BaseEvent> &event) {
     const auto install_complete = dynamic_cast<event::InstallTargetComplete *>(event.get());
     std::cout << "Installation complete for device " << install_complete->serial.ToString() << ": "
               << (install_complete->success ? "success" : "failure") << "\n";
-  } else if (event->variant == "Paused" || event->variant == "Resumed") {
-    // Do nothing.
   } else if (event->variant == "UpdateCheckComplete") {
     const auto check_complete = dynamic_cast<event::UpdateCheckComplete *>(event.get());
     current_updates = check_complete->result.updates;

--- a/src/libaktualizr/primary/aktualizr.cc
+++ b/src/libaktualizr/primary/aktualizr.cc
@@ -143,13 +143,15 @@ std::future<result::Install> Aktualizr::Install(const std::vector<Uptane::Target
 }
 
 void Aktualizr::Pause() {
-  api_queue_.pause(true);
-  uptane_client_->pause();
+  if (api_queue_.pause(true)) {
+    uptane_client_->pause();
+  }
 }
 
 void Aktualizr::Resume() {
-  api_queue_.pause(false);
-  uptane_client_->resume();
+  if (api_queue_.pause(false)) {
+    uptane_client_->resume();
+  }
 }
 
 boost::signals2::connection Aktualizr::SetSignalHandler(std::function<void(shared_ptr<event::BaseEvent>)> &handler) {

--- a/src/libaktualizr/primary/aktualizr.cc
+++ b/src/libaktualizr/primary/aktualizr.cc
@@ -142,16 +142,24 @@ std::future<result::Install> Aktualizr::Install(const std::vector<Uptane::Target
   return promise->get_future();
 }
 
-void Aktualizr::Pause() {
+result::Pause Aktualizr::Pause() {
   if (api_queue_.pause(true)) {
-    uptane_client_->pause();
+    uptane_client_->pauseFetching();
+
+    return {result::PauseStatus::kSuccess};
   }
+
+  return {result::PauseStatus::kAlreadyPaused};
 }
 
-void Aktualizr::Resume() {
+result::Pause Aktualizr::Resume() {
   if (api_queue_.pause(false)) {
-    uptane_client_->resume();
+    uptane_client_->resumeFetching();
+
+    return {result::PauseStatus::kSuccess};
   }
+
+  return {result::PauseStatus::kAlreadyRunning};
 }
 
 boost::signals2::connection Aktualizr::SetSignalHandler(std::function<void(shared_ptr<event::BaseEvent>)> &handler) {

--- a/src/libaktualizr/primary/aktualizr.cc
+++ b/src/libaktualizr/primary/aktualizr.cc
@@ -142,9 +142,15 @@ std::future<result::Install> Aktualizr::Install(const std::vector<Uptane::Target
   return promise->get_future();
 }
 
-result::Pause Aktualizr::Pause() { return uptane_client_->pause(); }
+void Aktualizr::Pause() {
+  api_queue_.pause(true);
+  uptane_client_->pause();
+}
 
-result::Pause Aktualizr::Resume() { return uptane_client_->resume(); }
+void Aktualizr::Resume() {
+  api_queue_.pause(false);
+  uptane_client_->resume();
+}
 
 boost::signals2::connection Aktualizr::SetSignalHandler(std::function<void(shared_ptr<event::BaseEvent>)> &handler) {
   return sig_->connect(handler);

--- a/src/libaktualizr/primary/aktualizr.h
+++ b/src/libaktualizr/primary/aktualizr.h
@@ -39,10 +39,14 @@ class ApiQueue {
     enqueue(std::function<void()>());
   }
 
-  void pause(bool do_pause) {
+  // returns true iff pause→resume or resume→pause
+  bool pause(bool do_pause) {
     std::lock_guard<std::mutex> lock(m_);
+    bool has_effect = paused_ != do_pause;
     paused_ = do_pause;
     c_.notify_one();
+
+    return has_effect;
   }
 
  private:

--- a/src/libaktualizr/primary/aktualizr.h
+++ b/src/libaktualizr/primary/aktualizr.h
@@ -155,7 +155,7 @@ class Aktualizr {
    *
    * @return Information about pause results.
    */
-  void Pause();
+  result::Pause Pause();
 
   /**
    * Resume the library operations.
@@ -164,7 +164,7 @@ class Aktualizr {
    *
    * @return Information about resume results.
    */
-  void Resume();
+  result::Pause Resume();
 
   /**
    * Synchronously run an uptane cycle: check for updates, download any new
@@ -197,7 +197,7 @@ class Aktualizr {
   FRIEND_TEST(Aktualizr, FullNoCorrelationId);
   FRIEND_TEST(Aktualizr, APICheck);
   FRIEND_TEST(Aktualizr, UpdateCheckCompleteError);
-  FRIEND_TEST(Aktualizr, PauseResumeEvents);
+  FRIEND_TEST(Aktualizr, PauseResumeQueue);
   FRIEND_TEST(Aktualizr, AddSecondary);
   FRIEND_TEST(Delegation, Basic);
 

--- a/src/libaktualizr/primary/aktualizr.h
+++ b/src/libaktualizr/primary/aktualizr.h
@@ -23,7 +23,7 @@ class ApiQueue {
 
   std::function<void()> dequeue() {
     std::unique_lock<std::mutex> wait_lock(m_);
-    while (q_.empty()) {
+    while (q_.empty() || paused_) {
       c_.wait(wait_lock);
       if (shutdown_) {
         return std::function<void()>();
@@ -33,9 +33,16 @@ class ApiQueue {
     q_.pop();
     return val;
   }
+
   void shutDown() {
     shutdown_ = true;
     enqueue(std::function<void()>());
+  }
+
+  void pause(bool do_pause) {
+    std::lock_guard<std::mutex> lock(m_);
+    paused_ = do_pause;
+    c_.notify_one();
   }
 
  private:
@@ -43,6 +50,7 @@ class ApiQueue {
   mutable std::mutex m_;
   std::condition_variable c_;
   std::atomic_bool shutdown_{false};
+  std::atomic_bool paused_{false};
 };
 
 /**
@@ -138,16 +146,21 @@ class Aktualizr {
   std::future<result::Install> Install(const std::vector<Uptane::Target>& updates);
 
   /**
-   * Pause a download current in progress.
+   * Pause the library operations.
+   * In progress target downloads will be paused and API calls will be deferred.
+   *
    * @return Information about pause results.
    */
-  result::Pause Pause();
+  void Pause();
 
   /**
-   * Resume a paused download.
+   * Resume the library operations.
+   * Target downloads will resume and API calls during pause state will execute
+   * in fifo order.
+   *
    * @return Information about resume results.
    */
-  result::Pause Resume();
+  void Resume();
 
   /**
    * Synchronously run an uptane cycle: check for updates, download any new

--- a/src/libaktualizr/primary/aktualizr_test.cc
+++ b/src/libaktualizr/primary/aktualizr_test.cc
@@ -1058,7 +1058,7 @@ TEST(Aktualizr, UpdateCheckCompleteError) {
   EXPECT_EQ(counter.error_events(), 1);
 }
 
-/* Test that Aktualizr retransmits DownloadPaused and DownloadResumed events */
+/* Test that Aktualizr retransmits Paused and Resumed events */
 TEST(Aktualizr, PauseResumeEvents) {
   TemporaryDirectory temp_dir;
   auto http = std::make_shared<HttpFake>(temp_dir.Path(), "noupdates");
@@ -1073,10 +1073,10 @@ TEST(Aktualizr, PauseResumeEvents) {
                                                                &n_events](std::shared_ptr<event::BaseEvent> event) {
     switch (n_events) {
       case 0:
-        EXPECT_EQ(event->variant, "DownloadPaused");
+        EXPECT_EQ(event->variant, "Paused");
         break;
       case 1:
-        EXPECT_EQ(event->variant, "DownloadResumed");
+        EXPECT_EQ(event->variant, "Resumed");
         end_promise.set_value();
         break;
       default:

--- a/src/libaktualizr/primary/events.h
+++ b/src/libaktualizr/primary/events.h
@@ -58,26 +58,6 @@ class UpdateCheckComplete : public BaseEvent {
 };
 
 /**
- * A download in progress has been paused.
- */
-class Paused : public BaseEvent {
- public:
-  explicit Paused() { variant = "Paused"; }
-  // TODO: info about paused downloads?
-  // result::Pause fetcher_result;
-};
-
-/**
- * A paused download has been resumed.
- */
-class Resumed : public BaseEvent {
- public:
-  explicit Resumed() { variant = "Resumed"; }
-  // TODO: info about resumed downloads?
-  // result::Pause fetcher_result;
-};
-
-/**
  * A report for a download in progress.
  */
 class DownloadProgressReport : public BaseEvent {

--- a/src/libaktualizr/primary/events.h
+++ b/src/libaktualizr/primary/events.h
@@ -60,19 +60,21 @@ class UpdateCheckComplete : public BaseEvent {
 /**
  * A download in progress has been paused.
  */
-class DownloadPaused : public BaseEvent {
+class Paused : public BaseEvent {
  public:
-  explicit DownloadPaused(result::Pause result_in) : result(result_in) { variant = "DownloadPaused"; }
-  result::Pause result;
+  explicit Paused() { variant = "Paused"; }
+  // TODO: info about paused downloads?
+  // result::Pause fetcher_result;
 };
 
 /**
  * A paused download has been resumed.
  */
-class DownloadResumed : public BaseEvent {
+class Resumed : public BaseEvent {
  public:
-  explicit DownloadResumed(result::Pause result_in) : result(result_in) { variant = "DownloadResumed"; }
-  result::Pause result;
+  explicit Resumed() { variant = "Resumed"; }
+  // TODO: info about resumed downloads?
+  // result::Pause fetcher_result;
 };
 
 /**

--- a/src/libaktualizr/primary/reportqueue.cc
+++ b/src/libaktualizr/primary/reportqueue.cc
@@ -79,6 +79,14 @@ CampaignAcceptedReport::CampaignAcceptedReport(const std::string& campaign_id) :
   custom["campaignId"] = campaign_id;
 }
 
+DevicePausedReport::DevicePausedReport(const std::string& correlation_id) : ReportEvent("DevicePaused", 0) {
+  setCorrelationId(correlation_id);
+}
+
+DeviceResumedReport::DeviceResumedReport(const std::string& correlation_id) : ReportEvent("DeviceResumed", 0) {
+  setCorrelationId(correlation_id);
+}
+
 EcuDownloadStartedReport::EcuDownloadStartedReport(const Uptane::EcuSerial& ecu, const std::string& correlation_id)
     : ReportEvent("EcuDownloadStarted", 0) {
   setEcu(ecu);

--- a/src/libaktualizr/primary/reportqueue.h
+++ b/src/libaktualizr/primary/reportqueue.h
@@ -37,6 +37,16 @@ class CampaignAcceptedReport : public ReportEvent {
   CampaignAcceptedReport(const std::string& campaign_id);
 };
 
+class DevicePausedReport : public ReportEvent {
+ public:
+  DevicePausedReport(const std::string& correlation_id);
+};
+
+class DeviceResumedReport : public ReportEvent {
+ public:
+  DeviceResumedReport(const std::string& correlation_id);
+};
+
 class EcuDownloadStartedReport : public ReportEvent {
  public:
   EcuDownloadStartedReport(const Uptane::EcuSerial& ecu, const std::string& correlation_id);

--- a/src/libaktualizr/primary/results.h
+++ b/src/libaktualizr/primary/results.h
@@ -52,12 +52,27 @@ class UpdateCheck {
   std::string message;
 };
 
-#if 0
 /**
  * Result of an attempt to pause or resume a download.
  */
-using Pause = Uptane::Fetcher::PauseRet;
-#endif
+enum class PauseStatus {
+  /* The system was successfully paused or resumed */
+  kSuccess = 0,
+  /* The system was already paused */
+  kAlreadyPaused,
+  /* The system was already running */
+  kAlreadyRunning,
+  /* General error */
+  kError,
+};
+
+class Pause {
+ public:
+  Pause() = default;
+  Pause(PauseStatus status_in) : status(status_in) {}
+
+  PauseStatus status{PauseStatus::kSuccess};
+};
 
 /**
  * Status of an update download.

--- a/src/libaktualizr/primary/results.h
+++ b/src/libaktualizr/primary/results.h
@@ -52,10 +52,12 @@ class UpdateCheck {
   std::string message;
 };
 
+#if 0
 /**
  * Result of an attempt to pause or resume a download.
  */
 using Pause = Uptane::Fetcher::PauseRet;
+#endif
 
 /**
  * Status of an update download.

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -881,14 +881,12 @@ result::Download SotaUptaneClient::downloadImages(const std::vector<Uptane::Targ
   return result;
 }
 
-void SotaUptaneClient::pause() {
+void SotaUptaneClient::pauseFetching() {
   uptane_fetcher->setPause(true);
-  sendEvent<event::Paused>();  // TODO: info about download paused?
 }
 
-void SotaUptaneClient::resume() {
+void SotaUptaneClient::resumeFetching() {
   uptane_fetcher->setPause(false);
-  sendEvent<event::Resumed>();  // TODO: info about download paused?
 }
 
 std::pair<bool, Uptane::Target> SotaUptaneClient::downloadImage(Uptane::Target target) {

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -883,10 +883,16 @@ result::Download SotaUptaneClient::downloadImages(const std::vector<Uptane::Targ
 
 void SotaUptaneClient::pauseFetching() {
   uptane_fetcher->setPause(true);
+
+  const std::string &correlation_id = director_repo.getCorrelationId();
+  report_queue->enqueue(std_::make_unique<DevicePausedReport>(correlation_id));
 }
 
 void SotaUptaneClient::resumeFetching() {
   uptane_fetcher->setPause(false);
+
+  const std::string &correlation_id = director_repo.getCorrelationId();
+  report_queue->enqueue(std_::make_unique<DeviceResumedReport>(correlation_id));
 }
 
 std::pair<bool, Uptane::Target> SotaUptaneClient::downloadImage(Uptane::Target target) {

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -881,20 +881,14 @@ result::Download SotaUptaneClient::downloadImages(const std::vector<Uptane::Targ
   return result;
 }
 
-result::Pause SotaUptaneClient::pause() {
-  result::Pause res = uptane_fetcher->setPause(true);
-
-  sendEvent<event::DownloadPaused>(res);
-
-  return res;
+void SotaUptaneClient::pause() {
+  uptane_fetcher->setPause(true);
+  sendEvent<event::Paused>();  // TODO: info about download paused?
 }
 
-result::Pause SotaUptaneClient::resume() {
-  result::Pause res = uptane_fetcher->setPause(false);
-
-  sendEvent<event::DownloadResumed>(res);
-
-  return res;
+void SotaUptaneClient::resume() {
+  uptane_fetcher->setPause(false);
+  sendEvent<event::Resumed>();  // TODO: info about download paused?
 }
 
 std::pair<bool, Uptane::Target> SotaUptaneClient::downloadImage(Uptane::Target target) {

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -44,8 +44,8 @@ class SotaUptaneClient {
   void initialize();
   void addNewSecondary(const std::shared_ptr<Uptane::SecondaryInterface> &sec);
   result::Download downloadImages(const std::vector<Uptane::Target> &targets);
-  void pause();
-  void resume();
+  void pauseFetching();
+  void resumeFetching();
   void sendDeviceData();
   result::UpdateCheck fetchMeta();
   bool putManifest();

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -44,8 +44,8 @@ class SotaUptaneClient {
   void initialize();
   void addNewSecondary(const std::shared_ptr<Uptane::SecondaryInterface> &sec);
   result::Download downloadImages(const std::vector<Uptane::Target> &targets);
-  result::Pause pause();
-  result::Pause resume();
+  void pause();
+  void resume();
   void sendDeviceData();
   result::UpdateCheck fetchMeta();
   bool putManifest();

--- a/src/libaktualizr/uptane/fetcher.cc
+++ b/src/libaktualizr/uptane/fetcher.cc
@@ -52,16 +52,16 @@ Fetcher::PauseRet Fetcher::setPause(bool pause) {
   std::lock_guard<std::mutex> guard(mutex_);
   if (pause_ == pause) {
     if (pause) {
-      LOG_INFO << "Download is already paused.";
+      LOG_DEBUG << "Fetcher: already paused";
       return PauseRet::kAlreadyPaused;
     } else {
-      LOG_INFO << "Download is not paused, can't resume.";
+      LOG_DEBUG << "Fetcher: nothing to resume";
       return PauseRet::kNotPaused;
     }
   }
 
   if (pause && downloading_ == 0u) {
-    LOG_INFO << "No download in progress, can't pause.";
+    LOG_DEBUG << "Fetcher: nothing to pause";
     return PauseRet::kNotDownloading;
   }
 


### PR DESCRIPTION
Now succeeds at all time: pauses current download as well as the api queue.

I still need to write some tests