### PR TITLE
Add a targets iterator

### DIFF
--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -1375,3 +1375,10 @@ std::string SotaUptaneClient::secondaryTreehubCredentials() const {
     return "";
   }
 }
+
+void SotaUptaneClient::iterateTargets(std::function<bool(const Uptane::Target& t)> callback) {
+  if (!updateImagesMeta()) {
+    LOG_ERROR << "Unable to get latest repo data";
+  }
+  images_repo.iterateTargets(callback);
+}

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -54,6 +54,7 @@ class SotaUptaneClient {
   void installationComplete(const std::shared_ptr<event::BaseEvent> &event);
   result::CampaignCheck campaignCheck();
   void campaignAccept(const std::string &campaign_id);
+  void iterateTargets(std::function<bool(const Uptane::Target& t)> callback);
 
  private:
   FRIEND_TEST(Aktualizr, FullNoUpdates);

--- a/src/libaktualizr/uptane/CMakeLists.txt
+++ b/src/libaktualizr/uptane/CMakeLists.txt
@@ -48,6 +48,7 @@ get_property(ASN1_INCLUDE_DIRS TARGET asn1_lib PROPERTY INCLUDE_DIRECTORIES)
 target_include_directories(uptane PUBLIC ${ASN1_INCLUDE_DIRS})
 
 add_aktualizr_test(NAME discovery_secondary SOURCES ipsecondary_discovery_test.cc PROJECT_WORKING_DIRECTORY)
+add_aktualizr_test(NAME images_repository SOURCES imagesrepository_test.cc ARGS PROJECT_WORKING_DIRECTORY)
 add_aktualizr_test(NAME tuf SOURCES tuf_test.cc PROJECT_WORKING_DIRECTORY)
 add_aktualizr_test(NAME tuf_hash SOURCES tuf_hash_test.cc PROJECT_WORKING_DIRECTORY)
 

--- a/src/libaktualizr/uptane/imagesrepository.cc
+++ b/src/libaktualizr/uptane/imagesrepository.cc
@@ -124,36 +124,37 @@ bool ImagesRepository::verifyTargets(const std::string& targets_raw, const Uptan
 }
 
 std::unique_ptr<Uptane::Target> ImagesRepository::getTarget(const Uptane::Target& director_target) {
+  std::unique_ptr<Uptane::Target> rv;
+  auto cb = [director_target, &rv](const Uptane::Target& t) {
+    if (director_target == t){
+      rv = std_::make_unique<Target>(t);
+      return false;
+    }
+    return true;
+  };
+  iterateTargets(cb);
+  return rv;
+}
+
+void ImagesRepository::iterateTargets(std::function<bool(const Uptane::Target& t)> callback) {
   // Search for the target in the top-level targets metadata.
   Uptane::Targets toplevel = targets["targets"];
-  auto it = std::find(toplevel.targets.cbegin(), toplevel.targets.cend(), director_target);
-  if (it != toplevel.targets.cend()) {
-    return std_::make_unique<Uptane::Target>(*it);
+  for (const auto& it : toplevel.targets) {
+    if (!callback(it)) return;
   }
 
-  // Check if the target matches any of the delegation paths.
   for (const auto& delegate_name : toplevel.delegated_role_names_) {
     Role delegate_role = Role::Delegation(delegate_name);
-    std::vector<std::string> patterns = toplevel.paths_for_role_[delegate_role];
-    for (const auto& pattern : patterns) {
-      if (fnmatch(pattern.c_str(), director_target.filename().c_str(), 0) != 0) {
-        continue;
-      }
-      // Match! Check delegation.
-      Uptane::Targets delegate = targets[delegate_name];
-      auto d_it = std::find(delegate.targets.cbegin(), delegate.targets.cend(), director_target);
-      if (d_it != delegate.targets.cend()) {
-        return std_::make_unique<Uptane::Target>(*d_it);
-      }
-      // TODO: recurse here if the delegation is non-terminating. For now,
-      // assume that all delegations are terminating.
-      if (!toplevel.terminating_role_[delegate_role]) {
-        LOG_ERROR << "Nested delegations are not currently supported.";
-      }
-      return std::unique_ptr<Uptane::Target>(nullptr);
+    Uptane::Targets delegate = targets[delegate_name];
+    for (const auto& it : delegate.targets) {
+      if (!callback(it)) return;
+    }
+    // TODO: recurse here if the delegation is non-terminating. For now,
+    // assume that all delegations are terminating.
+    if (!toplevel.terminating_role_[delegate_role]) {
+      LOG_ERROR << "Nested delegations are not currently supported.";
     }
   }
-  return std::unique_ptr<Uptane::Target>(nullptr);
 }
 
 }  // namespace Uptane

--- a/src/libaktualizr/uptane/imagesrepository.h
+++ b/src/libaktualizr/uptane/imagesrepository.h
@@ -30,6 +30,7 @@ class ImagesRepository : public RepositoryCommon {
   Exception getLastException() const { return last_exception; }
 
  private:
+  FRIEND_TEST(ImagesRepository, DelegateTargets);
   // Map from role name -> metadata ("targets" for top-level):
   std::map<std::string, Uptane::Targets> targets;
   Uptane::TimestampMeta timestamp;

--- a/src/libaktualizr/uptane/imagesrepository.h
+++ b/src/libaktualizr/uptane/imagesrepository.h
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <vector>
+#include <functional>
 
 #include "uptanerepository.h"
 
@@ -18,6 +19,7 @@ class ImagesRepository : public RepositoryCommon {
   bool targetsExpired(const std::string& role_name) { return targets[role_name].isExpired(TimeStamp::Now()); }
   int64_t targetsSize() { return snapshot.targets_size(); }
   std::set<std::string> delegations(const std::string& role_name) { return targets[role_name].delegated_role_names_; }
+  void iterateTargets(std::function<bool(const Uptane::Target& t)> callback);
   std::unique_ptr<Uptane::Target> getTarget(const Uptane::Target& director_target);
 
   bool verifyTimestamp(const std::string& timestamp_raw);
@@ -30,6 +32,7 @@ class ImagesRepository : public RepositoryCommon {
   Exception getLastException() const { return last_exception; }
 
  private:
+  FRIEND_TEST(ImagesRepository, Iterator);
   FRIEND_TEST(ImagesRepository, DelegateTargets);
   // Map from role name -> metadata ("targets" for top-level):
   std::map<std::string, Uptane::Targets> targets;

--- a/src/libaktualizr/uptane/imagesrepository_test.cc
+++ b/src/libaktualizr/uptane/imagesrepository_test.cc
@@ -1,0 +1,41 @@
+#include <gtest/gtest.h>
+
+#include "uptane/imagesrepository.h"
+
+namespace Uptane {
+
+TEST(ImagesRepository, DelegateTargets) {
+  Targets toplevel;
+  std::vector<Hash> hashes = {Hash("sha256", "deadbeef")};
+  toplevel.targets.push_back(Target("t1", hashes, 0));
+  toplevel.targets.push_back(Target("t2", hashes, 0));
+
+  Targets delegate;
+  delegate.targets.push_back(Target("abc/t1", hashes, 0));
+
+  Role delegate_role = Role::Delegation("drole");
+  toplevel.delegated_role_names_.insert(delegate_role.ToString());
+  toplevel.paths_for_role_[delegate_role].push_back("abc/*");
+  toplevel.terminating_role_[delegate_role] = true;
+
+  ImagesRepository repo;
+  repo.targets["targets"] = toplevel;
+  repo.targets[delegate_role.ToString()] = delegate;
+
+  auto t = repo.getTarget(Target("t2", hashes, 0));
+  EXPECT_EQ("t2", t->filename());
+  t = repo.getTarget(Target("bad", hashes, 0));
+  EXPECT_EQ(nullptr, t);
+  t = repo.getTarget(Target("abc/t1", hashes, 0));
+  EXPECT_EQ("abc/t1", t->filename());
+}
+
+}
+
+#ifndef __NO_MAIN__
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  logger_set_threshold(boost::log::trivial::trace);
+  return RUN_ALL_TESTS();
+}
+#endif

--- a/src/libaktualizr/uptane/imagesrepository_test.cc
+++ b/src/libaktualizr/uptane/imagesrepository_test.cc
@@ -4,6 +4,34 @@
 
 namespace Uptane {
 
+TEST(ImagesRepository, Iterator) {
+  Targets toplevel;
+  std::vector<Hash> hashes = {Hash("sha256", "deadbeef")};
+  toplevel.targets.push_back(Target("t1", hashes, 0));
+  toplevel.targets.push_back(Target("t2", hashes, 0));
+
+  Targets delegate;
+  delegate.targets.push_back(Target("abc/t1", hashes, 0));
+
+  Role delegate_role = Role::Delegation("drole");
+  toplevel.delegated_role_names_.insert(delegate_role.ToString());
+  toplevel.paths_for_role_[delegate_role].push_back("abc/*");
+  toplevel.terminating_role_[delegate_role] = true;
+
+  ImagesRepository repo;
+  repo.targets["targets"] = toplevel;
+  repo.targets[delegate_role.ToString()] = delegate;
+
+  std::set<std::string> found;
+  auto cb = [&found](const Target& t) {
+    found.insert(t.filename());
+    return true;
+  };
+  repo.iterateTargets(cb);
+  std::set<std::string> expected = {"t1", "t2", "abc/t1"};
+  EXPECT_EQ(expected, found);
+}
+
 TEST(ImagesRepository, DelegateTargets) {
   Targets toplevel;
   std::vector<Hash> hashes = {Hash("sha256", "deadbeef")};


### PR DESCRIPTION
This is related to issue:
  https://github.com/advancedtelematic/aktualizr/issues/1056
    
In order for an application to find the latest target, it will need
access to the list of targets found in the image repository.

I considered using a C++ iterator for this and before the delegation
merge it wasn't too bad. However, doing this as an iterator was
requiring keeping state of 3 iterators (the toplevel, the delegated roles,
and targets for a delegated role) and the resulting code seemed a
bit awkward compared to this.

I'm totally open to alternatives from you guys, but I thought I'd try 
and see if this might be okay. Feel free to just cherry-pick the
unit-test if you want that and nothing else :)