### PR TITLE
Feat/ota 678/delegation revoke tests

### DIFF
--- a/src/aktualizr_repo/director_repo.cc
+++ b/src/aktualizr_repo/director_repo.cc
@@ -32,6 +32,7 @@ void DirectorRepo::revokeTargets(const std::vector<std::string> &targets_to_remo
     }
   }
   targets_unsigned["targets"] = new_targets;
+  targets_unsigned["version"] = (targets_unsigned["version"].asUInt()) + 1;
   Utils::writeFile(path_ / "repo/director/targets.json",
                    Utils::jsonToCanonicalStr(signTuf(Uptane::Role::Targets(), targets_unsigned)));
   updateRepo();

--- a/src/aktualizr_repo/director_repo.cc
+++ b/src/aktualizr_repo/director_repo.cc
@@ -21,6 +21,22 @@ void DirectorRepo::addTarget(const std::string &target_name, const Json::Value &
   updateRepo();
 }
 
+void DirectorRepo::revokeTargets(const std::vector<std::string> &targets_to_remove) {
+  auto targets_path = path_ / "repo/director/targets.json";
+  auto targets_unsigned = Utils::parseJSONFile(targets_path)["signed"];
+
+  Json::Value new_targets;
+  for (Json::ValueIterator it = targets_unsigned["targets"].begin(); it != targets_unsigned["targets"].end(); ++it) {
+    if (std::find(targets_to_remove.begin(), targets_to_remove.end(), it.key().asString()) == targets_to_remove.end()) {
+      new_targets[it.key().asString()] = *it;
+    }
+  }
+  targets_unsigned["targets"] = new_targets;
+  Utils::writeFile(path_ / "repo/director/targets.json",
+                   Utils::jsonToCanonicalStr(signTuf(Uptane::Role::Targets(), targets_unsigned)));
+  updateRepo();
+}
+
 void DirectorRepo::signTargets() {
   const boost::filesystem::path current = path_ / "repo/director/targets.json";
   const boost::filesystem::path staging = path_ / "repo/director/staging/targets.json";

--- a/src/aktualizr_repo/director_repo.h
+++ b/src/aktualizr_repo/director_repo.h
@@ -9,6 +9,7 @@ class DirectorRepo : public Repo {
       : Repo(Uptane::RepositoryType::Director(), std::move(path), expires, std::move(correlation_id)) {}
   void addTarget(const std::string &target_name, const Json::Value &target, const std::string &hardware_id,
                  const std::string &ecu_serial);
+  void revokeTargets(const std::vector<std::string> &targets);
   void signTargets();
   void emptyTargets();
   void oldTargets();

--- a/src/aktualizr_repo/director_repo.h
+++ b/src/aktualizr_repo/director_repo.h
@@ -9,7 +9,7 @@ class DirectorRepo : public Repo {
       : Repo(Uptane::RepositoryType::Director(), std::move(path), expires, std::move(correlation_id)) {}
   void addTarget(const std::string &target_name, const Json::Value &target, const std::string &hardware_id,
                  const std::string &ecu_serial);
-  void revokeTargets(const std::vector<std::string> &targets);
+  void revokeTargets(const std::vector<std::string> &targets_to_remove);
   void signTargets();
   void emptyTargets();
   void oldTargets();

--- a/src/aktualizr_repo/image_repo.cc
+++ b/src/aktualizr_repo/image_repo.cc
@@ -73,7 +73,7 @@ void ImageRepo::addDelegation(const Uptane::Role &name, const std::string &path,
   updateRepo();
 }
 
-void ImageRepo::revokeDelegtion(const Uptane::Role &name) {
+void ImageRepo::revokeDelegation(const Uptane::Role &name) {
   if (keys_.count(name) == 0) {
     throw std::runtime_error("Delegation does not exist.");
   }

--- a/src/aktualizr_repo/image_repo.cc
+++ b/src/aktualizr_repo/image_repo.cc
@@ -73,6 +73,43 @@ void ImageRepo::addDelegation(const Uptane::Role &name, const std::string &path,
   updateRepo();
 }
 
+void ImageRepo::revokeDelegtion(const Uptane::Role &name) {
+  if (keys_.count(name) == 0) {
+    throw std::runtime_error("Delegation does not exist.");
+  }
+  if (Uptane::Role::IsReserved(name.ToString())) {
+    throw std::runtime_error("Delegation name " + name.ToString() + " is reserved.");
+  }
+
+  boost::filesystem::path keys_dir = path_ / ("keys/image/" + name.ToString());
+  boost::filesystem::remove_all(keys_dir);
+
+  boost::filesystem::path repo_dir(path_ / "repo/image");
+  boost::filesystem::remove(repo_dir / (name.ToString() + ".json"));
+  Json::Value targets = Utils::parseJSONFile(repo_dir / "targets.json")["signed"];
+  auto keypair = keys_[name];
+  targets["delegations"]["keys"].removeMember(keypair.public_key.KeyId());
+  Json::Value new_roles(Json::arrayValue);
+  for (const auto &role : targets["delegations"]["roles"]) {
+    if (role["name"].asString() != name.ToString()) {
+      new_roles.append(role);
+    }
+  }
+  targets["delegations"]["roles"] = new_roles;
+  Utils::writeFile(repo_dir / "targets.json", Utils::jsonToCanonicalStr(signTuf(Uptane::Role::Targets(), targets)));
+  updateRepo();
+}
+
+std::vector<std::string> ImageRepo::getDelegationTargets(const Uptane::Role &name) {
+  std::vector<std::string> result;
+  boost::filesystem::path repo_dir(path_ / "repo/image");
+  auto targets = Utils::parseJSONFile(repo_dir / (name.ToString() + ".json"))["signed"]["targets"];
+  for (Json::ValueIterator it = targets.begin(); it != targets.end(); ++it) {
+    result.push_back(it.key().asString());
+  }
+  return std::move(result);
+}
+
 void ImageRepo::addCustomImage(const std::string &name, const Uptane::Hash &hash, const uint64_t length,
                                const Delegation &delegation) {
   Json::Value target;

--- a/src/aktualizr_repo/image_repo.cc
+++ b/src/aktualizr_repo/image_repo.cc
@@ -107,7 +107,7 @@ std::vector<std::string> ImageRepo::getDelegationTargets(const Uptane::Role &nam
   for (Json::ValueIterator it = targets.begin(); it != targets.end(); ++it) {
     result.push_back(it.key().asString());
   }
-  return std::move(result);
+  return result;
 }
 
 void ImageRepo::addCustomImage(const std::string &name, const Uptane::Hash &hash, const uint64_t length,

--- a/src/aktualizr_repo/image_repo.cc
+++ b/src/aktualizr_repo/image_repo.cc
@@ -67,6 +67,7 @@ void ImageRepo::addDelegation(const Uptane::Role &name, const std::string &path,
   role["threshold"] = 1;
   role["terminating"] = terminating;
   targets_notsigned["delegations"]["roles"].append(role);
+  targets_notsigned["version"] = (targets_notsigned["version"].asUInt()) + 1;
 
   std::string signed_targets = Utils::jsonToCanonicalStr(signTuf(Uptane::Role::Targets(), targets_notsigned));
   Utils::writeFile(repo_dir / "targets.json", signed_targets);
@@ -96,6 +97,7 @@ void ImageRepo::revokeDelegation(const Uptane::Role &name) {
     }
   }
   targets["delegations"]["roles"] = new_roles;
+  targets["version"] = (targets["version"].asUInt()) + 1;
   Utils::writeFile(repo_dir / "targets.json", Utils::jsonToCanonicalStr(signTuf(Uptane::Role::Targets(), targets)));
   updateRepo();
 }

--- a/src/aktualizr_repo/image_repo.h
+++ b/src/aktualizr_repo/image_repo.h
@@ -11,7 +11,7 @@ class ImageRepo : public Repo {
                 const Delegation &delegation = {});
   void addCustomImage(const std::string &name, const Uptane::Hash &hash, uint64_t length, const Delegation &delegation);
   void addDelegation(const Uptane::Role &name, const std::string &path, KeyType key_type, bool terminating);
-  void revokeDelegtion(const Uptane::Role &name);
+  void revokeDelegation(const Uptane::Role &name);
   std::vector<std::string> getDelegationTargets(const Uptane::Role &name);
 
  private:

--- a/src/aktualizr_repo/image_repo.h
+++ b/src/aktualizr_repo/image_repo.h
@@ -11,6 +11,8 @@ class ImageRepo : public Repo {
                 const Delegation &delegation = {});
   void addCustomImage(const std::string &name, const Uptane::Hash &hash, uint64_t length, const Delegation &delegation);
   void addDelegation(const Uptane::Role &name, const std::string &path, KeyType key_type, bool terminating);
+  void revokeDelegtion(const Uptane::Role &name);
+  std::vector<std::string> getDelegationTargets(const Uptane::Role &name);
 
  private:
   void addImage(const std::string &name, const Json::Value &target, const Delegation &delegation = {});

--- a/src/aktualizr_repo/main.cc
+++ b/src/aktualizr_repo/main.cc
@@ -127,7 +127,7 @@ int main(int argc, char **argv) {
           std::cerr << "revokedelegation command requires --dname\n";
           exit(EXIT_FAILURE);
         }
-        repo.revokeDelegtion(Uptane::Role(vm["dname"].as<std::string>(), true));
+        repo.revokeDelegation(Uptane::Role(vm["dname"].as<std::string>(), true));
       } else if (command == "signtargets") {
         repo.signTargets();
       } else if (command == "emptytargets") {

--- a/src/aktualizr_repo/main.cc
+++ b/src/aktualizr_repo/main.cc
@@ -17,6 +17,7 @@ int main(int argc, char **argv) {
     ("help,h", "print usage")
     ("command", po::value<std::string>(), "generate: \tgenerate a new repository\n"
                                           "adddelegation: \tadd a delegated role to the images metadata\n"
+                                          "revokedelegation: \tremove delegated role from the images metadata and all signed targets of this role\n"
                                           "image: \tadd a target to the images metadata\n"
                                           "addtarget: \tprepare director targets metadata for a given device\n"
                                           "signtargets: \tsign the staged director targets metadata\n"
@@ -121,6 +122,12 @@ int main(int argc, char **argv) {
           exit(EXIT_FAILURE);
         }
         repo.addDelegation(Uptane::Role(vm["dname"].as<std::string>(), true), vm["dpattern"].as<std::string>());
+      } else if (command == "revokedelegation") {
+        if (vm.count("dname") == 0) {
+          std::cerr << "revokedelegation command requires --dname\n";
+          exit(EXIT_FAILURE);
+        }
+        repo.revokeDelegtion(Uptane::Role(vm["dname"].as<std::string>(), true));
       } else if (command == "signtargets") {
         repo.signTargets();
       } else if (command == "emptytargets") {

--- a/src/aktualizr_repo/repo_test.cc
+++ b/src/aktualizr_repo/repo_test.cc
@@ -196,6 +196,99 @@ TEST(aktualizr_repo, delegation) {
   check_repo(temp_dir);
 }
 
+TEST(aktualizr_repo, delegation_revoke) {
+  TemporaryDirectory temp_dir;
+  std::ostringstream keytype_stream;
+  keytype_stream << key_type;
+  std::string cmd = generate_repo_exec + " generate " + temp_dir.Path().string() + " --keytype " + keytype_stream.str();
+  std::string output;
+  int retval = Utils::shell(cmd, &output);
+  if (retval) {
+    FAIL() << "'" << cmd << "' exited with error code\n";
+  }
+  cmd = generate_repo_exec + " adddelegation " + temp_dir.Path().string() + " --keytype " + keytype_stream.str();
+  cmd += " --dname test_delegate --dpattern 'tests/test_data/*.txt' ";
+  retval = Utils::shell(cmd, &output);
+  if (retval) {
+    FAIL() << "'" << cmd << "' exited with error code\n";
+  }
+
+  EXPECT_TRUE(boost::filesystem::exists(temp_dir.Path() / "repo/image/test_delegate.json"));
+  auto targets = Utils::parseJSONFile(temp_dir.Path() / "repo/image/targets.json");
+  EXPECT_EQ(targets["signed"]["delegations"]["roles"][0]["name"].asString(), "test_delegate");
+  EXPECT_EQ(targets["signed"]["delegations"]["roles"][0]["paths"][0].asString(), "tests/test_data/*.txt");
+
+  cmd = generate_repo_exec + " image " + temp_dir.Path().string() + " --keytype " + keytype_stream.str();
+  cmd += " --dname test_delegate --filename tests/test_data/firmware.txt";
+  retval = Utils::shell(cmd, &output);
+  if (retval) {
+    FAIL() << "'" << output << "' exited with error code\n";
+  }
+  {
+    auto test_delegate = Utils::parseJSONFile(temp_dir.Path() / "repo/image/test_delegate.json");
+    Uptane::Targets delegate_targets(test_delegate);
+    EXPECT_EQ(delegate_targets.targets.size(), 1);
+    EXPECT_EQ(delegate_targets.targets[0].filename(), "tests/test_data/firmware.txt");
+    EXPECT_EQ(delegate_targets.targets[0].length(), 17);
+    EXPECT_EQ(delegate_targets.targets[0].sha256Hash(),
+              "d8e9caba8c1697fcbade1057f9c2488044192ff76bb64d4aba2c20e53dc33033");
+  }
+  cmd = generate_repo_exec + " image " + temp_dir.Path().string() + " --keytype " + keytype_stream.str();
+  cmd +=
+      " --dname test_delegate --targetname tests/test_data/firmware2.txt --targetsha256 "
+      "d8e9caba8c1697fcbade1057f9c2488044192ff76bb64d4aba2c20e53dc33033 --targetlength 17";
+  retval = Utils::shell(cmd, &output);
+  if (retval) {
+    FAIL() << "'" << cmd << "' exited with error code\n";
+  }
+
+  cmd = generate_repo_exec + " addtarget " + temp_dir.Path().string() + " --keytype " + keytype_stream.str();
+  cmd += " --hwid primary_hw --serial CA:FE:A6:D2:84:9D --targetname tests/test_data/firmware.txt";
+  retval = Utils::shell(cmd, &output);
+  if (retval) {
+    FAIL() << "'" << cmd << "' exited with error code\n";
+  }
+
+  cmd = generate_repo_exec + " signtargets " + temp_dir.Path().string() + " --keytype " + keytype_stream.str();
+  retval = Utils::shell(cmd, &output);
+  if (retval) {
+    FAIL() << "'" << cmd << "' exited with error code\n";
+  }
+  {
+    auto test_delegate = Utils::parseJSONFile(temp_dir.Path() / "repo/image/test_delegate.json");
+    Uptane::Targets delegate_targets(test_delegate);
+    EXPECT_EQ(delegate_targets.targets.size(), 2);
+    EXPECT_EQ(delegate_targets.targets[1].filename(), "tests/test_data/firmware2.txt");
+    EXPECT_EQ(delegate_targets.targets[1].length(), 17);
+    EXPECT_EQ(delegate_targets.targets[1].sha256Hash(),
+              "d8e9caba8c1697fcbade1057f9c2488044192ff76bb64d4aba2c20e53dc33033");
+  }
+  {
+    auto signed_targets = Utils::parseJSONFile(temp_dir.Path() / "repo/director/targets.json");
+    Uptane::Targets director_targets(signed_targets);
+    EXPECT_EQ(director_targets.targets.size(), 1);
+    EXPECT_EQ(director_targets.targets[0].filename(), "tests/test_data/firmware.txt");
+    EXPECT_EQ(director_targets.targets[0].length(), 17);
+    EXPECT_EQ(director_targets.targets[0].sha256Hash(),
+              "d8e9caba8c1697fcbade1057f9c2488044192ff76bb64d4aba2c20e53dc33033");
+  }
+  check_repo(temp_dir);
+
+  cmd = generate_repo_exec + " revokedelegation " + temp_dir.Path().string() + " --keytype " + keytype_stream.str();
+  cmd += " --dname test_delegate";
+  retval = Utils::shell(cmd, &output);
+  if (retval) {
+    FAIL() << "'" << cmd << "' exited with error code\n";
+  }
+  EXPECT_FALSE(boost::filesystem::exists(temp_dir.Path() / "repo/image/test_delegate.json"));
+  auto new_targets = Utils::parseJSONFile(temp_dir.Path() / "repo/image/targets.json");
+  EXPECT_EQ(new_targets["signed"]["delegations"]["keys"].size(), 0);
+  EXPECT_EQ(new_targets["signed"]["delegations"]["roles"].size(), 0);
+  auto signed_targets = Utils::parseJSONFile(temp_dir.Path() / "repo/director/targets.json");
+  Uptane::Targets director_targets(signed_targets);
+  EXPECT_EQ(director_targets.targets.size(), 0);
+}
+
 /*
  * Sign arbitrary metadata.
  */

--- a/src/aktualizr_repo/repo_test.cc
+++ b/src/aktualizr_repo/repo_test.cc
@@ -284,6 +284,7 @@ TEST(aktualizr_repo, delegation_revoke) {
   auto new_targets = Utils::parseJSONFile(temp_dir.Path() / "repo/image/targets.json");
   EXPECT_EQ(new_targets["signed"]["delegations"]["keys"].size(), 0);
   EXPECT_EQ(new_targets["signed"]["delegations"]["roles"].size(), 0);
+  EXPECT_EQ(new_targets["signed"]["version"].asUInt(), 3);
   auto signed_targets = Utils::parseJSONFile(temp_dir.Path() / "repo/director/targets.json");
   Uptane::Targets director_targets(signed_targets);
   EXPECT_EQ(director_targets.targets.size(), 0);

--- a/src/aktualizr_repo/uptane_repo.cc
+++ b/src/aktualizr_repo/uptane_repo.cc
@@ -22,6 +22,11 @@ void UptaneRepo::addDelegation(const Uptane::Role &name, const std::string &path
   image_repo_.addDelegation(name, path, key_type, terminating);
 }
 
+void UptaneRepo::revokeDelegtion(const Uptane::Role &name) {
+  director_repo_.revokeTargets(image_repo_.getDelegationTargets(name));
+  image_repo_.revokeDelegtion(name);
+}
+
 void UptaneRepo::addImage(const boost::filesystem::path &image_path, const boost::filesystem::path &targetname,
                           const Delegation &delegation) {
   image_repo_.addImage(image_path, targetname, delegation);

--- a/src/aktualizr_repo/uptane_repo.cc
+++ b/src/aktualizr_repo/uptane_repo.cc
@@ -22,9 +22,9 @@ void UptaneRepo::addDelegation(const Uptane::Role &name, const std::string &path
   image_repo_.addDelegation(name, path, key_type, terminating);
 }
 
-void UptaneRepo::revokeDelegtion(const Uptane::Role &name) {
+void UptaneRepo::revokeDelegation(const Uptane::Role &name) {
   director_repo_.revokeTargets(image_repo_.getDelegationTargets(name));
-  image_repo_.revokeDelegtion(name);
+  image_repo_.revokeDelegation(name);
 }
 
 void UptaneRepo::addImage(const boost::filesystem::path &image_path, const boost::filesystem::path &targetname,

--- a/src/aktualizr_repo/uptane_repo.h
+++ b/src/aktualizr_repo/uptane_repo.h
@@ -13,7 +13,7 @@ class UptaneRepo {
                 const Delegation &delegation);
   void addDelegation(const Uptane::Role &name, const std::string &path, KeyType key_type = KeyType::kRSA2048,
                      bool terminating = true);
-  void revokeDelegtion(const Uptane::Role &name);
+  void revokeDelegation(const Uptane::Role &name);
   void addCustomImage(const std::string &name, const Uptane::Hash &hash, uint64_t length,
                       const Delegation &delegation = {});
   void signTargets();

--- a/src/aktualizr_repo/uptane_repo.h
+++ b/src/aktualizr_repo/uptane_repo.h
@@ -13,6 +13,7 @@ class UptaneRepo {
                 const Delegation &delegation);
   void addDelegation(const Uptane::Role &name, const std::string &path, KeyType key_type = KeyType::kRSA2048,
                      bool terminating = true);
+  void revokeDelegtion(const Uptane::Role &name);
   void addCustomImage(const std::string &name, const Uptane::Hash &hash, uint64_t length,
                       const Delegation &delegation = {});
   void signTargets();

--- a/src/libaktualizr/primary/aktualizr.h
+++ b/src/libaktualizr/primary/aktualizr.h
@@ -183,6 +183,9 @@ class Aktualizr {
   FRIEND_TEST(Aktualizr, PauseResumeEvents);
   FRIEND_TEST(Aktualizr, AddSecondary);
   FRIEND_TEST(Delegation, Basic);
+  FRIEND_TEST(Delegation, RevokeAfterCheckUpdates);
+  FRIEND_TEST(Delegation, RevokeAfterInstall);
+  FRIEND_TEST(Delegation, RevokeAfterDownload);
 
   // This constructor is only being used in tests
   Aktualizr(Config& config, std::shared_ptr<INvStorage> storage_in, std::shared_ptr<HttpInterface> http_in);

--- a/src/libaktualizr/uptane/CMakeLists.txt
+++ b/src/libaktualizr/uptane/CMakeLists.txt
@@ -64,8 +64,7 @@ add_aktualizr_test(NAME uptane SOURCES uptane_test.cc PROJECT_WORKING_DIRECTORY)
 set_tests_properties(test_uptane PROPERTIES LABELS "crypto")
 
 add_aktualizr_test(NAME uptane_delegation SOURCES uptane_delegation_test.cc PROJECT_WORKING_DIRECTORY
-                   ARGS ${PROJECT_BINARY_DIR}/uptane_repos)
-add_dependencies(t_uptane_delegation uptane_repo_delegation_basic)
+                   ARGS "$<TARGET_FILE:aktualizr-repo>")
 set_tests_properties(test_uptane_delegation PROPERTIES LABELS "crypto")
 
 add_aktualizr_test(NAME uptane_implicit SOURCES uptane_implicit_test.cc PROJECT_WORKING_DIRECTORY)

--- a/src/libaktualizr/uptane/CMakeLists.txt
+++ b/src/libaktualizr/uptane/CMakeLists.txt
@@ -65,6 +65,7 @@ set_tests_properties(test_uptane PROPERTIES LABELS "crypto")
 
 add_aktualizr_test(NAME uptane_delegation SOURCES uptane_delegation_test.cc PROJECT_WORKING_DIRECTORY
                    ARGS "$<TARGET_FILE:aktualizr-repo>")
+add_dependencies(t_uptane_delegation aktualizr-repo)
 set_tests_properties(test_uptane_delegation PROPERTIES LABELS "crypto")
 
 add_aktualizr_test(NAME uptane_implicit SOURCES uptane_implicit_test.cc PROJECT_WORKING_DIRECTORY)

--- a/src/libaktualizr/uptane/uptane_delegation_test.cc
+++ b/src/libaktualizr/uptane/uptane_delegation_test.cc
@@ -11,12 +11,12 @@
 #include "primary/events.h"
 #include "uptane_test_common.h"
 
-boost::filesystem::path uptane_repos_dir;
+boost::filesystem::path aktualizr_repo_path;
 
 class HttpFakeDelegationBasic : public HttpFake {
  public:
   HttpFakeDelegationBasic(const boost::filesystem::path& test_dir_in)
-      : HttpFake(test_dir_in, "", uptane_repos_dir / "delegation_basic") {}
+      : HttpFake(test_dir_in, "", test_dir_in / "delegation_basic") {}
 
   HttpResponse handle_event(const std::string& url, const Json::Value& data) override {
     (void)url;
@@ -35,6 +35,11 @@ class HttpFakeDelegationBasic : public HttpFake {
  * Correlation ID is empty if none was provided in targets metadata. */
 TEST(Delegation, Basic) {
   TemporaryDirectory temp_dir;
+  auto delegation_path = temp_dir.Path() / "delegation_basic";
+  std::string output;
+  Utils::shell("tests/uptane_repo_generation/delegation_basic.sh " + aktualizr_repo_path.string() + " " +
+                   delegation_path.string(),
+               &output);
   auto http = std::make_shared<HttpFakeDelegationBasic>(temp_dir.Path());
 
   // scope `Aktualizr` object, so that the ReportQueue flushes its events before
@@ -61,14 +66,142 @@ TEST(Delegation, Basic) {
   EXPECT_EQ(http->events_seen, 8);
 }
 
+TEST(Delegation, RevokeAfterCheckUpdates) {
+  TemporaryDirectory temp_dir;
+  auto delegation_path = temp_dir.Path() / "delegation_basic";
+  std::string output;
+  Utils::shell("tests/uptane_repo_generation/delegation_basic.sh " + aktualizr_repo_path.string() + " " +
+                   delegation_path.string(),
+               &output);
+  {
+    auto http = std::make_shared<HttpFakeDelegationBasic>(temp_dir.Path());
+    Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
+    auto storage = INvStorage::newStorage(conf.storage);
+    Aktualizr aktualizr(conf, storage, http);
+    aktualizr.Initialize();
+
+    result::UpdateCheck update_result = aktualizr.CheckUpdates().get();
+    EXPECT_EQ(update_result.status, result::UpdateStatus::kUpdatesAvailable);
+    EXPECT_EQ(update_result.updates.size(), 2);
+  }
+  {
+    Utils::shell("tests/uptane_repo_generation/delegation_basic.sh " + aktualizr_repo_path.string() + " " +
+                     delegation_path.string() + " revoke",
+                 &output);
+    auto http = std::make_shared<HttpFakeDelegationBasic>(temp_dir.Path());
+    Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
+    auto storage = INvStorage::newStorage(conf.storage);
+    Aktualizr aktualizr(conf, storage, http);
+    aktualizr.Initialize();
+
+    auto update_result = aktualizr.CheckUpdates().get();
+    EXPECT_EQ(update_result.status, result::UpdateStatus::kUpdatesAvailable);
+    EXPECT_EQ(update_result.updates.size(), 1);
+
+    result::Download download_result = aktualizr.Download(update_result.updates).get();
+    EXPECT_EQ(download_result.status, result::DownloadStatus::kSuccess);
+
+    result::Install install_result = aktualizr.Install(download_result.updates).get();
+    for (const auto& r : install_result.ecu_reports) {
+      EXPECT_EQ(r.install_res.result_code.num_code, data::ResultCode::Numeric::kOk);
+    }
+  }
+}
+
+TEST(Delegation, RevokeAfterDownload) {
+  TemporaryDirectory temp_dir;
+  auto delegation_path = temp_dir.Path() / "delegation_basic";
+  std::string output;
+  Utils::shell("tests/uptane_repo_generation/delegation_basic.sh " + aktualizr_repo_path.string() + " " +
+                   delegation_path.string(),
+               &output);
+  {
+    auto http = std::make_shared<HttpFakeDelegationBasic>(temp_dir.Path());
+    Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
+    auto storage = INvStorage::newStorage(conf.storage);
+    Aktualizr aktualizr(conf, storage, http);
+    aktualizr.Initialize();
+
+    result::UpdateCheck update_result = aktualizr.CheckUpdates().get();
+    EXPECT_EQ(update_result.status, result::UpdateStatus::kUpdatesAvailable);
+
+    result::Download download_result = aktualizr.Download(update_result.updates).get();
+    EXPECT_EQ(download_result.status, result::DownloadStatus::kSuccess);
+  }
+  {
+    Utils::shell("tests/uptane_repo_generation/delegation_basic.sh " + aktualizr_repo_path.string() + " " +
+                     delegation_path.string() + " revoke",
+                 &output);
+
+    auto http = std::make_shared<HttpFakeDelegationBasic>(temp_dir.Path());
+    Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
+    auto storage = INvStorage::newStorage(conf.storage);
+    Aktualizr aktualizr(conf, storage, http);
+    aktualizr.Initialize();
+
+    auto update_result = aktualizr.CheckUpdates().get();
+    EXPECT_EQ(update_result.status, result::UpdateStatus::kUpdatesAvailable);
+    EXPECT_EQ(update_result.updates.size(), 1);
+
+    result::Download download_result = aktualizr.Download(update_result.updates).get();
+    EXPECT_EQ(download_result.status, result::DownloadStatus::kSuccess);
+
+    result::Install install_result = aktualizr.Install(download_result.updates).get();
+    for (const auto& r : install_result.ecu_reports) {
+      EXPECT_EQ(r.install_res.result_code.num_code, data::ResultCode::Numeric::kOk);
+    }
+  }
+}
+
+TEST(Delegation, RevokeAfterInstall) {
+  TemporaryDirectory temp_dir;
+  auto delegation_path = temp_dir.Path() / "delegation_basic";
+  std::string output;
+  Utils::shell("tests/uptane_repo_generation/delegation_basic.sh " + aktualizr_repo_path.string() + " " +
+                   delegation_path.string(),
+               &output);
+  {
+    auto http = std::make_shared<HttpFakeDelegationBasic>(temp_dir.Path());
+    Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
+    auto storage = INvStorage::newStorage(conf.storage);
+    Aktualizr aktualizr(conf, storage, http);
+    aktualizr.Initialize();
+
+    result::UpdateCheck update_result = aktualizr.CheckUpdates().get();
+    EXPECT_EQ(update_result.status, result::UpdateStatus::kUpdatesAvailable);
+
+    result::Download download_result = aktualizr.Download(update_result.updates).get();
+    EXPECT_EQ(download_result.status, result::DownloadStatus::kSuccess);
+
+    result::Install install_result = aktualizr.Install(download_result.updates).get();
+    for (const auto& r : install_result.ecu_reports) {
+      EXPECT_EQ(r.install_res.result_code.num_code, data::ResultCode::Numeric::kOk);
+    }
+  }
+  {
+    Utils::shell("tests/uptane_repo_generation/delegation_basic.sh " + aktualizr_repo_path.string() + " " +
+                     delegation_path.string() + " revoke",
+                 &output);
+
+    auto http = std::make_shared<HttpFakeDelegationBasic>(temp_dir.Path());
+    Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
+    auto storage = INvStorage::newStorage(conf.storage);
+    Aktualizr aktualizr(conf, storage, http);
+    aktualizr.Initialize();
+
+    auto update_result = aktualizr.CheckUpdates().get();
+    EXPECT_EQ(update_result.status, result::UpdateStatus::kNoUpdatesAvailable);
+  }
+}
+
 #ifndef __NO_MAIN__
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   if (argc != 2) {
-    std::cerr << "Error: " << argv[0] << " requires the path to the base directory of uptane repos.\n";
+    std::cerr << "Error: " << argv[0] << " requires the path to the aktualizr-repo utility\n";
     return EXIT_FAILURE;
   }
-  uptane_repos_dir = argv[1];
+  aktualizr_repo_path = argv[1];
 
   logger_init();
   logger_set_threshold(boost::log::trivial::trace);

--- a/tests/uptane_repo_generation/CMakeLists.txt
+++ b/tests/uptane_repo_generation/CMakeLists.txt
@@ -3,7 +3,3 @@ add_custom_target(uptane_repo_full_no_correlation_id
     $<TARGET_FILE:aktualizr-repo> ${PROJECT_BINARY_DIR}/uptane_repos/full_no_correlation_id)
 add_dependencies(uptane_repo_full_no_correlation_id aktualizr-repo)
 
-add_custom_target(uptane_repo_delegation_basic
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/delegation_basic.sh
-    $<TARGET_FILE:aktualizr-repo> ${PROJECT_BINARY_DIR}/uptane_repos/delegation_basic)
-add_dependencies(uptane_repo_delegation_basic aktualizr-repo)

--- a/tests/uptane_repo_generation/delegation_basic.sh
+++ b/tests/uptane_repo_generation/delegation_basic.sh
@@ -1,22 +1,22 @@
 #! /bin/bash
 set -eEuo pipefail
 
-if [ "$#" -ne 2 ]; then
-  echo "Usage: $0 <aktualizr-repo> <output directory>"
+if [ "$#" -lt 2 ]; then
+  echo "Usage: $0 <aktualizr-repo> <output directory> <revoke>"
   exit 1
 fi
 
 AKTUALIZR_REPO="$1"
 DEST_DIR="$2"
+REVOKE=""
+if [ "$#" -eq 3 ]; then
+  REVOKE="$3"
+fi
+
 
 akrepo() {
     "$AKTUALIZR_REPO" --path "$DEST_DIR" "$@"
 }
-
-if [ -d "$DEST_DIR" ]; then
-    # already here, bailing
-    exit 0
-fi
 
 mkdir -p "$DEST_DIR"
 trap 'rm -rf "$DEST_DIR"' ERR
@@ -27,11 +27,15 @@ PRIMARY_FIRMWARE="$IMAGES/primary.txt"
 echo "primary" > "$PRIMARY_FIRMWARE"
 SECONDARY_FIRMWARE="$IMAGES/secondary.txt"
 echo "secondary" > "$SECONDARY_FIRMWARE"
-
-akrepo --command generate --expires 2021-07-04T16:33:27Z
-akrepo --command adddelegation --dname new-role --dpattern "abc/*"
-akrepo --command image --filename "$PRIMARY_FIRMWARE" --targetname primary.txt
-akrepo --command image --filename "$SECONDARY_FIRMWARE" --targetname "abc/secondary.txt" --dname new-role
-akrepo --command addtarget --hwid primary_hw --serial CA:FE:A6:D2:84:9D --targetname primary.txt
-akrepo --command addtarget --hwid secondary_hw --serial secondary_ecu_serial --targetname "abc/secondary.txt"
-akrepo --command signtargets
+echo "oooo: $REVOKE"
+if [[ "$REVOKE" = "revoke" ]]; then
+    akrepo --command revokedelegation --dname new-role
+else
+    akrepo --command generate --expires 2021-07-04T16:33:27Z
+    akrepo --command adddelegation --dname new-role --dpattern "abc/*"
+    akrepo --command image --filename "$PRIMARY_FIRMWARE" --targetname primary.txt
+    akrepo --command image --filename "$SECONDARY_FIRMWARE" --targetname "abc/secondary.txt" --dname new-role
+    akrepo --command addtarget --hwid primary_hw --serial CA:FE:A6:D2:84:9D --targetname primary.txt
+    akrepo --command addtarget --hwid secondary_hw --serial secondary_ecu_serial --targetname "abc/secondary.txt"
+    akrepo --command signtargets
+fi

--- a/tests/uptane_repo_generation/delegation_basic.sh
+++ b/tests/uptane_repo_generation/delegation_basic.sh
@@ -27,7 +27,6 @@ PRIMARY_FIRMWARE="$IMAGES/primary.txt"
 echo "primary" > "$PRIMARY_FIRMWARE"
 SECONDARY_FIRMWARE="$IMAGES/secondary.txt"
 echo "secondary" > "$SECONDARY_FIRMWARE"
-echo "oooo: $REVOKE"
 if [[ "$REVOKE" = "revoke" ]]; then
     akrepo --command revokedelegation --dname new-role
 else


### PR DESCRIPTION
@patrickvacek  Those tests fails because there is some issues in delegation implementation I think.
So there is 3 tests, and 2 of them fails. The problem is when we check updates with delegation then we remove delegation and fetch again and we get an error "Hash verification for targets metadata failed". The problem is the same if we download targets before revoking delegation. But if we install delegated updates before revoke, the everything is ok.

I also tried to reproduce this issue by commenting the first block of code where we run aktualizr with delegation, to check does aktualizr can work with repository with revoked delegations, and it works well. So revoke functionality doesn't break the repo.