### PR TITLE
storage: support empty rollback migrations

### DIFF
--- a/src/libaktualizr/storage/embed_schemas.py
+++ b/src/libaktualizr/storage/embed_schemas.py
@@ -60,15 +60,17 @@ if __name__ == '__main__':
         header_file.write("\"\n};\n")
 
         header_file.write("extern const std::vector<std::string> {}_schema_rollback_migrations = {{".format(prefix))
-        ver = int(rollback_migrations_list[0].split(".")[1])
-        for i in range(ver):
-            header_file.write("\"\",\n")
-        for migration in rollback_migrations_list[:-1]:
-            apend_migration(os.path.join(rollback_folder, migration), header_file)
-            header_file.write("\",\n")
-        version = int(rollback_migrations_list[-1].split(".")[1])
-        apend_migration(os.path.join(rollback_folder, rollback_migrations_list[-1]), header_file)
-        header_file.write("\"\n};\n")
+        if len(rollback_migrations_list) > 0:
+            ver = int(rollback_migrations_list[0].split(".")[1])
+            for i in range(ver):
+                header_file.write("\"\",\n")
+            for migration in rollback_migrations_list[:-1]:
+                apend_migration(os.path.join(rollback_folder, migration), header_file)
+                header_file.write("\",\n")
+            version = int(rollback_migrations_list[-1].split(".")[1])
+            apend_migration(os.path.join(rollback_folder, rollback_migrations_list[-1]), header_file)
+            header_file.write("\"")
+        header_file.write("\n};\n")
 
         current_schema = open(os.path.join(sql_folder, "schema.sql"), 'r').read()
         current_schema_escaped = escape_string(current_schema)

--- a/src/libaktualizr/storage/sqlstorage_base.cc
+++ b/src/libaktualizr/storage/sqlstorage_base.cc
@@ -82,6 +82,12 @@ bool SQLStorageBase::dbMigrateForward(int version_from, int version_to) {
       LOG_ERROR << "Can't migrate db from version " << (k - 1) << " to version " << k << ": " << db.errmsg();
       return false;
     }
+
+    if (schema_rollback_migrations_.empty()) {
+      LOG_TRACE << "No backward migrations defined";
+      continue;
+    }
+
     if (schema_rollback_migrations_.at(static_cast<uint32_t>(k)).empty()) {
       LOG_TRACE << "No backward migration from version " << k << " to " << (k - 1);
       continue;


### PR DESCRIPTION
Useful for custom projects, especially when they have only
the first version of their database

Signed-off-by: Anton Gerasimov <anton.gerasimov@here.com>