### PR TITLE
Create new "aktualizr-lite" command

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,5 +12,6 @@ add_subdirectory("aktualizr_repo")
 add_subdirectory("aktualizr_check_discovery")
 add_subdirectory("cert_provider")
 add_subdirectory("hmi_stub")
+add_subdirectory("aktualizr_lite")
 
 add_subdirectory("load_tests")

--- a/src/aktualizr_lite/CMakeLists.txt
+++ b/src/aktualizr_lite/CMakeLists.txt
@@ -6,10 +6,7 @@ install(TARGETS aktualizr-lite RUNTIME DESTINATION bin COMPONENT aktualizr-lite)
 
 set(TEST_SOURCES test_lite.sh)
 
-add_custom_target(t_aktualizr-lite)
-add_dependencies(t_aktualizr-lite aktualizr-repo)
-add_dependencies(t_aktualizr-lite aktualizr-lite)
-add_dependencies(build_tests t_aktualizr-lite)
+add_dependencies(build_tests aktualizr-lite)
 
 add_test(test_aktualizr-lite
     ${CMAKE_CURRENT_SOURCE_DIR}/test_lite.sh

--- a/src/aktualizr_lite/CMakeLists.txt
+++ b/src/aktualizr_lite/CMakeLists.txt
@@ -1,0 +1,9 @@
+if(BUILD_OSTREE)
+add_executable(aktualizr-lite main.cc)
+target_link_libraries(aktualizr-lite aktualizr_static_lib ${AKTUALIZR_EXTERNAL_LIBS})
+
+install(TARGETS aktualizr-lite RUNTIME DESTINATION bin COMPONENT aktualizr-lite)
+
+endif(BUILD_OSTREE)
+aktualizr_source_file_checks(main.cc)
+# vim: set tabstop=4 shiftwidth=4 expandtab:

--- a/src/aktualizr_lite/CMakeLists.txt
+++ b/src/aktualizr_lite/CMakeLists.txt
@@ -4,6 +4,22 @@ target_link_libraries(aktualizr-lite aktualizr_static_lib ${AKTUALIZR_EXTERNAL_L
 
 install(TARGETS aktualizr-lite RUNTIME DESTINATION bin COMPONENT aktualizr-lite)
 
+set(TEST_SOURCES test_lite.sh)
+
+add_custom_target(t_aktualizr-lite)
+add_dependencies(t_aktualizr-lite aktualizr-repo)
+add_dependencies(t_aktualizr-lite aktualizr-lite)
+add_dependencies(build_tests t_aktualizr-lite)
+
+add_test(test_aktualizr-lite
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_lite.sh
+        ${CMAKE_BINARY_DIR}/src/aktualizr_lite/aktualizr-lite
+        ${CMAKE_BINARY_DIR}/src/aktualizr_repo/aktualizr-repo
+        ${PROJECT_SOURCE_DIR}/tests
+        ${RUN_VALGRIND}
+)
+
 endif(BUILD_OSTREE)
+
 aktualizr_source_file_checks(main.cc)
 # vim: set tabstop=4 shiftwidth=4 expandtab:

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -49,7 +49,7 @@ static int list_main(Config &config, const bpo::variables_map &unused) {
   return 0;
 }
 
-static std::unique_ptr<Uptane::Target> find_target(std::shared_ptr<SotaUptaneClient> client,
+static std::unique_ptr<Uptane::Target> find_target(const std::shared_ptr<SotaUptaneClient> &client,
                                                    Uptane::HardwareIdentifier &hwid, const std::string &version) {
   std::unique_ptr<Uptane::Target> rv;
   if (!client->updateImagesMeta()) {

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -1,0 +1,123 @@
+#include <iostream>
+
+#include <openssl/ssl.h>
+#include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
+
+#include "config/config.h"
+#include "package_manager/ostreemanager.h"
+#include "primary/sotauptaneclient.h"
+
+namespace bpo = boost::program_options;
+
+struct SubCommand {
+  const char *name;
+  int (*main)(Config &, const bpo::variables_map &);
+};
+static SubCommand commands[] = {};
+
+void check_info_options(const bpo::options_description &description, const bpo::variables_map &vm) {
+  if (vm.count("help") != 0 || vm.count("command") == 0) {
+    std::cout << description << '\n';
+    exit(EXIT_SUCCESS);
+  }
+  if (vm.count("version") != 0) {
+    std::cout << "Current aktualizr version is: " << AKTUALIZR_VERSION << "\n";
+    exit(EXIT_SUCCESS);
+  }
+}
+
+bpo::variables_map parse_options(int argc, char *argv[]) {
+  std::string subs("Command to execute: ");
+  for (size_t i = 0; i < sizeof(commands) / sizeof(SubCommand); i++) {
+    if (i != 0) {
+      subs += ", ";
+    }
+    subs += commands[i].name;
+  }
+  bpo::options_description description("aktualizr-lite command line options");
+  // clang-format off
+  // Try to keep these options in the same order as Config::updateFromCommandLine().
+  // The first three are commandline only.
+  description.add_options()
+      ("help,h", "print usage")
+      ("version,v", "Current aktualizr version")
+      ("config,c", bpo::value<std::vector<boost::filesystem::path> >()->composing(), "configuration file or directory")
+      ("loglevel", bpo::value<int>(), "set log level 0-5 (trace, debug, info, warning, error, fatal)")
+      ("repo-server", bpo::value<std::string>(), "url of the uptane repo repository")
+      ("ostree-server", bpo::value<std::string>(), "url of the ostree repository")
+      ("primary-ecu-hardware-id", bpo::value<std::string>(), "hardware ID of primary ecu")
+      ("command", bpo::value<std::string>(), subs.c_str());
+  // clang-format on
+
+  // consider the first positional argument as the aktualizr run mode
+  bpo::positional_options_description pos;
+  pos.add("command", 1);
+
+  bpo::variables_map vm;
+  std::vector<std::string> unregistered_options;
+  try {
+    bpo::basic_parsed_options<char> parsed_options =
+        bpo::command_line_parser(argc, argv).options(description).positional(pos).allow_unregistered().run();
+    bpo::store(parsed_options, vm);
+    check_info_options(description, vm);
+    bpo::notify(vm);
+    unregistered_options = bpo::collect_unrecognized(parsed_options.options, bpo::exclude_positional);
+    if (vm.count("help") == 0 && !unregistered_options.empty()) {
+      std::cout << description << "\n";
+      exit(EXIT_FAILURE);
+    }
+  } catch (const bpo::required_option &ex) {
+    // print the error and append the default commandline option description
+    std::cout << ex.what() << std::endl << description;
+    exit(EXIT_FAILURE);
+  } catch (const bpo::error &ex) {
+    check_info_options(description, vm);
+
+    // log boost error
+    LOG_ERROR << "boost command line option error: " << ex.what();
+
+    // print the error message to the standard output too, as the user provided
+    // a non-supported commandline option
+    std::cout << ex.what() << '\n';
+
+    // set the returnValue, thereby ctest will recognize
+    // that something went wrong
+    exit(EXIT_FAILURE);
+  }
+
+  return vm;
+}
+
+int main(int argc, char *argv[]) {
+  logger_init();
+  logger_set_threshold(boost::log::trivial::info);
+
+  bpo::variables_map commandline_map = parse_options(argc, argv);
+
+  int r = -1;
+  try {
+    if (geteuid() != 0) {
+      LOG_WARNING << "\033[31mRunning as non-root and may not work as expected!\033[0m\n";
+    }
+
+    Config config(commandline_map);
+    config.storage.uptane_metadata_path = BasedPath(config.storage.path / "metadata");
+    if (config.logger.loglevel <= boost::log::trivial::debug) {
+      SSL_load_error_strings();
+    }
+    LOG_DEBUG << "Current directory: " << boost::filesystem::current_path().string();
+
+    std::string cmd = commandline_map["command"].as<std::string>();
+    for (size_t i = 0; i < sizeof(commands) / sizeof(SubCommand); i++) {
+      if (cmd == commands[i].name) {
+        return commands[i].main(config, commandline_map);
+      }
+    }
+    throw bpo::invalid_option_value(cmd);
+  } catch (const std::exception &ex) {
+    LOG_ERROR << ex.what();
+    r = -1;
+  }
+  return r;
+}

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -49,8 +49,8 @@ static int list_main(Config &config, const bpo::variables_map &unused) {
   return 0;
 }
 
-static std::unique_ptr<Uptane::Target> latest_version(std::shared_ptr<SotaUptaneClient> client,
-                                                      Uptane::HardwareIdentifier &hwid) {
+static std::unique_ptr<Uptane::Target> find_target(std::shared_ptr<SotaUptaneClient> client,
+                                                   Uptane::HardwareIdentifier &hwid const std::string &version) {
   std::unique_ptr<Uptane::Target> rv;
   if (!client->updateImagesMeta()) {
     LOG_ERROR << "Unable to update latest metadata, using local copy";
@@ -58,21 +58,26 @@ static std::unique_ptr<Uptane::Target> latest_version(std::shared_ptr<SotaUptane
   for (auto &t : client->allTargets()) {
     for (auto const &it : t.hardwareIds()) {
       if (it == hwid) {
-        return std_::make_unique<Uptane::Target>(t);
+        if (version == "latest" || version == t.filename() || version == t.custom_version()) {
+          return std_::make_unique<Uptane::Target>(t);
+        }
       }
     }
   }
   throw std::runtime_error("Unable to find update");
 }
 
-static int update_main(Config &config, const bpo::variables_map &unused) {
-  (void)unused;
+static int update_main(Config &config, const bpo::variables_map &variables_map) {
   auto storage = INvStorage::newStorage(config.storage);
   auto client = SotaUptaneClient::newDefaultClient(config, storage);
   Uptane::HardwareIdentifier hwid(config.provision.primary_ecu_hardware_id);
 
-  LOG_INFO << "Finding latest version to update to...";
-  auto target = latest_version(client, hwid);
+  std::string version("latest");
+  if (variables_map.count("update-name") > 0) {
+    version = variables_map["update-name"].as<std::string>();
+  }
+  LOG_INFO << "Finding " << version << " to update to...";
+  auto target = find_target(client, hwid, version);
   LOG_INFO << "Updating to: " << *target;
 
   std::vector<Uptane::Target> targets{*target};
@@ -135,6 +140,7 @@ bpo::variables_map parse_options(int argc, char *argv[]) {
       ("repo-server", bpo::value<std::string>(), "url of the uptane repo repository")
       ("ostree-server", bpo::value<std::string>(), "url of the ostree repository")
       ("primary-ecu-hardware-id", bpo::value<std::string>(), "hardware ID of primary ecu")
+      ("update-name", bpo::value<std::string>(), "optional name of the update when running \"update\". default=latest")
       ("command", bpo::value<std::string>(), subs.c_str());
   // clang-format on
 

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -10,11 +10,25 @@
 
 namespace bpo = boost::program_options;
 
+static int status_main(Config &config, const bpo::variables_map &unused) {
+  (void)unused;
+  GObjectUniquePtr<OstreeSysroot> sysroot_smart = OstreeManager::LoadSysroot(config.pacman.sysroot);
+  OstreeDeployment *deployment = ostree_sysroot_get_booted_deployment(sysroot_smart.get());
+  if (deployment == nullptr) {
+    LOG_INFO << "No active deployment found";
+  } else {
+    LOG_INFO << "Active image is: " << ostree_deployment_get_csum(deployment);
+  }
+  return 0;
+}
+
 struct SubCommand {
   const char *name;
   int (*main)(Config &, const bpo::variables_map &);
 };
-static SubCommand commands[] = {};
+static SubCommand commands[] = {
+    {"status", status_main},
+};
 
 void check_info_options(const bpo::options_description &description, const bpo::variables_map &vm) {
   if (vm.count("help") != 0 || vm.count("command") == 0) {

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -50,7 +50,7 @@ static int list_main(Config &config, const bpo::variables_map &unused) {
 }
 
 static std::unique_ptr<Uptane::Target> find_target(std::shared_ptr<SotaUptaneClient> client,
-                                                   Uptane::HardwareIdentifier &hwid const std::string &version) {
+                                                   Uptane::HardwareIdentifier &hwid, const std::string &version) {
   std::unique_ptr<Uptane::Target> rv;
   if (!client->updateImagesMeta()) {
     LOG_ERROR << "Unable to update latest metadata, using local copy";

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -49,6 +49,51 @@ static int list_main(Config &config, const bpo::variables_map &unused) {
   return 0;
 }
 
+static std::unique_ptr<Uptane::Target> latest_version(std::shared_ptr<SotaUptaneClient> client,
+                                                      Uptane::HardwareIdentifier &hwid) {
+  std::unique_ptr<Uptane::Target> rv;
+  if (!client->updateImagesMeta()) {
+    LOG_ERROR << "Unable to update latest metadata, using local copy";
+  }
+  for (auto &t : client->allTargets()) {
+    for (auto const &it : t.hardwareIds()) {
+      if (it == hwid) {
+        return std_::make_unique<Uptane::Target>(t);
+      }
+    }
+  }
+  throw std::runtime_error("Unable to find update");
+}
+
+static int update_main(Config &config, const bpo::variables_map &unused) {
+  (void)unused;
+  auto storage = INvStorage::newStorage(config.storage);
+  auto client = SotaUptaneClient::newDefaultClient(config, storage);
+  Uptane::HardwareIdentifier hwid(config.provision.primary_ecu_hardware_id);
+
+  LOG_INFO << "Finding latest version to update to...";
+  auto target = latest_version(client, hwid);
+  LOG_INFO << "Updating to: " << *target;
+
+  std::vector<Uptane::Target> targets{*target};
+  auto result = client->downloadImages(targets);
+  if (result.status != result::DownloadStatus::kSuccess &&
+      result.status != result::DownloadStatus::kNothingToDownload) {
+    LOG_ERROR << "Unable to download update: " + result.message;
+    return 1;
+  }
+  auto iresult = client->PackageInstall(*target);
+  if (iresult.result_code.num_code == data::ResultCode::Numeric::kNeedCompletion) {
+    LOG_INFO << "Update complete. Please reboot the device to activate";
+  } else if (iresult.result_code.num_code != data::ResultCode::Numeric::kOk &&
+             iresult.result_code.num_code != data::ResultCode::Numeric::kNeedCompletion) {
+    LOG_ERROR << "Unable to install update: " << iresult.description;
+    return 1;
+  }
+  LOG_INFO << iresult.description;
+  return 0;
+}
+
 struct SubCommand {
   const char *name;
   int (*main)(Config &, const bpo::variables_map &);
@@ -56,6 +101,7 @@ struct SubCommand {
 static SubCommand commands[] = {
     {"status", status_main},
     {"list", list_main},
+    {"update", update_main},
 };
 
 void check_info_options(const bpo::options_description &description, const bpo::variables_map &vm) {

--- a/src/aktualizr_lite/test_lite.sh
+++ b/src/aktualizr_lite/test_lite.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -e
+
+build_dir=$(pwd)
+aklite=$1
+akrepo_bin=$2
+tests_dir=$3
+valgrind=$4
+port=$($tests_dir/get_open_port.py)
+
+dest_dir=$(mktemp -d)
+
+cleanup() {
+    echo "cleaning up temp dir"
+    rm -rf "$dest_dir"
+    if [ -n "$pid" ] ; then
+        echo "killing webserver"
+        kill $pid
+    fi
+}
+trap cleanup EXIT
+
+akrepo() {
+    $akrepo_bin --repotype image --path "$dest_dir" "$@"
+}
+
+add_target() {
+    custom_json="${dest_dir}/custom.json"
+    name=$1
+    if [ -n "$2" ] ; then
+        sha=$2
+    else
+        sha=$(echo $name | sha256sum | cut -f1 -d\  )
+    fi
+    cat >$custom_json <<EOF
+{
+  "hardwareIds": ["hwid-for-test"],
+  "targetFormat": "OSTREE"
+}
+EOF
+    akrepo --command image \
+        --targetname $name --targetsha256 $sha --targetlength 0 --targetcustom $custom_json
+}
+
+akrepo --command generate --expires 2021-07-04T16:33:27Z
+add_target foo1
+add_target foo2
+akrepo --command signtargets
+
+pushd $dest_dir
+python3 -m http.server $port &
+pid=$!
+
+# curl http://localhost:$port/repo/image/targets.json | json_pp
+
+export OSTREE_SYSROOT=$dest_dir/sysroot
+mkdir $OSTREE_SYSROOT
+$tests_dir/ostree-scripts/makephysical.sh $OSTREE_SYSROOT
+
+sota_dir=$dest_dir/sota
+mkdir $sota_dir
+cat >$sota_dir/sota.toml <<EOF
+[uptane]
+repo_server = "http://localhost:$port/repo/image"
+
+[provision]
+primary_ecu_hardware_id = "hwid-for-test"
+
+[pacman]
+type = "ostree"
+sysroot = "$OSTREE_SYSROOT"
+os = "dummy-os"
+
+[storage]
+type = "sqlite"
+path = "$sota_dir"
+sqldb_path = "sql.db"
+uptane_metadata_path = "$sota_dir/metadata"
+EOF
+
+## Check that we can do the info command
+$valgrind $aklite -h | grep "Command to execute: status, list, update"
+
+## Check that we can do the list command
+out=$($valgrind $aklite --loglevel 1 -c $sota_dir/sota.toml list)
+if [[ ! "$out" =~ "foo1" ]] ; then
+    echo "ERROR: foo1 update missing"
+    exit 1
+fi
+if [[ ! "$out" =~ "foo2" ]] ; then
+    echo "ERROR: foo2 update missing"
+    exit 1
+fi
+
+## Check that we can do the update command
+update=$(ostree admin status | head -n 1)
+name=$(echo $update | cut -d\  -f1)
+sha=$(echo $update | cut -d\  -f2 | sed 's/\.0$//')
+echo "Adding new target: $name / $sha"
+add_target $name $sha
+
+$valgrind $aklite --loglevel 1 -c $sota_dir/sota.toml update --update-name $name
+ostree admin status

--- a/src/aktualizr_lite/test_lite.sh
+++ b/src/aktualizr_lite/test_lite.sh
@@ -5,7 +5,8 @@ build_dir=$(pwd)
 aklite=$1
 akrepo_bin=$2
 tests_dir=$3
-valgrind=$4
+#valgrind=$4
+valgrind=""
 port=$($tests_dir/get_open_port.py)
 
 dest_dir=$(mktemp -d)

--- a/src/aktualizr_repo/image_repo.cc
+++ b/src/aktualizr_repo/image_repo.cc
@@ -139,7 +139,7 @@ std::vector<std::string> ImageRepo::getDelegationTargets(const Uptane::Role &nam
 }
 
 void ImageRepo::addCustomImage(const std::string &name, const Uptane::Hash &hash, const uint64_t length,
-                               const Delegation &delegation) {
+                               const Delegation &delegation, const Json::Value &custom) {
   Json::Value target;
   target["length"] = Json::UInt(length);
   if (hash.type() == Uptane::Hash::Type::kSha256) {
@@ -147,5 +147,6 @@ void ImageRepo::addCustomImage(const std::string &name, const Uptane::Hash &hash
   } else if (hash.type() == Uptane::Hash::Type::kSha512) {
     target["hashes"]["sha512"] = hash.HashString();
   }
+  target["custom"] = custom;
   addImage(name, target, delegation);
 }

--- a/src/aktualizr_repo/image_repo.h
+++ b/src/aktualizr_repo/image_repo.h
@@ -9,7 +9,8 @@ class ImageRepo : public Repo {
       : Repo(Uptane::RepositoryType::Image(), std::move(path), expires, std::move(correlation_id)) {}
   void addImage(const boost::filesystem::path &image_path, const boost::filesystem::path &targetname,
                 const Delegation &delegation = {});
-  void addCustomImage(const std::string &name, const Uptane::Hash &hash, uint64_t length, const Delegation &delegation);
+  void addCustomImage(const std::string &name, const Uptane::Hash &hash, uint64_t length, const Delegation &delegation,
+                      const Json::Value &custom = {});
   void addDelegation(const Uptane::Role &name, const Uptane::Role &parent_role, const std::string &path,
                      bool terminating, KeyType key_type);
   void revokeDelegation(const Uptane::Role &name);

--- a/src/aktualizr_repo/main.cc
+++ b/src/aktualizr_repo/main.cc
@@ -1,4 +1,5 @@
 #include <boost/program_options.hpp>
+#include <fstream>
 #include <iostream>
 #include <istream>
 #include <iterator>
@@ -27,6 +28,7 @@ int main(int argc, char **argv) {
     ("path", po::value<boost::filesystem::path>(), "path to the repository")
     ("filename", po::value<boost::filesystem::path>(), "path to the image")
     ("hwid", po::value<std::string>(), "target hardware identifier")
+    ("targetcustom", po::value<boost::filesystem::path>(), "path to custom JSON for 'image' command")
     ("serial", po::value<std::string>(), "target ECU serial")
     ("expires", po::value<std::string>(), "expiration time")
     ("keyname", po::value<std::string>(), "name of key's role")
@@ -109,7 +111,12 @@ int main(int argc, char **argv) {
           } else {
             hash = std_::make_unique<Uptane::Hash>(Uptane::Hash::Type::kSha512, vm["targetsha512"].as<std::string>());
           }
-          repo.addCustomImage(targetname.string(), *hash, vm["targetlength"].as<uint64_t>(), delegation);
+          Json::Value custom;
+          if (vm.count("targetcustom") > 0) {
+            std::ifstream custom_file(vm["targetcustom"].as<boost::filesystem::path>().c_str());
+            custom_file >> custom;
+          }
+          repo.addCustomImage(targetname.string(), *hash, vm["targetlength"].as<uint64_t>(), delegation, custom);
         }
       } else if (command == "addtarget") {
         if (vm.count("targetname") == 0 || vm.count("hwid") == 0 || vm.count("serial") == 0) {

--- a/src/aktualizr_repo/uptane_repo.cc
+++ b/src/aktualizr_repo/uptane_repo.cc
@@ -33,8 +33,8 @@ void UptaneRepo::addImage(const boost::filesystem::path &image_path, const boost
   image_repo_.addImage(image_path, targetname, delegation);
 }
 void UptaneRepo::addCustomImage(const std::string &name, const Uptane::Hash &hash, uint64_t length,
-                                const Delegation &delegation) {
-  image_repo_.addCustomImage(name, hash, length, delegation);
+                                const Delegation &delegation, const Json::Value &custom) {
+  image_repo_.addCustomImage(name, hash, length, delegation, custom);
 }
 
 void UptaneRepo::signTargets() { director_repo_.signTargets(); }

--- a/src/aktualizr_repo/uptane_repo.h
+++ b/src/aktualizr_repo/uptane_repo.h
@@ -15,7 +15,7 @@ class UptaneRepo {
                      bool terminating, KeyType key_type = KeyType::kRSA2048);
   void revokeDelegation(const Uptane::Role &name);
   void addCustomImage(const std::string &name, const Uptane::Hash &hash, uint64_t length,
-                      const Delegation &delegation = {});
+                      const Delegation &delegation = {}, const Json::Value &custom = {});
   void signTargets();
   void emptyTargets();
   void oldTargets();

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -115,6 +115,7 @@ class SotaUptaneClient {
                                               const Uptane::ImagesRepository &images_repo, INvStorage &storage,
                                               Uptane::Fetcher &fetcher);
   bool updateImagesMeta();  // TODO: make private once aktualizr has a proper TUF API
+  data::InstallationResult PackageInstall(const Uptane::Target &target);
 
  private:
   FRIEND_TEST(Aktualizr, FullNoUpdates);
@@ -147,7 +148,6 @@ class SotaUptaneClient {
   Uptane::Exception getLastException() const { return last_exception; }
   bool isInstalledOnPrimary(const Uptane::Target &target);
   std::vector<Uptane::Target> findForEcu(const std::vector<Uptane::Target> &targets, const Uptane::EcuSerial &ecu_id);
-  data::InstallationResult PackageInstall(const Uptane::Target &target);
   data::InstallationResult PackageInstallSetResult(const Uptane::Target &target);
   void finalizeAfterReboot();
   void reportHwInfo();


### PR DESCRIPTION
This PR is meant to address the functionality discussed in issue #1056. I'm not super happy about the lack of any new test coverage, but I was a little concerned it would require so much mocking that it might not provide much value. However, I'd be more than happy to work on that if you guys think its needed.

I've tested this against two different services:

1) Foundries.io's OTA Connect Deployment
   https://api.foundries.io/lmp/repo/release/api/v1/user_repo/targets.json

2) An "aktualizr-lite" only docker-compose setup
  https://github.com/doanac/ota-compose