### PR TITLE
Dockerfile: Include clang-format

### DIFF
--- a/docker/Dockerfile.ubuntu.bionic
+++ b/docker/Dockerfile.ubuntu.bionic
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get -y install \
   asn1c \
   automake \
   bison \
+  clang-format-6.0 \
   cmake \
   curl \
   e2fslibs-dev \


### PR DESCRIPTION
"make [check-]format" does not work in this project's default container
because clang-format isn't installed. CMake logs a message about this,
but its hard to notice.

Signed-off-by: Andy Doan <andy@foundries.io>