### PR TITLE
Directly bootstrap empty DB from current schema

### DIFF
--- a/src/libaktualizr/storage/sqlstorage_base.h
+++ b/src/libaktualizr/storage/sqlstorage_base.h
@@ -30,6 +30,7 @@ class SQLStorageBase {
   std::vector<std::string> schema_rollback_migrations_;
   const std::string current_schema_;
   const int current_schema_version_;
+  bool dbInsertBackMigrations(SQLite3Guard& db, int version_latest);
 };
 
 #endif  // SQLSTORAGE_BASE_H_


### PR DESCRIPTION
Instead of applying forward migrations.

Also, insert all backward migrations, not only those between we migrated from.

For the command  `time build/run-valgrind "build/src/libaktualizr/storage/t_sqlstorage" "src/libaktualizr/storage/test" --gtest_filter=sqlstorage.migrate_from_fs`, here is before and after:

```
==15663== HEAP SUMMARY:
==15663==     in use at exit: 35,188 bytes in 237 blocks
==15663==   total heap usage: 40,509 allocs, 40,272 frees, 10,669,084 bytes allocated
==15663==
==15663== LEAK SUMMARY:
==15663==    definitely lost: 0 bytes in 0 blocks
==15663==    indirectly lost: 0 bytes in 0 blocks
==15663==      possibly lost: 0 bytes in 0 blocks
==15663==    still reachable: 18,144 bytes in 37 blocks
==15663==                       of which reachable via heuristic:
==15663==                         newarray           : 1,536 bytes in 16 blocks
==15663==         suppressed: 17,044 bytes in 200 blocks
==15663== Reachable blocks (those to which a pointer was found) are not shown.
==15663== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==15663==
==15663== For counts of detected and suppressed errors, rerun with: -v
==15663== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

real    0m2.821s
user    0m2.752s
sys     0m0.068s
```

```
==18507== HEAP SUMMARY:
==18507==     in use at exit: 35,188 bytes in 237 blocks
==18507==   total heap usage: 19,698 allocs, 19,461 frees, 6,185,735 bytes allocated
==18507==
==18507== LEAK SUMMARY:
==18507==    definitely lost: 0 bytes in 0 blocks
==18507==    indirectly lost: 0 bytes in 0 blocks
==18507==      possibly lost: 0 bytes in 0 blocks
==18507==    still reachable: 18,144 bytes in 37 blocks
==18507==                       of which reachable via heuristic:
==18507==                         newarray           : 1,536 bytes in 16 blocks
==18507==         suppressed: 17,044 bytes in 200 blocks
==18507== Reachable blocks (those to which a pointer was found) are not shown.
==18507== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==18507==
==18507== For counts of detected and suppressed errors, rerun with: -v
==18507== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

real    0m2.539s
user    0m2.445s
sys     0m0.093s
```