### PR TITLE
fix implicit provisioning documentation

### DIFF
--- a/docs/implicit-provisioning.adoc
+++ b/docs/implicit-provisioning.adoc
@@ -31,7 +31,7 @@ An example `.toml` configuration file can be found at link:../config/sota_implic
 
 1. Generate a root CA private key and self-signed certificate.
 1. Upload the root CA certificate to the server.
-1. In meta-updater, set `SOTA_CLIENT_PROV = "aktualizr-implicit-ca-prov"` and `SOTA_DEPLOY_CREDENTIALS = "0"`. Currently, you will also need to set `SOTA_PACKED_CREDENTIALS` to a provisioning credentials zip file.
+1. In meta-updater, set `SOTA_CLIENT_PROV = "aktualizr-ca-implicit-prov"` and `SOTA_DEPLOY_CREDENTIALS = "0"`. Currently, you will also need to set `SOTA_PACKED_CREDENTIALS` to a provisioning credentials zip file.
 1. Build a standard image using bitbake.
 1. Boot the image.
 1. Sign the client device certificate with the root private key and install it on the client device.
@@ -43,7 +43,7 @@ An example `.toml` configuration file can be found at link:../config/sota_implic
 
 Implicit provisioning can be simulated with `aktualizr-cert-provider` without need for the user to create a root CA. `aktualizr-cert-provider` can use the existing autoprovisioning mechanisms to pre-install a certificate and key on the device.
 
-1. In meta-updater, set `SOTA_CLIENT_PROV = "aktualizr-implicit-ca-prov"` and `SOTA_DEPLOY_CREDENTIALS = "0"`. Currently, you will also need to set `SOTA_PACKED_CREDENTIALS` to provisioning credentials zip file.
+1. In meta-updater, set `SOTA_CLIENT_PROV = "aktualizr-ca-implicit-prov"` and `SOTA_DEPLOY_CREDENTIALS = "0"`. Currently, you will also need to set `SOTA_PACKED_CREDENTIALS` to provisioning credentials zip file.
 1. Build a standard image using bitbake.
 1. Boot the image.
 1. Optionally, verify that Aktualizr has not provisioned and that the device is not known to the server.


### PR DESCRIPTION
In meta-updater, the variable SOTA_CLIENT_PROV for implicit
provisioning needs to be set to `aktualizr-ca-implicit-prov`.

Signed-off-by: Stefan Agner <stefan.agner@toradex.com>