### PR TITLE
Fix unbound variable DOCKER_OPTS[@] in run_docker_test.sh

### DIFF
--- a/scripts/run_docker_test.sh
+++ b/scripts/run_docker_test.sh
@@ -45,5 +45,10 @@ IMG_TAG=dev-$(cat /proc/sys/kernel/random/uuid)
 
 docker build -t "${IMG_TAG}" -f "$DOCKERFILE" .
 
+
+# Prevent DOCKER_OPTS[@]: unbound variable
+# From SO: https://stackoverflow.com/a/34361807/6096518
+OPTS_STR=${DOCKER_OPTS[@]+"${DOCKER_OPTS[@]}"}
+
 # run under current user, mounting current directory at the same location in the container
-docker run -u "$(id -u):$(id -g)" -v "$PWD:$PWD" -w "$PWD" --rm "${DOCKER_OPTS[@]}" -it "${IMG_TAG}" "$@"
+docker run -u "$(id -u):$(id -g)" -v "$PWD:$PWD" -w "$PWD" --rm $OPTS_STR -it "${IMG_TAG}" "$@"


### PR DESCRIPTION
Resolve: './scripts/run_docker_test.sh: line 49: DOCKER_OPTS[@]: unbound variable'

Signed-off-by: Ben Clouser <ben.clouser@toradex.com>

for issue:
https://github.com/advancedtelematic/aktualizr/issues/1124