### PR TITLE
Make sure cert provider writes gateway URL file where expected

### DIFF
--- a/src/cert_provider/main.cc
+++ b/src/cert_provider/main.cc
@@ -502,7 +502,7 @@ int main(int argc, char* argv[]) {
       copyLocal(tmp_ca_file.PathString(), local_dir / ca_file.get(directory));
     }
     if (provide_url) {
-      copyLocal(tmp_url_file.PathString(), local_dir / url_file.get(""));
+      copyLocal(tmp_url_file.PathString(), local_dir / url_file.get(directory));
     }
     std::cout << "...success\n";
   }


### PR DESCRIPTION
Write the gateway URL file to the default base path (/var/sota/import)
or the configured base path.

Signed-off-by: Stefan Agner <stefan.agner@toradex.com>