### PR TITLE
Set the required permission for the DB/storage folder

### DIFF
--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -189,7 +189,7 @@ int main(int argc, char *argv[]) {
 
   bpo::variables_map commandline_map = parse_options(argc, argv);
 
-  int r = -1;
+  int r = 0;
   try {
     if (geteuid() != 0) {
       LOG_WARNING << "\033[31mRunning as non-root and may not work as expected!\033[0m\n";
@@ -211,7 +211,7 @@ int main(int argc, char *argv[]) {
     throw bpo::invalid_option_value(cmd);
   } catch (const std::exception &ex) {
     LOG_ERROR << ex.what();
-    r = -1;
+    r = 1;
   }
   return r;
 }

--- a/src/aktualizr_lite/test_lite.sh
+++ b/src/aktualizr_lite/test_lite.sh
@@ -60,6 +60,7 @@ $tests_dir/ostree-scripts/makephysical.sh $OSTREE_SYSROOT
 
 sota_dir=$dest_dir/sota
 mkdir $sota_dir
+chmod 700 $sota_dir
 cat >$sota_dir/sota.toml <<EOF
 [uptane]
 repo_server = "http://localhost:$port/repo/image"


### PR DESCRIPTION
Signed-off-by: Mike Sul <ext-mykhaylo.sul@here.com>

Set the required permission (700) for the DB/storage folder (<tmp-dir>/sota) in test_lite.sh.
Set '1' as a default and error exit code instead of -1.