### PR TITLE
OTA-2320: Add an option to aktualizr-info to print delegations metadata

### DIFF
--- a/actions.md
+++ b/actions.md
@@ -342,6 +342,7 @@ These tools all link with libaktualizr, although they do not necessary use the A
   - [x] Print primary ECU keys (aktualizr_info_test.cc)
   - [x] Print primary ECU current and pending versions (aktualizr_info_test.cc)
   - [x] Print device name only for scripting purposes (aktualizr_info_test.cc)
+  - [x] Print delegations (aktualizr_info_test.cc)
 
 ### aktualizr-repo
 

--- a/src/aktualizr_info/main.cc
+++ b/src/aktualizr_info/main.cc
@@ -12,6 +12,25 @@
 
 namespace po = boost::program_options;
 
+static void loadAndPrintDelegations(const std::shared_ptr<INvStorage> &storage) {
+  std::vector<std::pair<Uptane::Role, std::string> > delegations;
+  bool delegations_fetch_res = storage->loadAllDelegations(delegations);
+
+  if (!delegations_fetch_res) {
+    std::cout << "Failed to load delegations" << std::endl;
+    return;
+  }
+
+  if (delegations.size() == 0) {
+    std::cout << "Delegations are not present" << std::endl;
+  }
+
+  std::cout << "Delegations:" << std::endl;
+  for (auto delegation : delegations) {
+    std::cout << delegation.first << ": " << delegation.second << std::endl;
+  }
+}
+
 int main(int argc, char **argv) {
   po::options_description desc("aktualizr-info command line options");
   // clang-format off
@@ -24,6 +43,7 @@ int main(int argc, char **argv) {
     ("ecu-keys",  "Outputs UPTANE keys")
     ("images-root",  "Outputs root.json from images repo")
     ("images-target",  "Outputs targets.json from images repo")
+    ("delegation",  "Outputs metadata of image repo targets' delegations")
     ("director-root",  "Outputs root.json from director repo")
     ("director-target",  "Outputs targets.json from director repo")
     ("allow-migrate", "Opens database in read/write mode to make possible to migrate database if needed");
@@ -54,6 +74,7 @@ int main(int argc, char **argv) {
     std::string director_targets;
     std::string images_root;
     std::string images_targets;
+
     bool has_metadata = storage->loadLatestRoot(&director_root, Uptane::RepositoryType::Director());
     storage->loadLatestRoot(&images_root, Uptane::RepositoryType::Image());
     storage->loadNonRoot(&director_targets, Uptane::RepositoryType::Director(), Uptane::Role::Targets());
@@ -114,6 +135,10 @@ int main(int argc, char **argv) {
       if (vm.count("images-target") != 0u) {
         std::cout << "image targets.json content:" << std::endl;
         std::cout << images_targets << std::endl;
+      }
+
+      if (vm.count("delegation") != 0u) {
+        loadAndPrintDelegations(storage);
       }
 
       if (vm.count("director-root") != 0u) {

--- a/src/libaktualizr/storage/invstorage.h
+++ b/src/libaktualizr/storage/invstorage.h
@@ -138,6 +138,7 @@ class INvStorage {
   virtual void clearMetadata() = 0;
   virtual void storeDelegation(const std::string& data, Uptane::Role role) = 0;
   virtual bool loadDelegation(std::string* data, Uptane::Role role) = 0;
+  virtual bool loadAllDelegations(std::vector<std::pair<Uptane::Role, std::string>>& data) const = 0;
   virtual void deleteDelegation(Uptane::Role role) = 0;
   virtual void clearDelegations() = 0;
 

--- a/src/libaktualizr/storage/sqlstorage.h
+++ b/src/libaktualizr/storage/sqlstorage.h
@@ -45,6 +45,7 @@ class SQLStorage : public SQLStorageBase, public INvStorage {
   void clearMetadata() override;
   void storeDelegation(const std::string& data, Uptane::Role role) override;
   bool loadDelegation(std::string* data, Uptane::Role role) override;
+  bool loadAllDelegations(std::vector<std::pair<Uptane::Role, std::string>>& data) const override;
   void deleteDelegation(Uptane::Role role) override;
   void clearDelegations() override;
 


### PR DESCRIPTION
Signed-off-by: Mike Sul <ext-mykhaylo.sul@here.com>

1. Added an option `--delegate` to aktualizr-info aimed to print delegations metadata;
2. Added corresponding tests.