### PR TITLE
Make Utils::getDirEntriesByExt return sorted results

### DIFF
--- a/src/libaktualizr/utilities/utils.cc
+++ b/src/libaktualizr/utilities/utils.cc
@@ -649,6 +649,7 @@ boost::filesystem::path Utils::absolutePath(const boost::filesystem::path &root,
 }
 
 // passing ext argument keep the leading point e.g. '.ext'
+// results are returned sorted in alpanumeric order
 std::vector<boost::filesystem::path> Utils::getDirEntriesByExt(const boost::filesystem::path &dir_path,
                                                                const std::string &ext) {
   std::vector<boost::filesystem::path> entries;
@@ -659,6 +660,7 @@ std::vector<boost::filesystem::path> Utils::getDirEntriesByExt(const boost::file
       entries.push_back(entry_path);
     }
   }
+  std::sort(entries.begin(), entries.end());
   return entries;
 }
 

--- a/src/libaktualizr/utilities/utils_test.cc
+++ b/src/libaktualizr/utilities/utils_test.cc
@@ -330,6 +330,20 @@ TEST(Utils, shell) {
 
 TEST(Utils, urlencode) { EXPECT_EQ(Utils::urlEncode("test! test@ test#"), "test%21%20test%40%20test%23"); }
 
+TEST(Utils, getDirEntriesByExt) {
+  TemporaryDirectory temp_dir;
+
+  Utils::writeFile(temp_dir / "02-test.toml", std::string(""));
+  Utils::writeFile(temp_dir / "0x-test.noml", std::string(""));
+  Utils::writeFile(temp_dir / "03-test.toml", std::string(""));
+  Utils::writeFile(temp_dir / "01-test.toml", std::string(""));
+
+  auto files = Utils::getDirEntriesByExt(temp_dir.Path(), ".toml");
+  std::vector<boost::filesystem::path> expected{temp_dir / "01-test.toml", temp_dir / "02-test.toml",
+                                                temp_dir / "03-test.toml"};
+  EXPECT_EQ(files, expected);
+}
+
 TEST(Utils, BasedPath) {
   BasedPath bp("a/test.xml");
 


### PR DESCRIPTION
The property was lost when rewritten from Utils::glob