### PR TITLE
bootloader: gracefully reboot after update completes

### DIFF
--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -165,4 +165,5 @@ Options for configuring boot-specific behavior
 | `rollback_mode`        | `"none"`                        | Controls rollback on supported platforms, see link:{aktualizr-github-url}/docs/rollback.adoc[]. Options: `"none"`, `"uboot_generic"`, `"uboot_masked"`
 | `reboot_sentinel_dir`  | `"/var/run/aktualizr-session"`  | Base directory for reboot detection sentinel. Must reside in a temporary file system.
 | `reboot_sentinel_name` | `"need_reboot"`                 | Name of the reboot detection sentinel.
+| `reboot_command`       | `"/sbin/reboot"`                | Command to reboot the system after update completes. Applicable only if `uptane::force_install_completion` is set to `true`.
 |==========================================================================================

--- a/src/libaktualizr/bootloader/bootloader.cc
+++ b/src/libaktualizr/bootloader/bootloader.cc
@@ -1,7 +1,9 @@
 #include <fcntl.h>
-#include <sys/stat.h>
-
+#include <stdlib.h>
+#include <string.h>
 #include <sys/reboot.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include <boost/filesystem.hpp>
@@ -12,6 +14,7 @@
 
 Bootloader::Bootloader(const BootloaderConfig& config, INvStorage& storage) : config_(config), storage_(storage) {
   reboot_sentinel_ = config_.reboot_sentinel_dir / config_.reboot_sentinel_name;
+  reboot_command_ = config_.reboot_command;
 
   if (!Utils::createSecureDirectory(config_.reboot_sentinel_dir)) {
     LOG_WARNING << "Could not create " << config_.reboot_sentinel_dir << " securely, reboot detection support disabled";
@@ -116,12 +119,14 @@ void Bootloader::rebootFlagClear() {
 void Bootloader::reboot(bool fake_reboot) {
   if (fake_reboot) {
     boost::filesystem::remove(reboot_sentinel_);
-  } else {
-    sync();
-    if (setuid(0) != 0) {
-      LOG_ERROR << "Failed to set/verify a root user so cannot reboot system programmatically";
-    } else {
-      ::reboot(RB_AUTOBOOT);
-    }
+    return;
+  }
+  if (setuid(0) != 0) {
+    LOG_ERROR << "Failed to set/verify a root user so cannot reboot system programmatically";
+    return;
+  }
+  sync();
+  if (system(reboot_command_.c_str()) != 0) {
+    LOG_ERROR << "Failed to execute the reboot command: " << reboot_command_;
   }
 }

--- a/src/libaktualizr/bootloader/bootloader.h
+++ b/src/libaktualizr/bootloader/bootloader.h
@@ -29,6 +29,7 @@ class Bootloader {
 
   INvStorage& storage_;
   boost::filesystem::path reboot_sentinel_;
+  std::string reboot_command_;
   bool reboot_detect_supported_{false};
 };
 

--- a/src/libaktualizr/bootloader/bootloader_config.cc
+++ b/src/libaktualizr/bootloader/bootloader_config.cc
@@ -37,10 +37,12 @@ void BootloaderConfig::updateFromPropertyTree(const boost::property_tree::ptree&
   CopyFromConfig(rollback_mode, "rollback_mode", pt);
   CopyFromConfig(reboot_sentinel_dir, "reboot_sentinel_dir", pt);
   CopyFromConfig(reboot_sentinel_name, "reboot_sentinel_name", pt);
+  CopyFromConfig(reboot_command, "reboot_command", pt);
 }
 
 void BootloaderConfig::writeToStream(std::ostream& out_stream) const {
   writeOption(out_stream, rollback_mode, "rollback_mode");
   writeOption(out_stream, reboot_sentinel_dir, "reboot_sentinel_dir");
   writeOption(out_stream, reboot_sentinel_name, "reboot_sentinel_name");
+  writeOption(out_stream, reboot_command, "reboot_command");
 }

--- a/src/libaktualizr/bootloader/bootloader_config.h
+++ b/src/libaktualizr/bootloader/bootloader_config.h
@@ -12,6 +12,7 @@ struct BootloaderConfig {
   RollbackMode rollback_mode{RollbackMode::kBootloaderNone};
   boost::filesystem::path reboot_sentinel_dir{"/var/run/aktualizr-session"};
   boost::filesystem::path reboot_sentinel_name{"need_reboot"};
+  std::string reboot_command{"/sbin/reboot"};
 
   void updateFromPropertyTree(const boost::property_tree::ptree& pt);
   void writeToStream(std::ostream& out_stream) const;


### PR DESCRIPTION
This patch mainly aims to add a graceful reboot by executing
'/sbin/init 6' rather than calling reboot system call.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>