### PR TITLE
logging: Add optional ansi color-escaping for logs

### DIFF
--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -1,3 +1,4 @@
+#include <unistd.h>
 #include <iostream>
 
 #include <openssl/ssl.h>
@@ -184,7 +185,7 @@ bpo::variables_map parse_options(int argc, char *argv[]) {
 }
 
 int main(int argc, char *argv[]) {
-  logger_init();
+  logger_init(isatty(1) == 1);
   logger_set_threshold(boost::log::trivial::info);
 
   bpo::variables_map commandline_map = parse_options(argc, argv);

--- a/src/libaktualizr/logging/android_log_sink.cc
+++ b/src/libaktualizr/logging/android_log_sink.cc
@@ -16,7 +16,8 @@ class android_log_sink : public log::sinks::basic_sink_backend<log::sinks::synch
   }
 };
 
-void logger_init_sink() {
+void logger_init_sink(bool use_colors = false) {
+  (void)use_colors;
   typedef log::sinks::synchronous_sink<android_log_sink> android_log_sink_t;
   log::core::get()->add_sink(boost::shared_ptr<android_log_sink_t>(new android_log_sink_t()));
 }

--- a/src/libaktualizr/logging/default_log_sink.cc
+++ b/src/libaktualizr/logging/default_log_sink.cc
@@ -1,8 +1,38 @@
+#include <iomanip>
 #include <iostream>
 
+#include <boost/log/trivial.hpp>
 #include <boost/log/utility/setup/console.hpp>
 
-void logger_init_sink() {
-  boost::log::add_console_log(std::cout, boost::log::keywords::format = "%Message%",
-                              boost::log::keywords::auto_flush = true);
+static void color_fmt(boost::log::record_view const& rec, boost::log::formatting_ostream& strm) {
+  auto severity = rec[boost::log::trivial::severity];
+  bool color = false;
+  if (severity) {
+    switch (severity.get()) {
+      case boost::log::trivial::warning:
+        strm << "\033[33m";
+        color = true;
+        break;
+      case boost::log::trivial::error:
+      case boost::log::trivial::fatal:
+        strm << "\033[31m";
+        color = true;
+        break;
+      default:
+        break;
+    }
+  }
+  // setw(7) = the longest log level. eg "warning"
+  strm << std::setw(7) << std::setfill(' ') << severity << ": " << rec[boost::log::expressions::smessage];
+  if (color) {
+    strm << "\033[0m";
+  }
+}
+
+void logger_init_sink(bool use_colors = false) {
+  auto sink = boost::log::add_console_log(std::cout, boost::log::keywords::format = "%Message%",
+                                          boost::log::keywords::auto_flush = true);
+  if (use_colors) {
+    sink->set_formatter(&color_fmt);
+  }
 }

--- a/src/libaktualizr/logging/logging.cc
+++ b/src/libaktualizr/logging/logging.cc
@@ -4,14 +4,14 @@ using boost::log::trivial::severity_level;
 
 static severity_level gLoggingThreshold;
 
-extern void logger_init_sink();
+extern void logger_init_sink(bool use_colors = false);
 
 int64_t get_curlopt_verbose() { return gLoggingThreshold <= boost::log::trivial::trace ? 1L : 0L; }
 
-void logger_init() {
+void logger_init(bool use_colors) {
   gLoggingThreshold = boost::log::trivial::info;
 
-  logger_init_sink();
+  logger_init_sink(use_colors);
 
   boost::log::core::get()->set_filter(boost::log::trivial::severity >= gLoggingThreshold);
 }

--- a/src/libaktualizr/logging/logging.h
+++ b/src/libaktualizr/logging/logging.h
@@ -30,7 +30,7 @@
 // curl_easy_setopt(curl_handle, CURLOPT_VERBOSE, get_curlopt_verbose());
 int64_t get_curlopt_verbose();
 
-void logger_init();
+void logger_init(bool use_colors = false);
 
 void logger_set_threshold(boost::log::trivial::severity_level threshold);
 


### PR DESCRIPTION
All the young kids have discovered ansi escape sequences and are
producing colorful logs for TTYs. This may be your project's first PR
that needs a screenshot to explain:

 https://imgur.com/t0R4lO1

Signed-off-by: Andy Doan <andy@foundries.io>