### PR TITLE
OTA-1684: Test installation and installation finalization failures

### DIFF
--- a/actions.md
+++ b/actions.md
@@ -22,7 +22,7 @@ These are the primary actions that a user of libaktualizr can perform through th
     - [x] Store installation result (aktualizr_test.cc)
     - [x] Send manifest (aktualizr_test.cc)
     - [x] Update is not in pending state anymore after successful finalization (aktualizr_test.cc)
-    - [ ] Update is not in pending state anymore after failed finalization
+    - [x] Update is not in pending state anymore after failed finalization (aktualizr_test.cc)
   - [x] Provision with the server
     - [x] Automatically provision (OTA-983, uptane_init_test.cc, uptane_ci_test.cc, auto_prov_test.py)
       - [x] Extract credentials from a provided archive (config_test.cc, utils_test.cc)
@@ -96,8 +96,6 @@ These are the primary actions that a user of libaktualizr can perform through th
 - [x] Pause and Resume the API
   - [x] Suspend API calls during pause
   - [x] Catch up with calls queue after resume
-  - [ ] Pause ongoing download
-  - [ ] Resume ongoing download
 - [x] Download updates
   - [x] Find requested target
     - [x] Search first-order delegations (uptane_delegation_test.cc)
@@ -163,7 +161,8 @@ These are the primary actions that a user of libaktualizr can perform through th
       - [x] Send an event report (see below)
   - [x] Store installation result for device (uptane_test.cc)
   - [x] Compute device installation failure code as concatenation of ECU failure codes (aktualizr_test.cc)
-  - [ ] Store negative device installation result when an ECU installation failed
+  - [x] Store negative device installation result when an ECU installation failed (aktualizr_test.cc)
+  - [x] Update is not in pending state anymore after failed installation (aktualizr_test.cc)
   - [x] Send AllInstallsComplete event after all installations are finished (aktualizr_test.cc)
 - [x] Send installation report
   - [x] Generate and send manifest (see below)

--- a/docs/fault-injection.adoc
+++ b/docs/fault-injection.adoc
@@ -30,6 +30,7 @@ Please try to keep this list up-to-date when inserting/removing fail points.
 
 - `fake_package_install`: make the fake package manager installation to fail, optionally with a failure code supplied via `failinfo`
 - `secondary_install_xxx` (xxx is a virtual secondary ecu id): make a virtual secondary installation to fail, optionally with a failure code supplied via `failinfo`
+- `fake_install_finalization_failure`: make the fake package manager installation finalization to fail
 
 == Use in unit tests
 

--- a/src/libaktualizr/primary/aktualizr.h
+++ b/src/libaktualizr/primary/aktualizr.h
@@ -147,6 +147,8 @@ class Aktualizr {
   FRIEND_TEST(Aktualizr, DeviceInstallationResult);
   FRIEND_TEST(Aktualizr, FullWithUpdates);
   FRIEND_TEST(Aktualizr, FullWithUpdatesNeedReboot);
+  FRIEND_TEST(Aktualizr, FinalizationFailure);
+  FRIEND_TEST(Aktualizr, InstallationFailure);
   FRIEND_TEST(Aktualizr, AutoRebootAfterUpdate);
   FRIEND_TEST(Aktualizr, FullMultipleSecondaries);
   FRIEND_TEST(Aktualizr, CheckNoUpdates);

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -70,6 +70,8 @@ class SotaUptaneClient {
   FRIEND_TEST(Aktualizr, FullMultipleSecondaries);
   FRIEND_TEST(Aktualizr, CheckNoUpdates);
   FRIEND_TEST(Aktualizr, DownloadWithUpdates);
+  FRIEND_TEST(Aktualizr, FinalizationFailure);
+  FRIEND_TEST(Aktualizr, InstallationFailure);
   FRIEND_TEST(Aktualizr, AutoRebootAfterUpdate);
   FRIEND_TEST(Uptane, AssembleManifestGood);
   FRIEND_TEST(Uptane, AssembleManifestBad);

--- a/src/libaktualizr/storage/sqlstorage.cc
+++ b/src/libaktualizr/storage/sqlstorage.cc
@@ -1092,6 +1092,11 @@ bool SQLStorage::loadEcuInstallationResults(
     return false;
   }
 
+  if (statement_result == SQLITE_DONE) {
+    // if there are no any record in the DB
+    return false;
+  }
+
   for (; statement_result != SQLITE_DONE; statement_result = statement.step()) {
     try {
       std::string ecu_serial = statement.get_result_col_str(0).value();

--- a/src/libaktualizr/storage/storage_common_test.cc
+++ b/src/libaktualizr/storage/storage_common_test.cc
@@ -424,8 +424,8 @@ TEST(storage, load_store_installation_results) {
   EXPECT_EQ(correlation_id, "corrid");
 
   storage->clearInstallationResults();
-
-  EXPECT_TRUE(storage->loadEcuInstallationResults(&res));
+  res.clear();
+  EXPECT_FALSE(storage->loadEcuInstallationResults(&res));
   EXPECT_EQ(res.size(), 0);
   EXPECT_FALSE(storage->loadDeviceInstallationResult(&dev_res, &report, &correlation_id));
 }

--- a/src/libaktualizr/uptane/virtualsecondary.cc
+++ b/src/libaktualizr/uptane/virtualsecondary.cc
@@ -11,7 +11,7 @@ namespace Uptane {
 VirtualSecondary::VirtualSecondary(const SecondaryConfig& sconfig_in) : ManagedSecondary(sconfig_in) {}
 
 bool VirtualSecondary::storeFirmware(const std::string& target_name, const std::string& content) {
-  if (fiu_fail((std::string("secondary_install_") + getSerial().ToString()).c_str())) {
+  if (fiu_fail((std::string("secondary_install_") + getSerial().ToString()).c_str()) != 0) {
     return false;
   }
   Utils::writeFile(sconfig.target_name_path, target_name);

--- a/src/libaktualizr/utilities/types.h
+++ b/src/libaktualizr/utilities/types.h
@@ -185,6 +185,7 @@ struct InstallationResult {
 
   Json::Value toJson() const;
   bool isSuccess() const { return success; };
+  bool needCompletion() const { return result_code == ResultCode::Numeric::kNeedCompletion; }
 
   bool success{true};
   ResultCode result_code{ResultCode::Numeric::kOk};


### PR DESCRIPTION
Signed-off-by: Mike Sul <ext-mykhaylo.sul@here.com>

1. Added  tests for two cases:
    a) installation failure;
    b) installation finalization failure.

2. Fixed two bugs
   a) taking into account  the `need completion` case  in the procedure that computes and stores an installation result;
   b) return false if there is no any ECU installation result records in DB in order to make it consistent with other DB methods.