### PR TITLE
 Don't require hashes and sizes of Targets objects in Snapshot metadata.

### DIFF
--- a/src/aktualizr_repo/repo.cc
+++ b/src/aktualizr_repo/repo.cc
@@ -26,11 +26,6 @@ void Repo::addDelegationToSnapshot(Json::Value *snapshot, const Uptane::Role &ro
   Json::Value role_json = Utils::parseJSONFile(repo_dir / role_file_name)["signed"];
   std::string signed_role = Utils::readFile(repo_dir / role_file_name);
 
-  (*snapshot)["meta"][role_file_name]["hashes"]["sha256"] =
-      boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(signed_role)));
-  (*snapshot)["meta"][role_file_name]["hashes"]["sha512"] =
-      boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha512digest(signed_role)));
-  (*snapshot)["meta"][role_file_name]["length"] = static_cast<Json::UInt>(signed_role.length());
   (*snapshot)["meta"][role_file_name]["version"] = role_json["version"].asUInt();
 
   if (role_json["delegations"].isObject()) {
@@ -54,11 +49,6 @@ void Repo::updateRepo() {
   Json::Value root = Utils::parseJSONFile(repo_dir / "root.json")["signed"];
   std::string signed_root = Utils::readFile(repo_dir / "root.json");
 
-  snapshot["meta"]["root.json"]["hashes"]["sha256"] =
-      boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(signed_root)));
-  snapshot["meta"]["root.json"]["hashes"]["sha512"] =
-      boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha512digest(signed_root)));
-  snapshot["meta"]["root.json"]["length"] = static_cast<Json::UInt>(signed_root.length());
   snapshot["meta"]["root.json"]["version"] = root["version"].asUInt();
 
   addDelegationToSnapshot(&snapshot, Uptane::Role::Targets());
@@ -205,11 +195,6 @@ void Repo::generateRepo(KeyType key_type) {
       boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha512digest(signed_root)));
   snapshot["meta"]["root.json"]["length"] = static_cast<Json::UInt>(signed_root.length());
   snapshot["meta"]["root.json"]["version"] = 1;
-  snapshot["meta"]["targets.json"]["hashes"]["sha256"] =
-      boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(signed_targets)));
-  snapshot["meta"]["targets.json"]["hashes"]["sha512"] =
-      boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha512digest(signed_targets)));
-  snapshot["meta"]["targets.json"]["length"] = static_cast<Json::UInt>(signed_targets.length());
   snapshot["meta"]["targets.json"]["version"] = 1;
   std::string signed_snapshot = Utils::jsonToCanonicalStr(signTuf(Uptane::Role::Snapshot(), snapshot));
   Utils::writeFile(repo_dir / "snapshot.json", signed_snapshot);

--- a/src/aktualizr_repo/repo_test.cc
+++ b/src/aktualizr_repo/repo_test.cc
@@ -18,11 +18,6 @@ void check_repo(boost::filesystem::path repo_dir) {
   std::string signed_targets = Utils::readFile(repo_dir / "targets.json");
 
   Json::Value snapshot = Utils::parseJSONFile(repo_dir / "snapshot.json")["signed"];
-  EXPECT_EQ(snapshot["meta"]["targets.json"]["hashes"]["sha256"].asString(),
-            boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(signed_targets))));
-  EXPECT_EQ(snapshot["meta"]["targets.json"]["hashes"]["sha512"].asString(),
-            boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha512digest(signed_targets))));
-  EXPECT_EQ(snapshot["meta"]["targets.json"]["length"].asUInt(), static_cast<Json::UInt>(signed_targets.length()));
   EXPECT_EQ(snapshot["meta"]["targets.json"]["version"].asUInt(), targets["version"].asUInt());
 
   auto signed_snapshot = Utils::readFile(repo_dir / "snapshot.json");

--- a/src/libaktualizr/uptane/tuf.cc
+++ b/src/libaktualizr/uptane/tuf.cc
@@ -361,13 +361,19 @@ void Uptane::Snapshot::init(const Json::Value &json) {
         it.key().asString().substr(0, it.key().asString().rfind('.'));  // strip extension from the role name
     auto role_object = Role(role_name, !Role::IsReserved(role_name));
 
-    role_size_[role_object] = meta_size.asInt64();
     if (meta_version.isIntegral()) {
       role_version_[role_object] = meta_version.asInt();
     } else {
       role_version_[role_object] = -1;
     }
 
+    // Size and hashes are not required, but we may as well record them if
+    // present.
+    if (meta_size.isObject()) {
+      role_size_[role_object] = meta_size.asInt64();
+    } else {
+      role_size_[role_object] = -1;
+    }
     if (hashes_list.isObject()) {
       for (Json::ValueIterator h_it = hashes_list.begin(); h_it != hashes_list.end(); ++h_it) {
         Hash h(h_it.key().asString(), (*h_it).asString());


### PR DESCRIPTION
Uptane (and TUF) no longer require them. If they are there, we will use
them, and if not, we skip them. This provides no real security benefit,
but may help detect implementation faults.

For more information, see:
https://github.com/uptane/uptane-standard/issues/90
https://github.com/uptane/uptane-standard/pull/92

Please also review https://github.com/advancedtelematic/tuf-test-vectors/pull/49. That needs to get merged first.