### PR TITLE
fetcher_test: create temporary repo for OSTree

### DIFF
--- a/src/libaktualizr/package_manager/CMakeLists.txt
+++ b/src/libaktualizr/package_manager/CMakeLists.txt
@@ -43,7 +43,7 @@ endif(BUILD_OSTREE)
 
 add_aktualizr_test(NAME packagemanager_factory SOURCES packagemanagerfactory_test.cc NO_VALGRIND
                    ARGS ${PROJECT_BINARY_DIR}/ostree_repo)
-add_aktualizr_test(NAME fetcher SOURCES fetcher_test.cc ARGS ${PROJECT_BINARY_DIR}/ostree_repo PROJECT_WORKING_DIRECTORY)
+add_aktualizr_test(NAME fetcher SOURCES fetcher_test.cc ARGS PROJECT_WORKING_DIRECTORY)
 add_aktualizr_test(NAME fetcher_death SOURCES fetcher_death_test.cc NO_VALGRIND ARGS PROJECT_WORKING_DIRECTORY)
 
 aktualizr_source_file_checks(fetcher_death_test.cc fetcher_test.cc)


### PR DESCRIPTION
Currently, we are copying an ostree sysroot directory created by make_ostree_sysroot CMake target to use as a destination local repo for OSTree pull. For some reason, sometimes it was causing a problem on some deployments similar to the problem described and fixed by @patriotyk in https://github.com/advancedtelematic/aktualizr/pull/1007#issuecomment-441233660

This PR replaces the copy, as it's should be even faster to create an empty sysroot in a temp dir, and it also seems to fix the problem.

Signed-off-by: Eugene Smirnov <evgenii.smirnov@here.com>