### PR TITLE
OTA-1684: Test events sending if target downloading fails

### DIFF
--- a/actions.md
+++ b/actions.md
@@ -122,11 +122,11 @@ These are the primary actions that a user of libaktualizr can perform through th
     - [x] Send EcuDownloadCompletedReport to server (aktualizr_test.cc)
       - [x] Send an event report (see below)
   - [x] Send DownloadTargetComplete event if download is successful (aktualizr_test.cc)
-  - [ ] Send DownloadTargetComplete event if download is unsuccessful
+  - [x] Send DownloadTargetComplete event if download is unsuccessful (aktualizr_test.cc)
   - [x] Send AllDownloadsComplete event after all downloads are finished (aktualizr_test.cc)
-  - [ ] Send AllDownloadsComplete event after partial download success
+  - [x] Send AllDownloadsComplete event after partial download success (aktualizr_test.cc)
   - [x] Send AllDownloadsComplete event if there is nothing to download (aktualizr_test.cc)
-  - [ ] Send AllDownloadsComplete event if all downloads are unsuccessful
+  - [x] Send AllDownloadsComplete event if all downloads are unsuccessful (aktualizr_test.cc)
 - [x] Access downloaded binaries via API (aktualizr_test.cc)
 - [x] Install updates
   - [x] Send metadata to secondary ECUs (uptane_test.cc)

--- a/src/libaktualizr/primary/aktualizr.h
+++ b/src/libaktualizr/primary/aktualizr.h
@@ -151,6 +151,7 @@ class Aktualizr {
   FRIEND_TEST(Aktualizr, FullMultipleSecondaries);
   FRIEND_TEST(Aktualizr, CheckNoUpdates);
   FRIEND_TEST(Aktualizr, DownloadWithUpdates);
+  FRIEND_TEST(Aktualizr, DownloadFailures);
   FRIEND_TEST(Aktualizr, InstallWithUpdates);
   FRIEND_TEST(Aktualizr, ReportDownloadProgress);
   FRIEND_TEST(Aktualizr, CampaignCheckAndAccept);

--- a/src/libaktualizr/primary/events.h
+++ b/src/libaktualizr/primary/events.h
@@ -90,9 +90,11 @@ class DownloadProgressReport : public BaseEvent {
  */
 class DownloadTargetComplete : public BaseEvent {
  public:
+  static constexpr const char* TypeName{"DownloadTargetComplete"};
+
   DownloadTargetComplete(Uptane::Target update_in, bool success_in)
       : update(std::move(update_in)), success(success_in) {
-    variant = "DownloadTargetComplete";
+    variant = TypeName;
   }
 
   Uptane::Target update;
@@ -104,9 +106,9 @@ class DownloadTargetComplete : public BaseEvent {
  */
 class AllDownloadsComplete : public BaseEvent {
  public:
-  explicit AllDownloadsComplete(result::Download result_in) : result(std::move(result_in)) {
-    variant = "AllDownloadsComplete";
-  }
+  static constexpr const char* TypeName{"AllDownloadsComplete"};
+
+  explicit AllDownloadsComplete(result::Download result_in) : result(std::move(result_in)) { variant = TypeName; }
 
   result::Download result;
 };

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -545,6 +545,9 @@ result::Download SotaUptaneClient::downloadImages(const std::vector<Uptane::Targ
   if (!targets.empty()) {
     if (targets.size() == downloaded_targets.size()) {
       result = result::Download(downloaded_targets, result::DownloadStatus::kSuccess, "");
+    } else if (downloaded_targets.size() == 0) {
+      LOG_ERROR << "None of " << targets.size() << " targets were successfully downloaded.";
+      result = result::Download(downloaded_targets, result::DownloadStatus::kError, "Each target download has failed");
     } else {
       LOG_ERROR << "Only " << downloaded_targets.size() << " of " << targets.size() << " were successfully downloaded.";
       result = result::Download(downloaded_targets, result::DownloadStatus::kPartialSuccess, "");


### PR DESCRIPTION
Signed-off-by: Mike Sul <ext-mykhaylo.sul@here.com>

1. Test event sending if download fails;
2. Fix the download result if partial download failure.