### PR TITLE
Fix null pointer bug in aktualizr-lite

### DIFF
--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -31,7 +31,11 @@ static int list_main(Config &config, const bpo::variables_map &unused) {
 
   LOG_INFO << "Refreshing target metadata";
   if (!client->updateImagesMeta()) {
-    LOG_ERROR << "Unable to update latest metadata, using local copy";
+    LOG_WARNING << "Unable to update latest metadata, using local copy";
+    if (!client->checkImagesMetaOffline()) {
+      LOG_ERROR << "Unable to use local copy of TUF data";
+      return 1;
+    }
   }
 
   LOG_INFO << "Updates for available to " << hwid << ":";
@@ -54,7 +58,11 @@ static std::unique_ptr<Uptane::Target> find_target(const std::shared_ptr<SotaUpt
                                                    Uptane::HardwareIdentifier &hwid, const std::string &version) {
   std::unique_ptr<Uptane::Target> rv;
   if (!client->updateImagesMeta()) {
-    LOG_ERROR << "Unable to update latest metadata, using local copy";
+    LOG_WARNING << "Unable to update latest metadata, using local copy";
+    if (!client->checkImagesMetaOffline()) {
+      LOG_ERROR << "Unable to use local copy of TUF data";
+      throw std::runtime_error("Unable to find update");
+    }
   }
   for (auto &t : client->allTargets()) {
     for (auto const &it : t.hardwareIds()) {

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -62,6 +62,7 @@ class SotaUptaneClient {
   Uptane::LazyTargetsList allTargets();
 
   bool updateImagesMeta();  // TODO: make private once aktualizr has a proper TUF API
+  bool checkImagesMetaOffline();
   data::InstallationResult PackageInstall(const Uptane::Target &target);
 
  private:
@@ -115,7 +116,6 @@ class SotaUptaneClient {
   std::pair<bool, Uptane::Target> downloadImage(Uptane::Target target, const api::FlowControlToken *token = nullptr);
   void rotateSecondaryRoot(Uptane::RepositoryType repo, Uptane::SecondaryInterface &secondary);
   bool updateDirectorMeta();
-  bool checkImagesMetaOffline();
   bool checkDirectorMetaOffline();
   void computeDeviceInstallationResult(data::InstallationResult *result, const std::string &correlation_id);
   std::unique_ptr<Uptane::Target> findTargetInDelegationTree(const Uptane::Target &target);

--- a/src/libaktualizr/uptane/iterator.cc
+++ b/src/libaktualizr/uptane/iterator.cc
@@ -102,7 +102,7 @@ const Target &LazyTargetsList::DelegationIterator::operator*() {
     renewTargetsData();
   }
 
-  if (target_idx_ >= cur_targets_->targets.size()) {
+  if (!cur_targets_ || target_idx_ >= cur_targets_->targets.size()) {
     throw std::runtime_error("Inconsistent delegation iterator");  // TODO: UptaneException
   }
 


### PR DESCRIPTION
I was testing aktualizr-lite today and noticed what I think may be a new regression. If the repo server is offline, you'll get a core-dump like:
~~~
   info: Refreshing target metadata
  error: curl error 7 (http code 0): Couldn't connect to server
  error: curl error 7 (http code 0): Couldn't connect to server
  error: curl error 7 (http code 0): Couldn't connect to server
  error: Unable to update latest metadata, using local copy
   info: Updates available to raspberrypi3-64:
Segmentation fault (core dumped)
~~~

This fix does 2 things:
1) Adds exception handling for the situation in iterator.cc to make debugging future issues easier
2) Updates aktualizr-lite to be able to use the offline data if possible