### PR TITLE
OTA-2418: Remove example.com URL from automated garage-sign usage

### DIFF
--- a/src/sota_tools/deploy.cc
+++ b/src/sota_tools/deploy.cc
@@ -88,7 +88,7 @@ bool OfflineSignRepo(const ServerCredentials &push_credentials, const std::strin
     return false;
   }
 
-  std::string cmd("garage-sign targets add --repo aktualizr --format OSTREE --length 0 --url \"https://example.com/\"");
+  std::string cmd("garage-sign targets add --repo aktualizr --format OSTREE --length 0");
   cmd += " --name " + name + " --version " + hash.string() + " --sha256 " + hash.string();
   cmd += " --hardwareids " + hardwareids;
   if (system(cmd.c_str()) != 0) {


### PR DESCRIPTION
Signed-off-by: Mike Sul <ext-mykhaylo.sul@here.com>

Verification steps:
make check & make qa

Bitbaking and running 'happy path' scenarios on qemu, see this PR https://github.com/advancedtelematic/meta-updater/pull/510 for more details.