### PR TITLE
Remove unexisting CMake target

### DIFF
--- a/src/libaktualizr/storage/CMakeLists.txt
+++ b/src/libaktualizr/storage/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_custom_command(OUTPUT sql_schemas.cc sql_schemas_target
+add_custom_command(OUTPUT sql_schemas.cc
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/embed_schemas.py ${PROJECT_SOURCE_DIR}/config/sql/ ${CMAKE_CURRENT_BINARY_DIR}/sql_schemas.cc libaktualizr
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )


### PR DESCRIPTION
The `sql_schemas_target` is not generated anymore but was still present in the OUTPUT section of `add_custom_command` rule. That was causing `make` to rebuild the target every time.

Looks like the issue didn't appear when building with `ninja`.