### PR TITLE
Fix/no etc dir install

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -55,7 +55,7 @@ The default versions packaged in recent Debian/Ubuntu releases are generally new
 Additional packages are used for non-essential components:
 
 * To build the test suite, you will need `python3-dev python3-openssl python3-venv sqlite3 valgrind`.
-* To run the lintint tools, you will need `clang clang-format-6.0 clang-tidy-6.0`.
+* To run the linting tools, you will need `clang clang-format-6.0 clang-tidy-6.0`.
 * To build additional documentation, you will need `doxygen graphviz`.
 * To build with code coverage, you will need `lcov`.
 

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -17,5 +17,4 @@ if(BUILD_DEB)
         COMPONENT aktualizr)
 endif(BUILD_DEB)
 
-install(DIRECTORY DESTINATION etc/sota/conf.d COMPONENT aktualizr)
 install(DIRECTORY DESTINATION lib/sota/conf.d COMPONENT aktualizr)


### PR DESCRIPTION
The fix here https://github.com/advancedtelematic/aktualizr/commit/0eccec9f5d8aeba9f409e943a9a7dcc666829b85 was incorrect as it led the `/usr/etc/sota/conf.d` directory to be installed on yocto images.

We actually don't need to create this directory from CMake, so let's remove it altogether.

Also, a typo fix