### PR TITLE
Use bare-user-only in test_fetcher

### DIFF
--- a/src/libaktualizr/package_manager/fetcher_test.cc
+++ b/src/libaktualizr/package_manager/fetcher_test.cc
@@ -248,7 +248,7 @@ int main(int argc, char** argv) {
     return -1;
   }
   r = system((std::string("ostree config --repo=") + temp_dir.PathString() +
-              std::string("/ostree/repo set core.mode bare-user"))
+              std::string("/ostree/repo set core.mode bare-user-only"))
                  .c_str());
   if (r != 0) {
     return -1;


### PR DESCRIPTION
So that it can be run on temporary file systems (ptest for example)