### PR TITLE
Fix cert_provider_test with recent versions of openssl

### DIFF
--- a/src/cert_provider/cert_provider_test.cc
+++ b/src/cert_provider/cert_provider_test.cc
@@ -249,7 +249,7 @@ TEST_F(AktualizrCertProviderTest, DeviceCertParams) {
   ASSERT_NE(openssl.lastStdOut().find(expected_subject_str), std::string::npos);
 
   // check RSA length
-  const std::string expected_key_str = str(boost::format("Private-Key: (%1% bit)") % rsa_bits);
+  const std::string expected_key_str = str(boost::format("Private-Key: (%1% bit") % rsa_bits);
 
   openssl.run({"rsa", "-in", device_cred_path.privateKeyFileFullPath.string(), "-text", "-noout"});
   ASSERT_EQ(openssl.lastExitCode(), 0) << openssl.lastStdErr();


### PR DESCRIPTION
On OpenSSL 1.1.1b 26 Feb 2019, the line shows as:

    RSA Private-Key: (1024 bit, 2 primes)

Instead of:

    RSA Private-Key: (1024 bit)

One character diff PR!