### PR TITLE
OTA-2536: Preconfigure IpUptaneSecondary with IP address

### DIFF
--- a/src/aktualizr_primary/CMakeLists.txt
+++ b/src/aktualizr_primary/CMakeLists.txt
@@ -1,7 +1,13 @@
-add_executable(aktualizr main.cc)
-target_link_libraries(aktualizr aktualizr_static_lib ${AKTUALIZR_EXTERNAL_LIBS})
+set(TARGET aktualizr)
+set(SOURCES main.cc secondary_config.h secondary_config.cc secondary.h secondary.cc)
 
-aktualizr_source_file_checks(main.cc)
+add_executable(${TARGET} ${SOURCES})
+target_link_libraries(${TARGET} aktualizr_static_lib aktualizr-posix ${AKTUALIZR_EXTERNAL_LIBS})
+target_include_directories(${TARGET} PUBLIC
+  ${PROJECT_SOURCE_DIR}/src/libaktualizr-posix
+  ${PROJECT_SOURCE_DIR}/third_party)
+
+aktualizr_source_file_checks(${SOURCES})
 
 install(TARGETS aktualizr RUNTIME DESTINATION bin COMPONENT aktualizr)
 

--- a/src/aktualizr_primary/main.cc
+++ b/src/aktualizr_primary/main.cc
@@ -9,6 +9,7 @@
 #include "config/config.h"
 #include "logging/logging.h"
 #include "primary/aktualizr.h"
+#include "secondary.h"
 #include "utilities/utils.h"
 
 namespace bpo = boost::program_options;
@@ -42,6 +43,7 @@ bpo::variables_map parse_options(int argc, char *argv[]) {
       ("primary-ecu-serial", bpo::value<std::string>(), "serial number of primary ecu")
       ("primary-ecu-hardware-id", bpo::value<std::string>(), "hardware ID of primary ecu")
       ("secondary-configs-dir", bpo::value<boost::filesystem::path>(), "directory containing secondary ECU configuration files")
+      ("secondary-config-file", bpo::value<boost::filesystem::path>(), "secondary ECUs configuration file")
       ("campaign-id", bpo::value<std::string>(), "id of the campaign to act on");
   // clang-format on
 
@@ -120,6 +122,11 @@ int main(int argc, char *argv[]) {
     boost::signals2::scoped_connection conn;
 
     conn = aktualizr.SetSignalHandler(f_cb);
+
+    if (!config.uptane.secondary_config_file.empty()) {
+      Primary::initSecondaries(aktualizr, config.uptane.secondary_config_file);
+    }
+
     aktualizr.Initialize();
 
     std::string run_mode;

--- a/src/aktualizr_primary/secondary.cc
+++ b/src/aktualizr_primary/secondary.cc
@@ -1,0 +1,51 @@
+#include <unordered_map>
+
+#include "secondary.h"
+#include "secondary_config.h"
+
+#include "ipuptanesecondary.h"
+
+namespace Primary {
+
+using SecondaryFactoryRegistry =
+    std::unordered_map<std::string, std::function<std::shared_ptr<Uptane::SecondaryInterface>(const SecondaryConfig&)>>;
+
+static SecondaryFactoryRegistry sec_factory_registry = {
+    {IPSecondaryConfig::Type,
+     [](const SecondaryConfig& config) {
+       auto ip_sec_cgf = dynamic_cast<const IPSecondaryConfig&>(config);
+       return Uptane::IpUptaneSecondary::create(ip_sec_cgf.ip, ip_sec_cgf.port);
+     }},
+    //  {
+    //     Add another secondary factory here
+    //  }
+};
+
+static std::shared_ptr<Uptane::SecondaryInterface> createSecondary(const SecondaryConfig& config) {
+  return (sec_factory_registry.at(config.type()))(config);
+}
+
+void initSecondaries(Aktualizr& aktualizr, const boost::filesystem::path& config_file) {
+  if (!boost::filesystem::exists(config_file)) {
+    throw std::invalid_argument("Secondary ECUs config file does not exist: " + config_file.string());
+  }
+
+  auto secondary_configs = SecondaryConfigParser::parse_config_file(config_file);
+
+  for (auto& config : secondary_configs) {
+    try {
+      LOG_INFO << "Creating Secondary of type: " << config->type();
+      std::shared_ptr<Uptane::SecondaryInterface> secondary = createSecondary(*config);
+
+      LOG_INFO << "Adding Secondary to Aktualizr."
+               << "HW_ID: " << secondary->getHwId() << " Serial: " << secondary->getSerial();
+      aktualizr.AddSecondary(secondary);
+
+    } catch (const std::exception& exc) {
+      LOG_ERROR << "Failed to initialize a secondary: " << exc.what();
+      LOG_ERROR << "Continue with initialization of the remaining secondaries, if any left.";
+      // otherwise rethrow the exception
+    }
+  }
+}
+}  // namespace Primary

--- a/src/aktualizr_primary/secondary.h
+++ b/src/aktualizr_primary/secondary.h
@@ -1,0 +1,14 @@
+#ifndef SECONDARY_H_
+#define SECONDARY_H_
+
+#include <boost/filesystem.hpp>
+
+#include "primary/aktualizr.h"
+
+namespace Primary {
+
+void initSecondaries(Aktualizr& aktualizr, const boost::filesystem::path& config_file);
+
+}  // namespace Primary
+
+#endif  // SECONDARY_H_

--- a/src/aktualizr_primary/secondary_config.cc
+++ b/src/aktualizr_primary/secondary_config.cc
@@ -1,0 +1,91 @@
+#include <fstream>
+#include <iostream>
+#include <unordered_map>
+
+#include "logging/logging.h"
+#include "secondary_config.h"
+
+namespace Primary {
+
+const char* const IPSecondaryConfig::Type = "ip";
+
+SecondaryConfigParser::Configs SecondaryConfigParser::parse_config_file(const boost::filesystem::path& config_file) {
+  if (!boost::filesystem::exists(config_file)) {
+    throw std::invalid_argument("Specified config file doesn't exist: " + config_file.string());
+  }
+
+  auto cfg_file_ext = boost::filesystem::extension(config_file);
+  std::shared_ptr<SecondaryConfigParser> cfg_parser;
+
+  if (cfg_file_ext == ".json") {
+    cfg_parser = std::make_shared<JsonConfigParser>(config_file);
+  } else {  // add your format of configuration file + implement SecondaryConfigParser specialization
+    throw std::invalid_argument("Unsupported type of config format: " + cfg_file_ext);
+  }
+
+  return cfg_parser->parse();
+}
+
+/*
+config file example
+
+{
+  "ip": [
+          {"addr": "127.0.0.1:9031"},
+          {"addr": "127.0.0.1:9032"}
+  ],
+  "socketcan": [
+          {"key": "value", "key1": "value1"},
+          {"key": "value", "key1": "value1"}
+  ]
+}
+
+*/
+
+JsonConfigParser::JsonConfigParser(const boost::filesystem::path& config_file) {
+  assert(boost::filesystem::exists(config_file));
+  std::ifstream json_file_stream(config_file.string());
+  Json::Reader json_reader;
+
+  if (!json_reader.parse(json_file_stream, root_, false)) {
+    throw std::invalid_argument("Failed to parse secondary config file: " + config_file.string() + ": " +
+                                json_reader.getFormattedErrorMessages());
+  }
+}
+
+SecondaryConfigParser::Configs JsonConfigParser::parse() {
+  Configs res_sec_cfg;
+
+  for (Json::ValueIterator it = root_.begin(); it != root_.end(); ++it) {
+    std::string secondary_type = it.key().asString();
+
+    if (sec_cfg_factory_registry_.find(secondary_type) == sec_cfg_factory_registry_.end()) {
+      LOG_ERROR << "Unsupported type of sescondary config was found: `" << secondary_type
+                << "`. Ignoring it and continuing with parsing of other secondary configs";
+    } else {
+      (sec_cfg_factory_registry_.at(secondary_type))(res_sec_cfg, *it);
+    }
+  }
+
+  return res_sec_cfg;
+}
+
+static std::pair<std::string, uint16_t> getIPAndPort(const std::string& addr) {
+  auto del_pos = addr.find_first_of(':');
+  if (del_pos == std::string::npos) {
+    throw std::invalid_argument("Incorrect address string, couldn't find port delimeter: " + addr);
+  }
+  std::string ip = addr.substr(0, del_pos);
+  uint16_t port = static_cast<uint16_t>(std::stoul(addr.substr(del_pos + 1)));
+
+  return std::make_pair(ip, port);
+}
+
+void JsonConfigParser::createIPSecondaryConfig(Configs& configs, Json::Value& ip_sec_cfgs) {
+  for (const auto& ip_sec_cfg : ip_sec_cfgs) {
+    auto addr = getIPAndPort(ip_sec_cfg[IPSecondaryConfig::AddrField].asString());
+    configs.emplace_back(std::make_shared<IPSecondaryConfig>(addr.first, addr.second));
+  }
+}
+
+}  // namespace Primary

--- a/src/aktualizr_primary/secondary_config.h
+++ b/src/aktualizr_primary/secondary_config.h
@@ -1,0 +1,67 @@
+#ifndef SECONDARY_CONFIG_H_
+#define SECONDARY_CONFIG_H_
+
+#include <json/json.h>
+#include <boost/filesystem.hpp>
+#include <unordered_map>
+
+namespace Primary {
+
+class SecondaryConfig {
+ public:
+  SecondaryConfig(const char* type) : type_(type) {}
+  virtual const char* type() const { return type_; }
+  virtual ~SecondaryConfig() = default;
+
+ private:
+  const char* const type_;
+};
+
+class IPSecondaryConfig : public SecondaryConfig {
+ public:
+  static const char* const Type;
+  static constexpr const char* const AddrField{"addr"};
+
+  IPSecondaryConfig(std::string addr_ip, uint16_t addr_port)
+      : SecondaryConfig(Type), ip(std::move(addr_ip)), port(addr_port) {}
+
+ public:
+  const std::string ip;
+  const uint16_t port;
+};
+
+class SecondaryConfigParser {
+ public:
+  using Configs = std::vector<std::shared_ptr<SecondaryConfig>>;
+
+  static Configs parse_config_file(const boost::filesystem::path& config_file);
+  virtual ~SecondaryConfigParser() = default;
+
+  // TODO implement iterator instead of parse
+  virtual Configs parse() = 0;
+};
+
+class JsonConfigParser : public SecondaryConfigParser {
+ public:
+  JsonConfigParser(const boost::filesystem::path& config_file);
+
+  Configs parse() override;
+
+ private:
+  static void createIPSecondaryConfig(Configs& configs, Json::Value& ip_sec_cfgs);
+  // add here a factory method for another type of secondary config
+
+ private:
+  using SecondaryConfigFactoryRegistry = std::unordered_map<std::string, std::function<void(Configs&, Json::Value&)>>;
+
+  SecondaryConfigFactoryRegistry sec_cfg_factory_registry_ = {
+      {IPSecondaryConfig::Type, createIPSecondaryConfig}
+      // add here factory method for another type of secondary config
+  };
+
+  Json::Value root_;
+};
+
+}  // namespace Primary
+
+#endif  // SECONDARY_CONFIG_H_

--- a/src/aktualizr_secondary/aktualizr_secondary.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary.cc
@@ -120,16 +120,20 @@ bool AktualizrSecondary::sendFirmwareResp(const std::shared_ptr<std::string>& fi
   }
 
   std::string treehub_server;
-  try {
-    std::string ca, cert, pkey, server_url;
-    extractCredentialsArchive(*firmware, &ca, &cert, &pkey, &treehub_server);
-    keys_.loadKeys(&ca, &cert, &pkey);
-    boost::trim(server_url);
-    treehub_server = server_url;
-  } catch (std::runtime_error& exc) {
-    LOG_ERROR << exc.what();
 
-    return false;
+  if (target_->IsOstree()) {
+    // this is the ostree specific case
+    try {
+      std::string ca, cert, pkey, server_url;
+      extractCredentialsArchive(*firmware, &ca, &cert, &pkey, &treehub_server);
+      keys_.loadKeys(&ca, &cert, &pkey);
+      boost::trim(server_url);
+      treehub_server = server_url;
+    } catch (std::runtime_error& exc) {
+      LOG_ERROR << exc.what();
+
+      return false;
+    }
   }
 
   data::InstallationResult install_res;
@@ -147,7 +151,7 @@ bool AktualizrSecondary::sendFirmwareResp(const std::shared_ptr<std::string>& fi
     LOG_ERROR << "Could not pull from OSTree. Aktualizr was built without OSTree support!";
     return false;
 #endif
-  } else {
+  } else if (pacman->name() == "debian") {
     // TODO save debian package here.
     LOG_ERROR << "Installation of non ostree images is not suppotrted yet.";
     return false;

--- a/src/aktualizr_secondary/aktualizr_secondary_common.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_common.cc
@@ -35,6 +35,7 @@ bool AktualizrSecondaryCommon::uptaneInitialize() {
   if (storage_->loadEcuSerials(&ecu_serials)) {
     ecu_serial_ = ecu_serials[0].first;
     hardware_id_ = ecu_serials[0].second;
+
     return true;
   }
 

--- a/src/aktualizr_secondary/socket_server.cc
+++ b/src/aktualizr_secondary/socket_server.cc
@@ -61,6 +61,14 @@ void SocketServer::HandleOneConnection(int socket) {
     // Figure out what to do with the message
     Asn1Message::Ptr resp = Asn1Message::Empty();
     switch (msg->present()) {
+      case AKIpUptaneMes_PR_getInfoReq: {
+        Uptane::EcuSerial serial = impl_->getSerial();
+        Uptane::HardwareIdentifier hw_id = impl_->getHwId();
+        resp->present(AKIpUptaneMes_PR_getInfoResp);
+        auto r = resp->getInfoResp();
+        SetString(&r->ecuSerial, serial.ToString());
+        SetString(&r->hwId, hw_id.ToString());
+      } break;
       case AKIpUptaneMes_PR_publicKeyReq: {
         PublicKey pk = impl_->getPublicKey();
         resp->present(AKIpUptaneMes_PR_publicKeyResp);

--- a/src/libaktualizr-posix/asn1/asn1_message.h
+++ b/src/libaktualizr-posix/asn1/asn1_message.h
@@ -68,6 +68,8 @@ class Asn1Message {
     return Asn1Sub<MessageType>(this, &msg_.choice.FieldName); /* NOLINT(cppcoreguidelines-pro-type-union-access) */ \
   }
 
+  ASN1_MESSAGE_DEFINE_ACCESSOR(AKGetInfoReqMes_t, getInfoReq);
+  ASN1_MESSAGE_DEFINE_ACCESSOR(AKGetInfoRespMes_t, getInfoResp);
   ASN1_MESSAGE_DEFINE_ACCESSOR(AKDiscoveryReqMes_t, discoveryReq);
   ASN1_MESSAGE_DEFINE_ACCESSOR(AKDiscoveryRespMes_t, discoveryResp);
   ASN1_MESSAGE_DEFINE_ACCESSOR(AKPublicKeyReqMes_t, publicKeyReq);
@@ -122,5 +124,5 @@ void SetString(OCTET_STRING_t* dest, const std::string& str);
  * Open a TCP connection to client; send a message and wait for a
  * response.
  */
-Asn1Message::Ptr Asn1Rpc(const Asn1Message::Ptr& tx, const struct sockaddr_storage& client);
+Asn1Message::Ptr Asn1Rpc(const Asn1Message::Ptr& tx, const struct sockaddr_in& server_sock_addr);
 #endif  // ASN1_MESSAGE_H_

--- a/src/libaktualizr-posix/asn1/messages/ipuptane_message.asn1
+++ b/src/libaktualizr-posix/asn1/messages/ipuptane_message.asn1
@@ -31,6 +31,16 @@ IpUptane DEFINITIONS ::= BEGIN
 		...
 	}
 
+	AKGetInfoReqMes ::= SEQUENCE {
+		...
+	}
+
+	AKGetInfoRespMes ::= SEQUENCE {
+		ecuSerial UTF8String,
+		hwId UTF8String,
+		...
+	}
+
 	AKDiscoveryReqMes ::= SEQUENCE {
 		port INTEGER(0..65535),
 		...
@@ -101,6 +111,8 @@ IpUptane DEFINITIONS ::= BEGIN
 		putMetaResp [7] AKPutMetaRespMes,
 		sendFirmwareReq [12] AKSendFirmwareReqMes,
 		sendFirmwareResp [13] AKSendFirmwareRespMes,
+		getInfoReq [14] AKGetInfoReqMes,
+		getInfoResp [15] AKGetInfoRespMes,
 		...
 	}
 

--- a/src/libaktualizr-posix/ipsecondarydiscovery.cc
+++ b/src/libaktualizr-posix/ipsecondarydiscovery.cc
@@ -79,10 +79,10 @@ std::vector<Uptane::SecondaryConfig> IpSecondaryDiscovery::waitDevices() {
     auto resp = msg->discoveryResp();
     conf.ecu_serial = ToString(resp->ecuSerial);
     conf.ecu_hardware_id = ToString(resp->hwId);
-    conf.ip_addr = sec_address;
-    Utils::setSocketPort(&conf.ip_addr, htons(static_cast<uint16_t>(resp->port)));
+    // conf.ip_addr = sec_address;
+    // Utils::setSocketPort(&conf.ip_addr, htons(static_cast<uint16_t>(resp->port)));
 
-    LOG_INFO << "Found secondary:" << conf.ecu_serial << " " << conf.ecu_hardware_id << " " << conf.ip_addr;
+    // LOG_INFO << "Found secondary:" << conf.ecu_serial << " " << conf.ecu_hardware_id << " " << conf.ip_addr;
     conf.secondary_type = Uptane::SecondaryType::kIpUptane;
 
     secondaries.push_back(conf);

--- a/src/libaktualizr-posix/ipuptanesecondary.h
+++ b/src/libaktualizr-posix/ipuptanesecondary.h
@@ -7,22 +7,39 @@
 #include "uptane/secondaryinterface.h"
 
 namespace Uptane {
+
 class IpUptaneSecondary : public SecondaryInterface {
  public:
-  explicit IpUptaneSecondary(const SecondaryConfig& conf) : SecondaryInterface(conf) {}
+  static std::shared_ptr<Uptane::SecondaryInterface> create(const std::string& address, unsigned short port);
 
-  // SecondaryInterface implementation
-  PublicKey getPublicKey() override;
+  explicit IpUptaneSecondary(const sockaddr_in& sock_addr, EcuSerial serial, HardwareIdentifier hw_id,
+                             PublicKey pub_key);
+
+  // what this method for ? Looks like should be removed out of SecondaryInterface
+  void Initialize() override{};
+
+  // It looks more natural to return const EcuSerial& and const Uptane::HardwareIdentifier&
+  // and they should be 'const' methods
+  EcuSerial getSerial() /*const*/ override { return serial_; };
+  Uptane::HardwareIdentifier getHwId() /*const*/ override { return hw_id_; }
+  PublicKey getPublicKey() /*const*/ override { return pub_key_; }
+
   bool putMetadata(const RawMetaPack& meta_pack) override;
   int32_t getRootVersion(bool /* director */) override { return 0; }
   bool putRoot(const std::string& /* root */, bool /* director */) override { return true; }
   bool sendFirmware(const std::shared_ptr<std::string>& data) override;
   Json::Value getManifest() override;
 
-  sockaddr_storage getAddr() { return sconfig.ip_addr; }
+ private:
+  const sockaddr_in& getAddr() const { return sock_address_; }
 
  private:
   std::mutex install_mutex;
+
+  struct sockaddr_in sock_address_;
+  const EcuSerial serial_;
+  const HardwareIdentifier hw_id_;
+  const PublicKey pub_key_;
 };
 
 }  // namespace Uptane

--- a/src/libaktualizr/config/config.cc
+++ b/src/libaktualizr/config/config.cc
@@ -71,6 +71,7 @@ void UptaneConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt)
   CopyFromConfig(key_source, "key_source", pt);
   CopyFromConfig(key_type, "key_type", pt);
   CopyFromConfig(force_install_completion, "force_install_completion", pt);
+  CopyFromConfig(secondary_config_file, "secondary_config_file", pt);
   CopyFromConfig(secondary_configs_dir, "secondary_configs_dir", pt);
   // uptane.secondary_configs is populated by processing secondary_configs_dir
 }
@@ -82,6 +83,7 @@ void UptaneConfig::writeToStream(std::ostream& out_stream) const {
   writeOption(out_stream, key_source, "key_source");
   writeOption(out_stream, key_type, "key_type");
   writeOption(out_stream, force_install_completion, "force_install_completion");
+  writeOption(out_stream, secondary_config_file, "secondary_config_file");
   writeOption(out_stream, secondary_configs_dir, "secondary_configs_dir");
 }
 
@@ -242,6 +244,9 @@ void Config::updateFromCommandLine(const boost::program_options::variables_map& 
   }
   if (cmd.count("primary-ecu-hardware-id") != 0) {
     provision.primary_ecu_hardware_id = cmd["primary-ecu-hardware-id"].as<std::string>();
+  }
+  if (cmd.count("secondary-config-file") != 0) {
+    uptane.secondary_config_file = cmd["secondary_config_file"].as<boost::filesystem::path>();
   }
   if (cmd.count("secondary-configs-dir") != 0) {
     uptane.secondary_configs_dir = cmd["secondary-configs-dir"].as<boost::filesystem::path>();

--- a/src/libaktualizr/config/config.h
+++ b/src/libaktualizr/config/config.h
@@ -69,6 +69,7 @@ struct UptaneConfig {
   KeyType key_type{KeyType::kRSA2048};
   bool force_install_completion{false};
   boost::filesystem::path secondary_configs_dir;
+  boost::filesystem::path secondary_config_file;
   std::vector<Uptane::SecondaryConfig> secondary_configs{};
 
   void updateFromPropertyTree(const boost::property_tree::ptree& pt);

--- a/src/libaktualizr/uptane/secondaryconfig.h
+++ b/src/libaktualizr/uptane/secondaryconfig.h
@@ -37,16 +37,18 @@ class SecondaryConfig {
   std::string ecu_public_key;
   KeyType key_type{KeyType::kRSA2048};
 
+  // TODO: secondary config contains secondary specific params
+  // so introduction of any new type of secondary will require changes here/libaktualizr
+  // what we would like to avoid
   boost::filesystem::path full_client_dir;   // SecondaryType::kVirtual
   boost::filesystem::path firmware_path;     // SecondaryType::kVirtual
   boost::filesystem::path metadata_path;     // SecondaryType::kVirtual
   boost::filesystem::path target_name_path;  // SecondaryType::kVirtual
 
-  sockaddr_storage ip_addr{};  // SecondaryType::kIpUptane
-
   uint16_t can_id{0x0000};  // SecondaryType::kIsoTpUptane;
   std::string can_iface;    // SecondaryType::kIsoTpUptane;
 };
+
 }  // namespace Uptane
 
 #endif

--- a/src/libaktualizr/uptane/secondaryinterface.h
+++ b/src/libaktualizr/uptane/secondaryinterface.h
@@ -20,13 +20,20 @@ namespace Uptane {
 
 class SecondaryInterface {
  public:
+  // This ctor should be removed as the secondary configuration SecondaryConfig
+  // is the secondaries's specific, see SecondaryConfig declaration
   explicit SecondaryInterface(SecondaryConfig sconfig_in) : sconfig(std::move(sconfig_in)) {}
   virtual ~SecondaryInterface() = default;
+  // not clear what this method for, can be removed
   virtual void Initialize(){};  // optional step, called after device registration
+  // should be pure virtual, since the current implementation reads from the secondaries specific config
   virtual EcuSerial getSerial() { return Uptane::EcuSerial(sconfig.ecu_serial); }
+  // should be pure virtual, since the current implementation reads from the secondaries specific config
   virtual Uptane::HardwareIdentifier getHwId() { return Uptane::HardwareIdentifier(sconfig.ecu_hardware_id); }
   virtual PublicKey getPublicKey() = 0;
 
+  // getSerial(), getHwId() and getPublicKey() can be moved to seperate interface
+  // since their usage pattern differ from the following methods' one
   virtual Json::Value getManifest() = 0;
   virtual bool putMetadata(const RawMetaPack& meta_pack) = 0;
   virtual int32_t getRootVersion(bool director) = 0;
@@ -34,7 +41,11 @@ class SecondaryInterface {
 
   // FIXME: Instead of std::string we should use StorageTargetRHandle
   virtual bool sendFirmware(const std::shared_ptr<std::string>& data) = 0;
+  // Should be removes as it's secondary specific
   const SecondaryConfig sconfig;
+
+ protected:
+  SecondaryInterface() : sconfig{} {};
 };
 }  // namespace Uptane
 


### PR DESCRIPTION
1. Tiny IpUptaneSecondary refactoring 
 - to make it working with a fake package manager;
 - to get serial & hw-id from Secondary during initialization;

2. Pre-configure Secondary with IP addresses by using a json configuration file;
3. Initialize Aktualizr app with Secondaries.


Signed-off-by: Mike Sul <ext-mykhaylo.sul@here.com>