### PR TITLE
Fix/ota 2451/empty targets

### DIFF
--- a/src/libaktualizr/crypto/p11engine.h
+++ b/src/libaktualizr/crypto/p11engine.h
@@ -3,9 +3,9 @@
 
 #include <memory>
 
-#include <gtest/gtest.h>
 #include <openssl/engine.h>
 #include <openssl/err.h>
+#include "gtest/gtest_prod.h"
 
 #include "logging/logging.h"
 #include "p11_config.h"

--- a/src/libaktualizr/http/httpclient.cc
+++ b/src/libaktualizr/http/httpclient.cc
@@ -1,7 +1,8 @@
 #include "httpclient.h"
-#include "utilities/utils.h"
 
 #include <assert.h>
+#include <sstream>
+
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>

--- a/src/libaktualizr/http/httpclient.h
+++ b/src/libaktualizr/http/httpclient.h
@@ -2,10 +2,10 @@
 #define HTTPCLIENT_H_
 
 #include <future>
+#include <memory>
 
 #include <curl/curl.h>
-#include <gtest/gtest.h>
-#include <memory>
+#include "gtest/gtest_prod.h"
 #include "json/json.h"
 
 #include "httpinterface.h"

--- a/src/libaktualizr/package_manager/packagemanagerfake.cc
+++ b/src/libaktualizr/package_manager/packagemanagerfake.cc
@@ -24,6 +24,8 @@ Uptane::Target PackageManagerFake::getCurrent() const {
 }
 
 data::InstallationResult PackageManagerFake::install(const Uptane::Target &target) const {
+  (void)target;
+
   // fault injection: only enabled with FIU_ENABLE defined
   if (fiu_fail("fake_package_install") != 0) {
     std::string failure_cause = fault_injection_last_info();
@@ -35,17 +37,13 @@ data::InstallationResult PackageManagerFake::install(const Uptane::Target &targe
   }
 
   if (config.fake_need_reboot) {
-    storage_->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kPending);
-
     // set reboot flag to be notified later
     if (bootloader_ != nullptr) {
       bootloader_->rebootFlagSet();
     }
-
     return data::InstallationResult(data::ResultCode::Numeric::kNeedCompletion, "Application successful, need reboot");
   }
 
-  storage_->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kCurrent);
   return data::InstallationResult(data::ResultCode::Numeric::kOk, "Installing package was successful");
 }
 
@@ -84,6 +82,5 @@ data::InstallationResult PackageManagerFake::finalizeInstall(const Uptane::Targe
         data::InstallationResult(data::ResultCode::Numeric::kInternalError, "Pending and new target do not match");
   }
 
-  storage_->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kCurrent);
   return install_res;
 }

--- a/src/libaktualizr/package_manager/packagemanagerfake_test.cc
+++ b/src/libaktualizr/package_manager/packagemanagerfake_test.cc
@@ -29,6 +29,7 @@ TEST(PackageManagerFake, FinalizeAfterReboot) {
   Uptane::Target target("pkg", {Uptane::Hash(Uptane::Hash::Type::kSha256, "hash")}, 1, "");
   auto result = fakepm.install(target);
   EXPECT_EQ(result.result_code, data::ResultCode::Numeric::kNeedCompletion);
+  storage->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kPending);
 
   result = fakepm.finalizeInstall(target);
   EXPECT_EQ(result.result_code, data::ResultCode::Numeric::kOk);

--- a/src/libaktualizr/primary/CMakeLists.txt
+++ b/src/libaktualizr/primary/CMakeLists.txt
@@ -17,5 +17,7 @@ add_aktualizr_test(NAME aktualizr SOURCES aktualizr_test.cc PROJECT_WORKING_DIRE
 add_dependencies(t_aktualizr uptane_repo_full_no_correlation_id)
 
 add_aktualizr_test(NAME reportqueue SOURCES reportqueue_test.cc PROJECT_WORKING_DIRECTORY)
+add_aktualizr_test(NAME emptytargets SOURCES empty_targets_test.cc PROJECT_WORKING_DIRECTORY
+                   ARGS "$<TARGET_FILE:aktualizr-repo>")
 
 aktualizr_source_file_checks(${SOURCES} ${HEADERS} ${TEST_SOURCES})

--- a/src/libaktualizr/primary/aktualizr.h
+++ b/src/libaktualizr/primary/aktualizr.h
@@ -176,6 +176,7 @@ class Aktualizr {
   FRIEND_TEST(Aktualizr, UpdateCheckCompleteError);
   FRIEND_TEST(Aktualizr, PauseResumeQueue);
   FRIEND_TEST(Aktualizr, AddSecondary);
+  FRIEND_TEST(Aktualizr, EmptyTargets);
   FRIEND_TEST(Delegation, Basic);
   FRIEND_TEST(Delegation, RevokeAfterCheckUpdates);
   FRIEND_TEST(Delegation, RevokeAfterInstall);

--- a/src/libaktualizr/primary/aktualizr.h
+++ b/src/libaktualizr/primary/aktualizr.h
@@ -182,7 +182,7 @@ class Aktualizr {
   FRIEND_TEST(Delegation, RevokeAfterDownload);
   FRIEND_TEST(Delegation, IterateAll);
 
-  // This constructor is only being used in tests
+  // This constructor is only used for tests
   Aktualizr(Config& config, std::shared_ptr<INvStorage> storage_in, std::shared_ptr<HttpInterface> http_in);
   static void systemSetup();
 

--- a/src/libaktualizr/primary/aktualizr.h
+++ b/src/libaktualizr/primary/aktualizr.h
@@ -4,8 +4,8 @@
 #include <atomic>
 #include <memory>
 
-#include <gtest/gtest.h>
 #include <boost/signals2.hpp>
+#include "gtest/gtest_prod.h"
 
 #include "config/config.h"
 #include "primary/events.h"

--- a/src/libaktualizr/primary/empty_targets_test.cc
+++ b/src/libaktualizr/primary/empty_targets_test.cc
@@ -1,0 +1,115 @@
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include <boost/process.hpp>
+
+#include "httpfake.h"
+#include "primary/aktualizr.h"
+#include "test_utils.h"
+#include "uptane_test_common.h"
+
+boost::filesystem::path aktualizr_repo_path;
+
+class HttpRejectEmptyCorrId : public HttpFake {
+ public:
+  HttpRejectEmptyCorrId(const boost::filesystem::path &test_dir_in, const boost::filesystem::path &meta_dir_in)
+      : HttpFake(test_dir_in, "", meta_dir_in) {}
+
+  HttpResponse put(const std::string &url, const Json::Value &data) override {
+    last_manifest = data;
+    if (url.find("/manifest") != std::string::npos) {
+      if (data["signed"].isMember("installation_report") &&
+          data["signed"]["installation_report"]["report"]["correlation_id"].asString().empty()) {
+        EXPECT_FALSE(data["signed"]["installation_report"]["report"]["correlation_id"].asString().empty());
+        return HttpResponse(url, 400, CURLE_OK, "");
+      }
+    }
+    return HttpResponse(url, 200, CURLE_OK, "");
+  }
+};
+
+/*
+ * Verify that we can successfully install an update after receiving
+ * subsequent targets metadata that is empty.
+ */
+TEST(Aktualizr, EmptyTargets) {
+  TemporaryDirectory temp_dir;
+  TemporaryDirectory meta_dir;
+  auto http = std::make_shared<HttpRejectEmptyCorrId>(temp_dir.Path(), meta_dir.Path() / "repo");
+  Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
+  conf.pacman.fake_need_reboot = true;
+  conf.bootloader.reboot_sentinel_dir = temp_dir / "aktualizr-session";
+  logger_set_threshold(boost::log::trivial::trace);
+
+  Process akt_repo(aktualizr_repo_path.string());
+  akt_repo.run({"generate", "--path", meta_dir.PathString(), "--correlationid", "abc123"});
+  akt_repo.run({"image", "--path", meta_dir.PathString(), "--filename", "tests/test_data/firmware.txt", "--targetname",
+                "firmware.txt"});
+  akt_repo.run({"addtarget", "--path", meta_dir.PathString(), "--targetname", "firmware.txt", "--hwid", "primary_hw",
+                "--serial", "CA:FE:A6:D2:84:9D"});
+  akt_repo.run({"signtargets", "--path", meta_dir.PathString(), "--correlationid", "abc123"});
+  // Work around inconsistent directory naming.
+  Utils::copyDir(meta_dir.Path() / "repo/image", meta_dir.Path() / "repo/repo");
+
+  auto storage = INvStorage::newStorage(conf.storage);
+  {
+    Aktualizr aktualizr(conf, storage, http);
+    aktualizr.Initialize();
+
+    result::UpdateCheck update_result = aktualizr.CheckUpdates().get();
+    EXPECT_EQ(update_result.status, result::UpdateStatus::kUpdatesAvailable);
+
+    result::Download download_result = aktualizr.Download(update_result.updates).get();
+    EXPECT_EQ(download_result.status, result::DownloadStatus::kSuccess);
+
+    akt_repo.run({"emptytargets", "--path", meta_dir.PathString()});
+    akt_repo.run({"signtargets", "--path", meta_dir.PathString(), "--correlationid", "abc123"});
+
+    result::UpdateCheck update_result2 = aktualizr.CheckUpdates().get();
+    EXPECT_EQ(update_result2.status, result::UpdateStatus::kUpdatesAvailable);
+
+    result::Install install_result = aktualizr.Install(update_result2.updates).get();
+    EXPECT_EQ(install_result.ecu_reports.size(), 1);
+    EXPECT_EQ(install_result.ecu_reports[0].install_res.result_code.num_code,
+              data::ResultCode::Numeric::kNeedCompletion);
+
+    aktualizr.uptane_client_->package_manager_->completeInstall();
+  }
+  {
+    Aktualizr aktualizr(conf, storage, http);
+    aktualizr.Initialize();
+
+    const Json::Value manifest = http->last_manifest["signed"];
+    const Json::Value manifest_versions = manifest["ecu_version_manifests"];
+
+    EXPECT_EQ(manifest["installation_report"]["report"]["items"].size(), 1);
+    EXPECT_EQ(manifest["installation_report"]["report"]["items"][0]["ecu"].asString(), "CA:FE:A6:D2:84:9D");
+    EXPECT_TRUE(manifest["installation_report"]["report"]["items"][0]["result"]["success"].asBool());
+
+    EXPECT_EQ(manifest_versions["CA:FE:A6:D2:84:9D"]["signed"]["installed_image"]["filepath"].asString(),
+              "firmware.txt");
+    EXPECT_EQ(manifest_versions["CA:FE:A6:D2:84:9D"]["signed"]["installed_image"]["fileinfo"]["length"].asUInt(), 17);
+
+    result::UpdateCheck update_result3 = aktualizr.CheckUpdates().get();
+    EXPECT_EQ(update_result3.status, result::UpdateStatus::kNoUpdatesAvailable);
+  }
+}
+
+#ifndef __NO_MAIN__
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  if (argc != 2) {
+    std::cerr << "Error: " << argv[0] << " requires the path to the aktualizr-repo utility\n";
+    return EXIT_FAILURE;
+  }
+  aktualizr_repo_path = argv[1];
+
+  logger_init();
+  logger_set_threshold(boost::log::trivial::trace);
+
+  return RUN_ALL_TESTS();
+}
+#endif
+
+// vim: set tabstop=2 shiftwidth=2 expandtab:

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -168,7 +168,7 @@ void SotaUptaneClient::finalizeAfterReboot() {
       LOG_ERROR << "Expected reboot after update on primary but no update found";
     }
   } else {
-    LOG_ERROR << "Invalid UPTANE metadata in storage.";
+    LOG_ERROR << "Invalid Uptane metadata in storage.";
   }
 
   bootloader->rebootFlagClear();
@@ -712,6 +712,7 @@ result::UpdateCheck SotaUptaneClient::fetchMeta() {
 
   if (hasPendingUpdates()) {
     // no need in update checking if there are some pending updates
+    LOG_DEBUG << "An update is pending. Skipping check for update until installation is complete";
     return result::UpdateCheck({}, 0, result::UpdateStatus::kError, Json::nullValue,
                                "There are pending updates, no new updates are checked");
   }
@@ -738,9 +739,9 @@ result::UpdateCheck SotaUptaneClient::checkUpdates() {
   std::vector<Uptane::Target> updates;
   unsigned int ecus_count = 0;
   if (!uptaneOfflineIteration(&updates, &ecus_count)) {
-    LOG_ERROR << "Invalid UPTANE metadata in storage.";
+    LOG_ERROR << "Invalid Uptane metadata in storage.";
     result = result::UpdateCheck({}, 0, result::UpdateStatus::kError, Json::nullValue,
-                                 "Invalid UPTANE metadata in storage.");
+                                 "Invalid Uptane metadata in storage.");
   } else {
     std::string director_targets;
     storage->loadNonRoot(&director_targets, Uptane::RepositoryType::Director(), Uptane::Role::Targets());

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -316,7 +316,7 @@ void SotaUptaneClient::initialize() {
 bool SotaUptaneClient::updateMeta() {
   // Uptane step 1 (build the vehicle version manifest):
   if (!putManifestSimple()) {
-    return false;
+    LOG_ERROR << "Error sending manifest!";
   }
   return uptaneIteration();
 }

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -72,6 +72,7 @@ class SotaUptaneClient {
   FRIEND_TEST(Aktualizr, FinalizationFailure);
   FRIEND_TEST(Aktualizr, InstallationFailure);
   FRIEND_TEST(Aktualizr, AutoRebootAfterUpdate);
+  FRIEND_TEST(Aktualizr, EmptyTargets);
   FRIEND_TEST(Uptane, AssembleManifestGood);
   FRIEND_TEST(Uptane, AssembleManifestBad);
   FRIEND_TEST(Uptane, InstallFake);

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -7,8 +7,8 @@
 #include <utility>
 #include <vector>
 
-#include <gtest/gtest.h>
 #include <boost/signals2.hpp>
+#include "gtest/gtest_prod.h"
 #include "json/json.h"
 
 #include "bootloader/bootloader.h"

--- a/src/libaktualizr/uptane/CMakeLists.txt
+++ b/src/libaktualizr/uptane/CMakeLists.txt
@@ -73,4 +73,7 @@ add_aktualizr_test(NAME uptane_serial SOURCES uptane_serial_test.cc ARGS ${PROJE
 
 add_aktualizr_test(NAME uptane_init SOURCES uptane_init_test.cc PROJECT_WORKING_DIRECTORY)
 
+add_aktualizr_test(NAME director SOURCES director_test.cc PROJECT_WORKING_DIRECTORY
+                   ARGS "$<TARGET_FILE:aktualizr-repo>")
+
 aktualizr_source_file_checks(${SOURCES} ${HEADERS} isotpsecondary.cc isotpsecondary.h ${TEST_SOURCES})

--- a/src/libaktualizr/uptane/director_test.cc
+++ b/src/libaktualizr/uptane/director_test.cc
@@ -1,0 +1,66 @@
+#include <gtest/gtest.h>
+
+#include "directorrepository.h"
+#include "test_utils.h"
+#include "utilities/utils.h"
+
+boost::filesystem::path aktualizr_repo_path;
+
+namespace Uptane {
+
+/*
+ * Verify that we correctly persist non-empty targets metadata after receiving
+ * subsequent targets metadata that is empty.
+ */
+TEST(Director, EmptyTargets) {
+  TemporaryDirectory meta_dir;
+
+  Process akt_repo(aktualizr_repo_path.string());
+  akt_repo.run({"generate", "--path", meta_dir.PathString()});
+
+  DirectorRepository director;
+  EXPECT_TRUE(director.initRoot(Utils::readFile(meta_dir.Path() / "repo/director/root.json")));
+
+  EXPECT_TRUE(director.verifyTargets(Utils::readFile(meta_dir.Path() / "repo/director/targets.json")));
+  EXPECT_TRUE(director.targets.targets.empty());
+  EXPECT_TRUE(director.latest_targets.targets.empty());
+
+  akt_repo.run({"image", "--path", meta_dir.PathString(), "--filename", "tests/test_data/firmware.txt", "--targetname",
+                "firmware.txt"});
+  akt_repo.run({"addtarget", "--path", meta_dir.PathString(), "--targetname", "firmware.txt", "--hwid", "primary_hw",
+                "--serial", "CA:FE:A6:D2:84:9D"});
+  akt_repo.run({"signtargets", "--path", meta_dir.PathString()});
+
+  EXPECT_TRUE(director.verifyTargets(Utils::readFile(meta_dir.Path() / "repo/director/targets.json")));
+  EXPECT_EQ(director.targets.targets.size(), 1);
+  EXPECT_EQ(director.targets.targets[0].filename(), "firmware.txt");
+  EXPECT_EQ(director.targets.targets.size(), director.latest_targets.targets.size());
+
+  akt_repo.run({"emptytargets", "--path", meta_dir.PathString()});
+  akt_repo.run({"signtargets", "--path", meta_dir.PathString(), "--correlationid", "abc123"});
+
+  EXPECT_TRUE(director.verifyTargets(Utils::readFile(meta_dir.Path() / "repo/director/targets.json")));
+  EXPECT_EQ(director.targets.targets.size(), 1);
+  EXPECT_EQ(director.targets.targets[0].filename(), "firmware.txt");
+  EXPECT_TRUE(director.latest_targets.targets.empty());
+}
+
+}  // namespace Uptane
+
+#ifndef __NO_MAIN__
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  if (argc != 2) {
+    std::cerr << "Error: " << argv[0] << " requires the path to the aktualizr-repo utility\n";
+    return EXIT_FAILURE;
+  }
+  aktualizr_repo_path = argv[1];
+
+  logger_init();
+  logger_set_threshold(boost::log::trivial::trace);
+
+  return RUN_ALL_TESTS();
+}
+#endif
+
+// vim: set tabstop=2 shiftwidth=2 expandtab:

--- a/src/libaktualizr/uptane/directorrepository.h
+++ b/src/libaktualizr/uptane/directorrepository.h
@@ -17,14 +17,21 @@ class DirectorRepository : public RepositoryCommon {
   bool verifyTargets(const std::string& targets_raw);
   const std::vector<Target>& getTargets() const { return targets.targets; }
   const std::string& getCorrelationId() const { return targets.correlation_id(); }
-  bool targetsExpired() const { return targets.isExpired(TimeStamp::Now()); }
+  bool targetsExpired() const { return latest_targets.isExpired(TimeStamp::Now()); }
+  // Don't store the new targets if they are empty and we've previously received
+  // a non-empty list.
+  bool usePreviousTargets() const { return !targets.targets.empty() && latest_targets.targets.empty(); }
   bool checkMetaOffline(INvStorage& storage);
 
   Exception getLastException() const { return last_exception; }
   bool updateMeta(INvStorage& storage, Fetcher& fetcher);
 
  private:
-  Uptane::Targets targets;
+  // Since the Director can send us an empty targets list to mean "no new
+  // updates", we have to persist the previous targets list. Use the latest for
+  // checking expiration but the most recent non-empty list for everything else.
+  Uptane::Targets targets;         // Only empty if we've never received non-empty targets.
+  Uptane::Targets latest_targets;  // Can be an empty list.
   Exception last_exception{"", ""};
 };
 

--- a/src/libaktualizr/uptane/directorrepository.h
+++ b/src/libaktualizr/uptane/directorrepository.h
@@ -1,6 +1,8 @@
 #ifndef DIRECTOR_REPOSITORY_H_
 #define DIRECTOR_REPOSITORY_H_
 
+#include "gtest/gtest_prod.h"
+
 #include "fetcher.h"
 #include "uptanerepository.h"
 
@@ -27,6 +29,7 @@ class DirectorRepository : public RepositoryCommon {
   bool updateMeta(INvStorage& storage, Fetcher& fetcher);
 
  private:
+  FRIEND_TEST(Director, EmptyTargets);
   // Since the Director can send us an empty targets list to mean "no new
   // updates", we have to persist the previous targets list. Use the latest for
   // checking expiration but the most recent non-empty list for everything else.

--- a/src/libaktualizr/uptane/uptane_delegation_test.cc
+++ b/src/libaktualizr/uptane/uptane_delegation_test.cc
@@ -38,7 +38,10 @@ void delegation_nested(const boost::filesystem::path& delegation_path, bool revo
 class HttpFakeDelegation : public HttpFake {
  public:
   HttpFakeDelegation(const boost::filesystem::path& test_dir_in)
-      : HttpFake(test_dir_in, "", test_dir_in / "delegation_test") {}
+      : HttpFake(test_dir_in, "", test_dir_in / "delegation_test/repo") {
+    // Work around inconsistent directory naming.
+    Utils::copyDir(test_dir_in / "delegation_test/repo/image", test_dir_in / "delegation_test/repo/repo");
+  }
 
   HttpResponse handle_event(const std::string& url, const Json::Value& data) override {
     (void)url;

--- a/src/sota_tools/ostree_object.h
+++ b/src/sota_tools/ostree_object.h
@@ -6,9 +6,9 @@
 #include <sstream>
 
 #include <curl/curl.h>
-#include <gtest/gtest.h>
 #include <boost/filesystem.hpp>
 #include <boost/intrusive_ptr.hpp>
+#include "gtest/gtest_prod.h"
 
 #include "garage_common.h"
 #include "treehub_server.h"


### PR DESCRIPTION
Two main fixes:
1. Check for updates even if sending the manifest fails.
2. Persist the last non-empty targets metadata received from the Director to make sure we always know what the last thing we were expected to install was.

There are tests for both in addition to some other much smaller things found while working on this.