### PR TITLE
OTA-2536: Get a pub key along with hw_id and serial

### DIFF
--- a/src/aktualizr_secondary/socket_server.cc
+++ b/src/aktualizr_secondary/socket_server.cc
@@ -64,16 +64,12 @@ void SocketServer::HandleOneConnection(int socket) {
       case AKIpUptaneMes_PR_getInfoReq: {
         Uptane::EcuSerial serial = impl_->getSerial();
         Uptane::HardwareIdentifier hw_id = impl_->getHwId();
+        PublicKey pk = impl_->getPublicKey();
         resp->present(AKIpUptaneMes_PR_getInfoResp);
         auto r = resp->getInfoResp();
         SetString(&r->ecuSerial, serial.ToString());
         SetString(&r->hwId, hw_id.ToString());
-      } break;
-      case AKIpUptaneMes_PR_publicKeyReq: {
-        PublicKey pk = impl_->getPublicKey();
-        resp->present(AKIpUptaneMes_PR_publicKeyResp);
-        auto r = resp->publicKeyResp();
-        r->type = static_cast<AKIpUptaneKeyType_t>(pk.Type());
+        r->keyType = static_cast<AKIpUptaneKeyType_t>(pk.Type());
         SetString(&r->key, pk.Value());
       } break;
       case AKIpUptaneMes_PR_manifestReq: {

--- a/src/libaktualizr-posix/asn1/asn1_message.h
+++ b/src/libaktualizr-posix/asn1/asn1_message.h
@@ -68,18 +68,16 @@ class Asn1Message {
     return Asn1Sub<MessageType>(this, &msg_.choice.FieldName); /* NOLINT(cppcoreguidelines-pro-type-union-access) */ \
   }
 
-  ASN1_MESSAGE_DEFINE_ACCESSOR(AKGetInfoReqMes_t, getInfoReq);
-  ASN1_MESSAGE_DEFINE_ACCESSOR(AKGetInfoRespMes_t, getInfoResp);
   ASN1_MESSAGE_DEFINE_ACCESSOR(AKDiscoveryReqMes_t, discoveryReq);
   ASN1_MESSAGE_DEFINE_ACCESSOR(AKDiscoveryRespMes_t, discoveryResp);
-  ASN1_MESSAGE_DEFINE_ACCESSOR(AKPublicKeyReqMes_t, publicKeyReq);
-  ASN1_MESSAGE_DEFINE_ACCESSOR(AKPublicKeyRespMes_t, publicKeyResp);
   ASN1_MESSAGE_DEFINE_ACCESSOR(AKManifestReqMes_t, manifestReq);
   ASN1_MESSAGE_DEFINE_ACCESSOR(AKManifestRespMes_t, manifestResp);
   ASN1_MESSAGE_DEFINE_ACCESSOR(AKPutMetaReqMes_t, putMetaReq);
   ASN1_MESSAGE_DEFINE_ACCESSOR(AKPutMetaRespMes_t, putMetaResp);
   ASN1_MESSAGE_DEFINE_ACCESSOR(AKSendFirmwareReqMes_t, sendFirmwareReq);
   ASN1_MESSAGE_DEFINE_ACCESSOR(AKSendFirmwareRespMes_t, sendFirmwareResp);
+  ASN1_MESSAGE_DEFINE_ACCESSOR(AKGetInfoReqMes_t, getInfoReq);
+  ASN1_MESSAGE_DEFINE_ACCESSOR(AKGetInfoRespMes_t, getInfoResp);
 
   /**
    * The underlying message structure. This is public to simplify calls to

--- a/src/libaktualizr-posix/asn1/asn1_test.cc
+++ b/src/libaktualizr-posix/asn1/asn1_test.cc
@@ -246,7 +246,7 @@ TEST(asn1_common, Asn1MessageSimple) {
 }
 
 TEST(asn1_common, parse) {
-  std::string data = Utils::fromBase64("rAowCAQGaGVsbG8K");
+  std::string data = Utils::fromBase64("pgkwBwQFaGVsbG8=");
   // BER decode
   asn_codec_ctx_t context;
   memset(&context, 0, sizeof(context));

--- a/src/libaktualizr-posix/asn1/messages/ipuptane_message.asn1
+++ b/src/libaktualizr-posix/asn1/messages/ipuptane_message.asn1
@@ -38,6 +38,8 @@ IpUptane DEFINITIONS ::= BEGIN
 	AKGetInfoRespMes ::= SEQUENCE {
 		ecuSerial UTF8String,
 		hwId UTF8String,
+		keyType AKIpUptaneKeyType,
+		key OCTET STRING,
 		...
 	}
 
@@ -50,16 +52,6 @@ IpUptane DEFINITIONS ::= BEGIN
 		ecuSerial UTF8String,
 		hwId UTF8String,
 		port INTEGER(0..65535),
-		...
-	}
-
-	AKPublicKeyReqMes ::= SEQUENCE {
-		...
-	}
-
-	AKPublicKeyRespMes ::= SEQUENCE {
-		type AKIpUptaneKeyType,
-		key OCTET STRING,
 		...
 	}
 
@@ -103,16 +95,14 @@ IpUptane DEFINITIONS ::= BEGIN
 	AKIpUptaneMes ::= CHOICE {
 		discoveryReq [0] AKDiscoveryReqMes,
 		discoveryResp [1] AKDiscoveryRespMes,
-		publicKeyReq [2] AKPublicKeyReqMes,
-		publicKeyResp [3] AKPublicKeyRespMes,
-		manifestReq [4] AKManifestReqMes,
-		manifestResp [5] AKManifestRespMes,
-		putMetaReq [6] AKPutMetaReqMes,
-		putMetaResp [7] AKPutMetaRespMes,
-		sendFirmwareReq [12] AKSendFirmwareReqMes,
-		sendFirmwareResp [13] AKSendFirmwareRespMes,
-		getInfoReq [14] AKGetInfoReqMes,
-		getInfoResp [15] AKGetInfoRespMes,
+		manifestReq [2] AKManifestReqMes,
+		manifestResp [3] AKManifestRespMes,
+		putMetaReq [4] AKPutMetaReqMes,
+		putMetaResp [5] AKPutMetaRespMes,
+		sendFirmwareReq [6] AKSendFirmwareReqMes,
+		sendFirmwareResp [7] AKSendFirmwareRespMes,
+		getInfoReq [8] AKGetInfoReqMes,
+		getInfoResp [9] AKGetInfoRespMes,
 		...
 	}
 


### PR DESCRIPTION
Tiny improvement to avoid two RPC calls during a secondary client initialization, i.e. get serial, hw-id and pub-key within a single RPC call.

Signed-off-by: Mike Sul <ext-mykhaylo.sul@here.com>