### PR TITLE
Fix issue with never-ending install retries

### DIFF
--- a/src/libaktualizr/primary/aktualizr.h
+++ b/src/libaktualizr/primary/aktualizr.h
@@ -177,6 +177,7 @@ class Aktualizr {
   FRIEND_TEST(Aktualizr, PauseResumeQueue);
   FRIEND_TEST(Aktualizr, AddSecondary);
   FRIEND_TEST(Aktualizr, EmptyTargets);
+  FRIEND_TEST(Aktualizr, EmptyTargetsAfterInstall);
   FRIEND_TEST(Delegation, Basic);
   FRIEND_TEST(Delegation, RevokeAfterCheckUpdates);
   FRIEND_TEST(Delegation, RevokeAfterInstall);

--- a/src/libaktualizr/primary/empty_targets_test.cc
+++ b/src/libaktualizr/primary/empty_targets_test.cc
@@ -9,6 +9,8 @@
 #include "test_utils.h"
 #include "uptane_test_common.h"
 
+#include "utilities/fault_injection.h"
+
 boost::filesystem::path aktualizr_repo_path;
 
 class HttpRejectEmptyCorrId : public HttpFake {
@@ -95,6 +97,65 @@ TEST(Aktualizr, EmptyTargets) {
     EXPECT_EQ(update_result3.status, result::UpdateStatus::kNoUpdatesAvailable);
   }
 }
+
+#ifdef FIU_ENABLE
+
+/* Check that Aktualizr switches back to empty targets after completing an
+ * installation attempt (OTA-2587) */
+TEST(Aktualizr, EmptyTargetsAfterInstall) {
+  TemporaryDirectory temp_dir;
+  TemporaryDirectory meta_dir;
+  auto http = std::make_shared<HttpRejectEmptyCorrId>(temp_dir.Path(), meta_dir.Path() / "repo");
+  Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
+  logger_set_threshold(boost::log::trivial::trace);
+
+  Process akt_repo(aktualizr_repo_path.string());
+  akt_repo.run({"generate", "--path", meta_dir.PathString(), "--correlationid", "abc123"});
+  akt_repo.run({"image", "--path", meta_dir.PathString(), "--filename", "tests/test_data/firmware.txt", "--targetname",
+                "firmware.txt"});
+  akt_repo.run({"addtarget", "--path", meta_dir.PathString(), "--targetname", "firmware.txt", "--hwid", "primary_hw",
+                "--serial", "CA:FE:A6:D2:84:9D"});
+  akt_repo.run({"signtargets", "--path", meta_dir.PathString(), "--correlationid", "abc123"});
+  // Work around inconsistent directory naming.
+  Utils::copyDir(meta_dir.Path() / "repo/image", meta_dir.Path() / "repo/repo");
+
+  // failing install
+  auto storage = INvStorage::newStorage(conf.storage);
+  {
+    Aktualizr aktualizr(conf, storage, http);
+    aktualizr.Initialize();
+
+    result::UpdateCheck update_result = aktualizr.CheckUpdates().get();
+    EXPECT_EQ(update_result.status, result::UpdateStatus::kUpdatesAvailable);
+
+    result::Download download_result = aktualizr.Download(update_result.updates).get();
+    EXPECT_EQ(download_result.status, result::DownloadStatus::kSuccess);
+
+    update_result = aktualizr.CheckUpdates().get();
+    fiu_init(0);
+    fault_injection_enable("fake_package_install", 1, "", 0);
+    result::Install install_result = aktualizr.Install(update_result.updates).get();
+    EXPECT_EQ(install_result.ecu_reports.size(), 1);
+    EXPECT_EQ(install_result.ecu_reports[0].install_res.result_code.num_code,
+              data::ResultCode::Numeric::kInstallFailed);
+    fault_injection_disable("fake_package_install");
+  }
+
+  // Backend reacts to failure: no need to install the target anymore
+  akt_repo.run({"emptytargets", "--path", meta_dir.PathString()});
+  akt_repo.run({"signtargets", "--path", meta_dir.PathString(), "--correlationid", "abc123"});
+
+  // check that no update is available
+  {
+    Aktualizr aktualizr(conf, storage, http);
+    aktualizr.Initialize();
+
+    result::UpdateCheck update_result = aktualizr.CheckUpdates().get();
+    EXPECT_EQ(update_result.status, result::UpdateStatus::kNoUpdatesAvailable);
+  }
+}
+
+#endif
 
 #ifndef __NO_MAIN__
 int main(int argc, char **argv) {

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -163,6 +163,7 @@ void SotaUptaneClient::finalizeAfterReboot() {
 
       computeDeviceInstallationResult(nullptr, correlation_id);
       putManifestSimple();
+      director_repo.dropTargets(*storage);  // fix for OTA-2587, listen to backend again after end of install
     } else {
       // nothing found on primary
       LOG_ERROR << "Expected reboot after update on primary but no update found";
@@ -827,6 +828,10 @@ result::Install SotaUptaneClient::uptaneInstall(const std::vector<Uptane::Target
   result.ecu_reports.insert(result.ecu_reports.end(), sec_reports.begin(), sec_reports.end());
   computeDeviceInstallationResult(&result.dev_report, correlation_id);
   sendEvent<event::AllInstallsComplete>(result);
+
+  if (result.dev_report.result_code != data::ResultCode::Numeric::kNeedCompletion) {
+    director_repo.dropTargets(*storage);  // fix for OTA-2587, listen to backend again after end of install
+  }
 
   return result;
 }

--- a/src/libaktualizr/uptane/directorrepository.cc
+++ b/src/libaktualizr/uptane/directorrepository.cc
@@ -7,6 +7,14 @@ void DirectorRepository::resetMeta() {
   targets = Targets();
 }
 
+bool DirectorRepository::targetsExpired() const { return latest_targets.isExpired(TimeStamp::Now()); }
+
+bool DirectorRepository::usePreviousTargets() const {
+  // Don't store the new targets if they are empty and we've previously received
+  // a non-empty list.
+  return !targets.targets.empty() && latest_targets.targets.empty();
+}
+
 bool DirectorRepository::verifyTargets(const std::string& targets_raw) {
   try {
     // Verify the signature:

--- a/src/libaktualizr/uptane/directorrepository.cc
+++ b/src/libaktualizr/uptane/directorrepository.cc
@@ -5,6 +5,7 @@ namespace Uptane {
 void DirectorRepository::resetMeta() {
   resetRoot();
   targets = Targets();
+  latest_targets = Targets();
 }
 
 bool DirectorRepository::targetsExpired() const { return latest_targets.isExpired(TimeStamp::Now()); }
@@ -156,6 +157,11 @@ bool DirectorRepository::updateMeta(INvStorage& storage, Fetcher& fetcher) {
   }
 
   return true;
+}
+
+void DirectorRepository::dropTargets(INvStorage& storage) {
+  storage.clearNonRootMeta(RepositoryType::Director());
+  resetMeta();
 }
 
 }  // namespace Uptane

--- a/src/libaktualizr/uptane/directorrepository.h
+++ b/src/libaktualizr/uptane/directorrepository.h
@@ -19,10 +19,8 @@ class DirectorRepository : public RepositoryCommon {
   bool verifyTargets(const std::string& targets_raw);
   const std::vector<Target>& getTargets() const { return targets.targets; }
   const std::string& getCorrelationId() const { return targets.correlation_id(); }
-  bool targetsExpired() const { return latest_targets.isExpired(TimeStamp::Now()); }
-  // Don't store the new targets if they are empty and we've previously received
-  // a non-empty list.
-  bool usePreviousTargets() const { return !targets.targets.empty() && latest_targets.targets.empty(); }
+  bool targetsExpired() const;
+  bool usePreviousTargets() const;
   bool checkMetaOffline(INvStorage& storage);
 
   Exception getLastException() const { return last_exception; }

--- a/src/libaktualizr/uptane/directorrepository.h
+++ b/src/libaktualizr/uptane/directorrepository.h
@@ -22,6 +22,7 @@ class DirectorRepository : public RepositoryCommon {
   bool targetsExpired() const;
   bool usePreviousTargets() const;
   bool checkMetaOffline(INvStorage& storage);
+  void dropTargets(INvStorage& storage);
 
   Exception getLastException() const { return last_exception; }
   bool updateMeta(INvStorage& storage, Fetcher& fetcher);

--- a/src/libaktualizr/uptane/tuf.h
+++ b/src/libaktualizr/uptane/tuf.h
@@ -432,6 +432,12 @@ class Targets : public MetaWithKeys {
     return version_ == rhs.version() && expiry_ == rhs.expiry() && targets == rhs.targets;
   }
   const std::string &correlation_id() const { return correlation_id_; }
+  void clear() {
+    targets.clear();
+    delegated_role_names_.clear();
+    paths_for_role_.clear();
+    terminating_role_.clear();
+  }
 
   std::vector<Uptane::Target> targets;
   std::vector<std::string> delegated_role_names_;


### PR DESCRIPTION
As backend sends empty director targets in some unexpected situations,
we've implemented a client-side mitigation in
02deeb5cc45e2a1fac4f6e3eb515a396cd14c1c3.

One unwanted side-effect is that after a failed installation, we'll keep
taking into account the targets containing the new version, hence
retrying installations in a loop until the backend asks to install
something new.

Second fix is to drop director targets after installation end, until
we've come to an agreement on a proper solution on both sides.

Note: would probably need an accompanying unit test, on the way :)