### PR TITLE
Move Travis build env to Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,15 @@ branches:
     - master
     - /^\d\d\d\d\.\d+$/
 env:
-- DOCKERFILE=docker/Dockerfile.ubuntu.bionic SCRIPT=scripts/test.sh
-  DARGS="-eTEST_CMAKE_BUILD_TYPE=Valgrind -eTEST_WITH_COVERAGE=1 -eTEST_WITH_P11=1 -eTEST_WITH_FAULT_INJECTION=1 -eTEST_TESTSUITE_EXCLUDE=credentials -eTEST_SOTA_PACKED_CREDENTIALS=dummy-credentials"
-- DOCKERFILE=docker/Dockerfile.debian.testing SCRIPT=scripts/test.sh
-  DARGS="-eTEST_CC=clang -eTEST_WITH_LOAD_TESTS=1 -eTEST_WITH_TESTSUITE=0 -eTEST_WITH_STATICTESTS=1"
-- DEPLOY_PKGS=1 RELEASE_NAME=ubuntu_18.04 DOCKERFILE=docker/Dockerfile.ubuntu.bionic INSTALL_DOCKERFILE=docker/Dockerfile-test-install.ubuntu.bionic SCRIPT=scripts/build_ubuntu.sh DARGS="-eTEST_INSTALL_RELEASE_NAME=-ubuntu_18.04"
-- DEPLOY_PKGS=1 RELEASE_NAME=ubuntu_16.04 DOCKERFILE=docker/Dockerfile.ubuntu.xenial INSTALL_DOCKERFILE=docker/Dockerfile-test-install.ubuntu.xenial SCRIPT=scripts/build_ubuntu.sh DARGS="-eTEST_INSTALL_RELEASE_NAME=-ubuntu_16.04"
+  global:
+    - APIKEY_SECURE="K1Qb6xwVTuCns2xyvfc5l7RDlEniIT2+xvViEpu2gG+pDuVqx+yX7F0qL59RMLxcoP1F4g+11OYrZXrcMys39QhOC0guNZlZo4UJx15KeHbWGM7gNkbGjifPuCSECGS9poUthMLyv86Q2u29wlpj6GffemKxPA3hmj4fR8Ph0vEfD//HL8ANZs+867w8W2Gco5E9FnWO6BINuife6QkapMJ9wL7GhenK4Ykkf1Kgxklu2hey8PXVXf7Oj/wISGMgndZULdRvnzgkEFpSlBZENG3yTuL1++acsoYWhLOIzwqob3Fgc+EeWiIFQbf9C4LMMN43nYG4w8lx/X6mXvJ1oUdHmEMeYv7ewDoRmbtR22I++KgDd96C60Od1JNEDW8uA6x6wmagGKP1PwYMetgaSsCgvIWVfMVxNN0o78YjNrtob2Hrb93ZK+5/f0v0W4zhtk7bOfCbxe/uSpkW37uu1Mp5PG9cGi1bFluuGc2F/zsqNk30R6QbPSNxo4p13CfzKLNaOXQn2BIbMCV3gpkZiz3/9mW0l5KAXYbCWag1yEZ/ZSoCE22aap2i00+5sYBg1QrxKBN8Z7RhepsXU4Wfl4tNhUJeSXC/Y7kb6TwTkaKlqhMRdaMeU9sDxBvTSnhWpNI21X9B9dFgPAQnOmqFEoxtno4dqHF3Ii2jeKYSFLY="
+  matrix:
+    - DOCKERFILE=docker/Dockerfile.ubuntu.bionic SCRIPT=scripts/test.sh
+      DARGS="-eTEST_CMAKE_BUILD_TYPE=Valgrind -eTEST_WITH_COVERAGE=1 -eTEST_WITH_P11=1 -eTEST_WITH_FAULT_INJECTION=1 -eTEST_TESTSUITE_EXCLUDE=credentials -eTEST_SOTA_PACKED_CREDENTIALS=dummy-credentials"
+    - DOCKERFILE=docker/Dockerfile.debian.testing SCRIPT=scripts/test.sh
+      DARGS="-eTEST_CC=clang -eTEST_WITH_LOAD_TESTS=1 -eTEST_WITH_TESTSUITE=0 -eTEST_WITH_STATICTESTS=1"
+    - DEPLOY_PKGS=1 RELEASE_NAME=ubuntu_18.04 DOCKERFILE=docker/Dockerfile.ubuntu.bionic INSTALL_DOCKERFILE=docker/Dockerfile-test-install.ubuntu.bionic SCRIPT=scripts/build_ubuntu.sh DARGS="-eTEST_INSTALL_RELEASE_NAME=-ubuntu_18.04"
+    - DEPLOY_PKGS=1 RELEASE_NAME=ubuntu_16.04 DOCKERFILE=docker/Dockerfile.ubuntu.xenial INSTALL_DOCKERFILE=docker/Dockerfile-test-install.ubuntu.xenial SCRIPT=scripts/build_ubuntu.sh DARGS="-eTEST_INSTALL_RELEASE_NAME=-ubuntu_16.04"
 services:
 - docker
 script:
@@ -32,8 +35,7 @@ deploy:
                   condition: $RELEASE_NAME = "ubuntu_18.04"
 
           api_key:
-                  secure: "Z9IEs+GbPW+pxxfYofmeT4Jwjz4OpXJ6WZbv8nyN0MOZV146QExKhZA64mJ7nuXRepS7M5wFgVd0QVlmE7lLa8oNVTKujn+DmQ6701HeP9bITwv6wcDyhNOULLRBwRD2YN5lR29vHGWsjMUm8R13Wtgr/XyOG4L8fcg021B0BMtvepO9HJD4kHSNqB8pJXWVSMd5+d77BRz8Yr72oP98iBMAm94XNd5Gd2RB77YBRKlR7XEV2DxW346C9xI48crMRAKAyp/35vTCTMT04In4FpSexSue0q5dGqfQZf2I5fpGtSbwwJIb3ct/T0CUcW8mDQL01LtG3Hm2qNXKn8aCse6MrVoktUWBTA+tn7DMGq6zY4XXkyC7OisBYg9eel8HacSPrCXDB9C80aJht9a7AZIHehLC4yUomhYmnQDotvHoc3JrJXMSq4HE31WwIBn0xmOpr4ts0nnAprl3bRCQcv10J4MU4zK+BEYET+sLs1stqeION/AYTr0OxWVfbUhRdVepAjDh/mNLYO7raDb/PTZb4upunjS5a1RK+U+aW8ct85RPamZ+8+ZTo8Ofj5VGQiVJmmmrlVkDyBzXwJL3WonnZwuU6QDaaYCFUuzyVqmEuYZNc3i6jNUs0Yptw2YjKww6ayV5msyGaA0QZ3vdGWRk9K7JQQhE7CII2N4yzvI="
-
+            secure: $APIKEY_SECURE
         - provider: releases
           file: /persistent/aktualizr-ubuntu_18.04.deb
           skip-cleanup: true
@@ -43,7 +45,7 @@ deploy:
                   repo: advancedtelematic/aktualizr
                   condition: $RELEASE_NAME = "ubuntu_18.04"
           api_key:
-                  secure: "Z9IEs+GbPW+pxxfYofmeT4Jwjz4OpXJ6WZbv8nyN0MOZV146QExKhZA64mJ7nuXRepS7M5wFgVd0QVlmE7lLa8oNVTKujn+DmQ6701HeP9bITwv6wcDyhNOULLRBwRD2YN5lR29vHGWsjMUm8R13Wtgr/XyOG4L8fcg021B0BMtvepO9HJD4kHSNqB8pJXWVSMd5+d77BRz8Yr72oP98iBMAm94XNd5Gd2RB77YBRKlR7XEV2DxW346C9xI48crMRAKAyp/35vTCTMT04In4FpSexSue0q5dGqfQZf2I5fpGtSbwwJIb3ct/T0CUcW8mDQL01LtG3Hm2qNXKn8aCse6MrVoktUWBTA+tn7DMGq6zY4XXkyC7OisBYg9eel8HacSPrCXDB9C80aJht9a7AZIHehLC4yUomhYmnQDotvHoc3JrJXMSq4HE31WwIBn0xmOpr4ts0nnAprl3bRCQcv10J4MU4zK+BEYET+sLs1stqeION/AYTr0OxWVfbUhRdVepAjDh/mNLYO7raDb/PTZb4upunjS5a1RK+U+aW8ct85RPamZ+8+ZTo8Ofj5VGQiVJmmmrlVkDyBzXwJL3WonnZwuU6QDaaYCFUuzyVqmEuYZNc3i6jNUs0Yptw2YjKww6ayV5msyGaA0QZ3vdGWRk9K7JQQhE7CII2N4yzvI="
+            secure: $APIKEY_SECURE
         - provider: releases
           file: /persistent/garage_deploy-ubuntu_16.04.deb
           skip-cleanup: true
@@ -54,8 +56,7 @@ deploy:
                   condition: $RELEASE_NAME = "ubuntu_16.04"
 
           api_key:
-                  secure: "Z9IEs+GbPW+pxxfYofmeT4Jwjz4OpXJ6WZbv8nyN0MOZV146QExKhZA64mJ7nuXRepS7M5wFgVd0QVlmE7lLa8oNVTKujn+DmQ6701HeP9bITwv6wcDyhNOULLRBwRD2YN5lR29vHGWsjMUm8R13Wtgr/XyOG4L8fcg021B0BMtvepO9HJD4kHSNqB8pJXWVSMd5+d77BRz8Yr72oP98iBMAm94XNd5Gd2RB77YBRKlR7XEV2DxW346C9xI48crMRAKAyp/35vTCTMT04In4FpSexSue0q5dGqfQZf2I5fpGtSbwwJIb3ct/T0CUcW8mDQL01LtG3Hm2qNXKn8aCse6MrVoktUWBTA+tn7DMGq6zY4XXkyC7OisBYg9eel8HacSPrCXDB9C80aJht9a7AZIHehLC4yUomhYmnQDotvHoc3JrJXMSq4HE31WwIBn0xmOpr4ts0nnAprl3bRCQcv10J4MU4zK+BEYET+sLs1stqeION/AYTr0OxWVfbUhRdVepAjDh/mNLYO7raDb/PTZb4upunjS5a1RK+U+aW8ct85RPamZ+8+ZTo8Ofj5VGQiVJmmmrlVkDyBzXwJL3WonnZwuU6QDaaYCFUuzyVqmEuYZNc3i6jNUs0Yptw2YjKww6ayV5msyGaA0QZ3vdGWRk9K7JQQhE7CII2N4yzvI="
-
+            secure: $APIKEY_SECURE
         - provider: releases
           file: /persistent/aktualizr-ubuntu_16.04.deb
           skip-cleanup: true
@@ -65,4 +66,4 @@ deploy:
                   repo: advancedtelematic/aktualizr
                   condition: $RELEASE_NAME = "ubuntu_16.04"
           api_key:
-                  secure: "Z9IEs+GbPW+pxxfYofmeT4Jwjz4OpXJ6WZbv8nyN0MOZV146QExKhZA64mJ7nuXRepS7M5wFgVd0QVlmE7lLa8oNVTKujn+DmQ6701HeP9bITwv6wcDyhNOULLRBwRD2YN5lR29vHGWsjMUm8R13Wtgr/XyOG4L8fcg021B0BMtvepO9HJD4kHSNqB8pJXWVSMd5+d77BRz8Yr72oP98iBMAm94XNd5Gd2RB77YBRKlR7XEV2DxW346C9xI48crMRAKAyp/35vTCTMT04In4FpSexSue0q5dGqfQZf2I5fpGtSbwwJIb3ct/T0CUcW8mDQL01LtG3Hm2qNXKn8aCse6MrVoktUWBTA+tn7DMGq6zY4XXkyC7OisBYg9eel8HacSPrCXDB9C80aJht9a7AZIHehLC4yUomhYmnQDotvHoc3JrJXMSq4HE31WwIBn0xmOpr4ts0nnAprl3bRCQcv10J4MU4zK+BEYET+sLs1stqeION/AYTr0OxWVfbUhRdVepAjDh/mNLYO7raDb/PTZb4upunjS5a1RK+U+aW8ct85RPamZ+8+ZTo8Ofj5VGQiVJmmmrlVkDyBzXwJL3WonnZwuU6QDaaYCFUuzyVqmEuYZNc3i6jNUs0Yptw2YjKww6ayV5msyGaA0QZ3vdGWRk9K7JQQhE7CII2N4yzvI="
+            secure: $APIKEY_SECURE

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
-dist: trusty
-sudo: false
-language: cpp
+dist: xenial
+language: minimal
 git:
   depth: false
 branches:


### PR DESCRIPTION
The new default:

https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment

+ remove deprecated sudo flag

https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

Would be curious to see if it fixes our problem with deploying the last release.
