### PR TITLE
Refact/ota 2487/ipsecondaries initialization

### DIFF
--- a/src/aktualizr_primary/secondary.cc
+++ b/src/aktualizr_primary/secondary.cc
@@ -1,9 +1,15 @@
-#include <unordered_map>
+#include <boost/asio/deadline_timer.hpp>
+#include <boost/asio/io_service.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/placeholders.hpp>
+#include <boost/bind.hpp>
 
-#include "secondary.h"
-#include "secondary_config.h"
+#include <unordered_map>
+#include <unordered_set>
 
 #include "ipuptanesecondary.h"
+#include "secondary.h"
+#include "secondary_config.h"
 
 namespace Primary {
 
@@ -39,7 +45,7 @@ void initSecondaries(Aktualizr& aktualizr, const boost::filesystem::path& config
       LOG_INFO << "Creating " << config->type() << " secondaries...";
       Secondaries secondaries = createSecondaries(*config);
 
-      for (auto secondary : secondaries) {
+      for (const auto& secondary : secondaries) {
         LOG_INFO << "Adding Secondary to Aktualizr."
                  << "HW_ID: " << secondary->getHwId() << " Serial: " << secondary->getSerial();
         aktualizr.AddSecondary(secondary);
@@ -52,12 +58,97 @@ void initSecondaries(Aktualizr& aktualizr, const boost::filesystem::path& config
   }
 }
 
+class SecondaryWaiter {
+ public:
+  SecondaryWaiter(uint16_t wait_port, size_t wait_timeout, Secondaries& secondaries)
+      : endpoint_{boost::asio::ip::tcp::v4(), wait_port},
+        timeout_{static_cast<boost::posix_time::seconds>(wait_timeout)},
+        timer_{io_context_},
+        connected_secondaries_(secondaries) {}
+
+  void addSecoondary(const std::string& ip, uint16_t port) { secondaries_to_wait_for_.insert(key(ip, port)); }
+
+  void wait() {
+    if (secondaries_to_wait_for_.empty()) {
+      return;
+    }
+
+    timer_.expires_from_now(timeout_);
+    timer_.async_wait([&](const boost::system::error_code& error_code) {
+      if (error_code) {
+        LOG_ERROR << "Wait for secondaries has failed: " << error_code;
+      } else {
+        LOG_ERROR << "Timeout while waiting for secondaries: " << error_code;
+      }
+      io_context_.stop();
+    });
+    accept();
+    io_context_.run();
+  }
+
+ private:
+  void accept() {
+    LOG_INFO << "Waiting for connection from " << secondaries_to_wait_for_.size() << " secondaries...";
+    acceptor_.async_accept(con_socket_,
+                           boost::bind(&SecondaryWaiter::connectionHdlr, this, boost::asio::placeholders::error));
+  }
+
+  void connectionHdlr(const boost::system::error_code& error_code) {
+    if (!error_code) {
+      auto sec_ip = con_socket_.remote_endpoint().address().to_string();
+      auto sec_port = con_socket_.remote_endpoint().port();
+
+      LOG_INFO << "Accepted connection from a secondary: (" << sec_ip << ":" << sec_port << ")";
+      try {
+        auto sec_creation_res = Uptane::IpUptaneSecondary::create(sec_ip, sec_port, con_socket_.native_handle());
+        if (sec_creation_res.first) {
+          connected_secondaries_.push_back(sec_creation_res.second);
+        }
+      } catch (const std::exception& exc) {
+        LOG_ERROR << "Failed to initialize a secondary: " << exc.what();
+      }
+      con_socket_.shutdown(boost::asio::ip::tcp::socket::shutdown_both);
+      con_socket_.close();
+
+      secondaries_to_wait_for_.erase(key(sec_ip, sec_port));
+      if (!secondaries_to_wait_for_.empty()) {
+        accept();
+      } else {
+        io_context_.stop();
+      }
+    } else {
+      LOG_ERROR << "Failed to accept connection from a secondary";
+    }
+  }
+
+  static std::string key(const std::string& ip, uint16_t port) { return (ip + std::to_string(port)); }
+
+ private:
+  boost::asio::io_service io_context_;
+  boost::asio::ip::tcp::endpoint endpoint_;
+  boost::asio::ip::tcp::acceptor acceptor_{io_context_, endpoint_};
+  boost::asio::ip::tcp::socket con_socket_{io_context_};
+  boost::posix_time::seconds timeout_;
+  boost::asio::deadline_timer timer_;
+
+  Secondaries& connected_secondaries_;
+  std::unordered_set<std::string> secondaries_to_wait_for_;
+};
+
 static Secondaries createIPSecondaries(const IPSecondariesConfig& config) {
   Secondaries result;
+  SecondaryWaiter sec_waiter{config.secondaries_wait_port, config.secondaries_wait_timeout, result};
 
   for (auto& ip_sec_cfg : config.secondaries_cfg) {
-    result.push_back(Uptane::IpUptaneSecondary::create(ip_sec_cfg.ip, ip_sec_cfg.port));
+    auto sec_creation_res = Uptane::IpUptaneSecondary::connectAndCreate(ip_sec_cfg.ip, ip_sec_cfg.port);
+    if (sec_creation_res.first) {
+      result.push_back(sec_creation_res.second);
+    } else {
+      sec_waiter.addSecoondary(ip_sec_cfg.ip, ip_sec_cfg.port);
+    }
   }
+
+  sec_waiter.wait();
   return result;
 }
 

--- a/src/aktualizr_primary/secondary_config.cc
+++ b/src/aktualizr_primary/secondary_config.cc
@@ -7,7 +7,7 @@
 
 namespace Primary {
 
-const char* const IPSecondaryConfig::Type = "ip";
+const char* const IPSecondariesConfig::Type = "IP";
 
 SecondaryConfigParser::Configs SecondaryConfigParser::parse_config_file(const boost::filesystem::path& config_file) {
   if (!boost::filesystem::exists(config_file)) {

--- a/src/aktualizr_primary/secondary_config.h
+++ b/src/aktualizr_primary/secondary_config.h
@@ -17,13 +17,11 @@ class SecondaryConfig {
   const char* const type_;
 };
 
-class IPSecondaryConfig : public SecondaryConfig {
+class IPSecondaryConfig {
  public:
-  static const char* const Type;
   static constexpr const char* const AddrField{"addr"};
 
-  IPSecondaryConfig(std::string addr_ip, uint16_t addr_port)
-      : SecondaryConfig(Type), ip(std::move(addr_ip)), port(addr_port) {}
+  IPSecondaryConfig(std::string addr_ip, uint16_t addr_port) : ip(std::move(addr_ip)), port(addr_port) {}
 
   friend std::ostream& operator<<(std::ostream& os, const IPSecondaryConfig& cfg) {
     os << "(addr: " << cfg.ip << ":" << cfg.port << ")";
@@ -37,7 +35,7 @@ class IPSecondaryConfig : public SecondaryConfig {
 
 class IPSecondariesConfig : public SecondaryConfig {
  public:
-  static constexpr const char* const Type{"IP"};
+  static const char* const Type;
   static constexpr const char* const PortField{"secondaries_wait_port"};
   static constexpr const char* const TimeoutField{"secondaries_wait_timeout"};
   static constexpr const char* const SecondariesField{"secondaries"};

--- a/src/aktualizr_primary/secondary_config.h
+++ b/src/aktualizr_primary/secondary_config.h
@@ -25,9 +25,35 @@ class IPSecondaryConfig : public SecondaryConfig {
   IPSecondaryConfig(std::string addr_ip, uint16_t addr_port)
       : SecondaryConfig(Type), ip(std::move(addr_ip)), port(addr_port) {}
 
+  friend std::ostream& operator<<(std::ostream& os, const IPSecondaryConfig& cfg) {
+    os << "(addr: " << cfg.ip << ":" << cfg.port << ")";
+    return os;
+  }
+
  public:
   const std::string ip;
   const uint16_t port;
+};
+
+class IPSecondariesConfig : public SecondaryConfig {
+ public:
+  static constexpr const char* const Type{"IP"};
+  static constexpr const char* const PortField{"secondaries_wait_port"};
+  static constexpr const char* const TimeoutField{"secondaries_wait_timeout"};
+  static constexpr const char* const SecondariesField{"secondaries"};
+
+  IPSecondariesConfig(uint16_t wait_port, size_t wait_timeout)
+      : SecondaryConfig(Type), secondaries_wait_port{wait_port}, secondaries_wait_timeout{wait_timeout} {}
+
+  friend std::ostream& operator<<(std::ostream& os, const IPSecondariesConfig& cfg) {
+    os << "(wait_port: " << cfg.secondaries_wait_port << " wait_timeout: " << cfg.secondaries_wait_timeout << ")";
+    return os;
+  }
+
+ public:
+  const uint16_t secondaries_wait_port;
+  const size_t secondaries_wait_timeout;
+  std::vector<IPSecondaryConfig> secondaries_cfg;
 };
 
 class SecondaryConfigParser {
@@ -48,14 +74,14 @@ class JsonConfigParser : public SecondaryConfigParser {
   Configs parse() override;
 
  private:
-  static void createIPSecondaryConfig(Configs& configs, Json::Value& ip_sec_cfgs);
+  static void createIPSecondariesCfg(Configs& configs, Json::Value& json_ip_sec_cfg);
   // add here a factory method for another type of secondary config
 
  private:
   using SecondaryConfigFactoryRegistry = std::unordered_map<std::string, std::function<void(Configs&, Json::Value&)>>;
 
   SecondaryConfigFactoryRegistry sec_cfg_factory_registry_ = {
-      {IPSecondaryConfig::Type, createIPSecondaryConfig}
+      {IPSecondariesConfig::Type, createIPSecondariesCfg}
       // add here factory method for another type of secondary config
   };
 

--- a/src/aktualizr_secondary/aktualizr_secondary.h
+++ b/src/aktualizr_secondary/aktualizr_secondary.h
@@ -33,6 +33,9 @@ class AktualizrSecondary : public AktualizrSecondaryInterface, private Aktualizr
                                         std::string* pkey, std::string* treehub_server);
 
  private:
+  void connectToPrimary();
+
+ private:
   SocketServer socket_server_;
 };
 

--- a/src/aktualizr_secondary/aktualizr_secondary_config.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_config.cc
@@ -4,10 +4,14 @@
 
 void AktualizrSecondaryNetConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt) {
   CopyFromConfig(port, "port", pt);
+  CopyFromConfig(primary_ip, "primary_ip", pt);
+  CopyFromConfig(primary_port, "primary_port", pt);
 }
 
 void AktualizrSecondaryNetConfig::writeToStream(std::ostream& out_stream) const {
   writeOption(out_stream, port, "port");
+  writeOption(out_stream, primary_ip, "primary_ip");
+  writeOption(out_stream, primary_port, "primary_port");
 }
 
 void AktualizrSecondaryUptaneConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt) {

--- a/src/aktualizr_secondary/aktualizr_secondary_config.h
+++ b/src/aktualizr_secondary/aktualizr_secondary_config.h
@@ -18,6 +18,8 @@
 
 struct AktualizrSecondaryNetConfig {
   in_port_t port{9030};
+  std::string primary_ip;
+  in_port_t primary_port{9030};
 
   void updateFromPropertyTree(const boost::property_tree::ptree& pt);
   void writeToStream(std::ostream& out_stream) const;

--- a/src/aktualizr_secondary/socket_server.cc
+++ b/src/aktualizr_secondary/socket_server.cc
@@ -14,6 +14,11 @@
 #include <sys/types.h>
 
 void SocketServer::Run() {
+  if (listen(*socket_, SOMAXCONN) < 0) {
+    throw std::system_error(errno, std::system_category(), "listen");
+  }
+  LOG_INFO << "Listening on " << Utils::ipGetSockaddr(*socket_);
+
   while (true) {
     int con_fd;
     sockaddr_storage peer_sa{};
@@ -178,10 +183,5 @@ SocketHandle SocketFromSystemdOrPort(in_port_t port) {
     throw std::system_error(errno, std::system_category(), "bind");
   }
 
-  if (listen(*hdl, SOMAXCONN) < 0) {
-    throw std::system_error(errno, std::system_category(), "listen");
-  }
-
-  LOG_INFO << "Listening on " << Utils::ipGetSockaddr(*hdl);
   return hdl;
 }

--- a/src/libaktualizr-posix/asn1/asn1_message.h
+++ b/src/libaktualizr-posix/asn1/asn1_message.h
@@ -120,5 +120,6 @@ void SetString(OCTET_STRING_t* dest, const std::string& str);
  * Open a TCP connection to client; send a message and wait for a
  * response.
  */
-Asn1Message::Ptr Asn1Rpc(const Asn1Message::Ptr& tx, const struct sockaddr_in& server_sock_addr);
+Asn1Message::Ptr Asn1Rpc(const Asn1Message::Ptr& tx, int con_fd);
+Asn1Message::Ptr Asn1Rpc(const Asn1Message::Ptr& tx, const std::pair<std::string, uint16_t>& addr);
 #endif  // ASN1_MESSAGE_H_

--- a/src/libaktualizr-posix/ipuptanesecondary.h
+++ b/src/libaktualizr-posix/ipuptanesecondary.h
@@ -10,10 +10,14 @@ namespace Uptane {
 
 class IpUptaneSecondary : public SecondaryInterface {
  public:
-  static std::shared_ptr<Uptane::SecondaryInterface> create(const std::string& address, unsigned short port);
+  static std::pair<bool, std::shared_ptr<Uptane::SecondaryInterface>> connectAndCreate(const std::string& address,
+                                                                                       unsigned short port);
 
-  explicit IpUptaneSecondary(const sockaddr_in& sock_addr, EcuSerial serial, HardwareIdentifier hw_id,
-                             PublicKey pub_key);
+  static std::pair<bool, std::shared_ptr<Uptane::SecondaryInterface>> create(const std::string& address,
+                                                                             unsigned short port, int con_fd);
+
+  explicit IpUptaneSecondary(const std::string& address, unsigned short port, EcuSerial serial,
+                             HardwareIdentifier hw_id, PublicKey pub_key);
 
   // what this method for ? Looks like should be removed out of SecondaryInterface
   void Initialize() override{};
@@ -31,12 +35,12 @@ class IpUptaneSecondary : public SecondaryInterface {
   Json::Value getManifest() override;
 
  private:
-  const sockaddr_in& getAddr() const { return sock_address_; }
+  const std::pair<std::string, uint16_t>& getAddr() const { return addr_; }
 
  private:
   std::mutex install_mutex;
 
-  struct sockaddr_in sock_address_;
+  std::pair<std::string, uint16_t> addr_;
   const EcuSerial serial_;
   const HardwareIdentifier hw_id_;
   const PublicKey pub_key_;

--- a/src/libaktualizr/utilities/utils.h
+++ b/src/libaktualizr/utilities/utils.h
@@ -126,6 +126,20 @@ struct SocketCloser {
 using SocketHandle = std::unique_ptr<int, SocketCloser>;
 bool operator<(const sockaddr_storage &left, const sockaddr_storage &right);  // required by std::map
 
+class Socket {
+ public:
+  Socket(const std::string &ip, uint16_t port);
+  ~Socket();
+
+  int bind(in_port_t port, bool reuse = true);
+  int connect();
+  int getFD() { return socket_fd_; }
+
+ private:
+  struct sockaddr_in sock_address_;
+  int socket_fd_;
+};
+
 // wrapper for curl handles
 class CurlEasyWrapper {
  public:


### PR DESCRIPTION
1. Add ability to specify params that are common across secondaries of the same type (connection wait timeout);
2. Primary waits for a connection from Secondary if it fails to connect to it. Secondary tries to connect to Primary at a startup time.