### PR TITLE
Probabilistic IO failure test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,7 +247,7 @@ if(CLANG_FORMAT)
             string(REPLACE "/" "_" TARGETNAME_CI "aktualizr_ci_clang_format-${SUBDIR}-${FILE}")
 
             add_custom_target(${TARGETNAME_CI}
-              COMMAND ${CLANG_FORMAT} -style=file ${FILE} | diff -u ${FILE} - || { echo "Found unformatted code! Run make format"\; false\; }
+                COMMAND ${CLANG_FORMAT} -style=file ${FILE} | diff -u ${FILE} - || { echo 'Found unformatted code! Run make format'\; false\; }
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
             add_dependencies(check-format ${TARGETNAME_CI})
         endforeach()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -201,11 +201,15 @@ add_test(NAME test_ip_secondary
 add_executable(aktualizr-cycle-simple aktualizr_cycle_simple.cc)
 target_link_libraries(aktualizr-cycle-simple aktualizr_static_lib ${AKTUALIZR_EXTERNAL_LIBS})
 aktualizr_source_file_checks(aktualizr_cycle_simple.cc)
+add_dependencies(build_tests aktualizr-cycle-simple)
 
-# disabled by default, can be run with `ctest -C disabled ...`
-add_test(NAME test_io_failure CONFIGURATIONS ignored COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_io_failure.py
-    --akt-repo $<TARGET_FILE:aktualizr-repo> --akt-test $<TARGET_FILE:aktualizr-cycle-simple>
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+if(FAULT_INJECTION)
+    # run with a very small amount of tests on CI, should be more useful when
+    # run for several hours
+    add_test(NAME test_io_failure COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_io_failure.py
+        --akt-repo $<TARGET_FILE:aktualizr-repo> --akt-test $<TARGET_FILE:aktualizr-cycle-simple> -n 50 -j 10
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+endif(FAULT_INJECTION)
 
 add_dependencies(qa check)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -198,6 +198,15 @@ set_tests_properties(test_log_negative
 add_test(NAME test_ip_secondary
          COMMAND ${PROJECT_SOURCE_DIR}/tests/ipsecondary_test.py --build-dir ${PROJECT_BINARY_DIR})
 
+add_executable(aktualizr-cycle-simple aktualizr_cycle_simple.cc)
+target_link_libraries(aktualizr-cycle-simple aktualizr_static_lib ${AKTUALIZR_EXTERNAL_LIBS})
+aktualizr_source_file_checks(aktualizr_cycle_simple.cc)
+
+# disabled by default, can be run with `ctest -C disabled ...`
+add_test(NAME test_io_failure CONFIGURATIONS ignored COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_io_failure.py
+    --akt-repo $<TARGET_FILE:aktualizr-repo> --akt-test $<TARGET_FILE:aktualizr-cycle-simple>
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+
 add_dependencies(qa check)
 
 aktualizr_source_file_checks(${TEST_SOURCES})

--- a/tests/aktualizr_cycle_simple.cc
+++ b/tests/aktualizr_cycle_simple.cc
@@ -1,0 +1,90 @@
+#include <gtest/gtest.h>
+
+#include <future>
+#include <iostream>
+#include <string>
+#include <thread>
+
+#include "config/config.h"
+#include "logging/logging.h"
+#include "package_manager/ostreemanager.h"
+#include "primary/aktualizr.h"
+#include "storage/sqlstorage.h"
+
+int updateOneCycle(const boost::filesystem::path &storage_dir, const std::string &server) {
+  Config conf;
+  conf.pacman.type = PackageManager::kNone;
+  conf.pacman.fake_need_reboot = true;
+  conf.provision.device_id = "device_id";
+  conf.provision.ecu_registration_endpoint = server + "/director/ecus";
+  conf.tls.server = server;
+  conf.uptane.director_server = server + "/director";
+  conf.uptane.repo_server = server + "/repo";
+  conf.uptane.key_type = KeyType::kED25519;
+  conf.provision.server = server;
+  conf.provision.provision_path = "tests/test_data/cred.zip";
+  conf.provision.primary_ecu_serial = "CA:FE:A6:D2:84:9D";
+  conf.provision.primary_ecu_hardware_id = "primary_hw";
+  conf.storage.path = storage_dir;
+  conf.bootloader.reboot_sentinel_dir = storage_dir;
+  conf.postUpdateValues();
+  logger_set_threshold(boost::log::trivial::debug);
+
+  {
+    Aktualizr aktualizr(conf);
+
+    aktualizr.Initialize();
+
+    result::UpdateCheck update_result = aktualizr.CheckUpdates().get();
+    if (update_result.status != result::UpdateStatus::kUpdatesAvailable) {
+      LOG_ERROR << "no update available";
+      return 0;
+    }
+
+    result::Download download_result = aktualizr.Download(update_result.updates).get();
+    if (download_result.status != result::DownloadStatus::kSuccess) {
+      LOG_ERROR << "download failed";
+      return 1;
+    }
+
+    result::Install install_result = aktualizr.Install(update_result.updates).get();
+    if (install_result.ecu_reports.size() != 1) {
+      LOG_ERROR << "install failed";
+      return 1;
+    }
+    if (install_result.ecu_reports[0].install_res.result_code.num_code != data::ResultCode::Numeric::kNeedCompletion) {
+      return 1;
+    }
+  }
+
+  // do "reboot" and finalize
+  boost::filesystem::remove(conf.bootloader.reboot_sentinel_dir / conf.bootloader.reboot_sentinel_name);
+
+  {
+    Aktualizr aktualizr(conf);
+
+    aktualizr.Initialize();
+
+    result::UpdateCheck update_result = aktualizr.CheckUpdates().get();
+    if (update_result.status != result::UpdateStatus::kNoUpdatesAvailable) {
+      LOG_ERROR << "finalize failed";
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+int main(int argc, char **argv) {
+  logger_init();
+
+  if (argc != 3) {
+    std::cerr << "Error: " << argv[0] << " requires the path to the storage directory "
+              << "and url of uptane server\n";
+    return EXIT_FAILURE;
+  }
+  boost::filesystem::path storage_dir = argv[1];
+  std::string server = argv[2];
+
+  return updateOneCycle(storage_dir, server);
+}

--- a/tests/fake_http_server/fake_test_server.py
+++ b/tests/fake_http_server/fake_test_server.py
@@ -1,6 +1,9 @@
 #!/usr/bin/python3
 
 import argparse
+import contextlib
+import multiprocessing
+import logging
 import os
 import sys
 import socket
@@ -8,6 +11,9 @@ import socket
 from http.server import SimpleHTTPRequestHandler, HTTPServer
 from os import path
 from time import sleep
+
+
+logger = logging.getLogger("fake_test_server")
 
 
 class FailInjector:
@@ -166,13 +172,49 @@ class FakeTestServer(HTTPServer):
     def __init__(self, addr, meta_path, target_path, srcdir=None, fail_injector=None):
         super(HTTPServer, self).__init__(server_address=addr, RequestHandlerClass=Handler)
         self.meta_path = meta_path
-        self.target_path = target_path
+        if target_path is not None:
+            self.target_path = target_path
+        elif meta_path is not None:
+            self.target_path = path.join(meta_path, 'repo/image/targets')
+        else:
+            self.target_path = None
         self.fail_injector = fail_injector
         self.srcdir = srcdir if srcdir is not None else os.getcwd()
 
     def server_bind(self):
         self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         HTTPServer.server_bind(self)
+
+
+class FakeTestServerBackground:
+
+    def __init__(self, meta_path, target_path=None, srcdir=None, port=0):
+        if srcdir is None:
+            srcdir = os.getcwd()
+        self._httpd = FakeTestServer(addr=('', port), meta_path=meta_path,
+                                     target_path=target_path, srcdir=srcdir)
+        self._server_process = self.__class__.Process(target=self._httpd.serve_forever)
+
+    class Process(multiprocessing.Process):
+        def run(self):
+            with open(os.devnull, 'w') as devnull_fd:
+                with contextlib.redirect_stdout(devnull_fd),\
+                        contextlib.redirect_stderr(devnull_fd):
+                    super(multiprocessing.Process, self).run()
+
+    @property
+    def port(self):
+        return self._httpd.server_port
+
+    def __enter__(self):
+        self._server_process.start()
+        logger.debug("Uptane server running and listening: {}".format(self.port))
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._server_process.terminate()
+        self._server_process.join(timeout=10)
+        logger.debug("Uptane server has been stopped")
 
 
 def main():

--- a/tests/fake_http_server/fake_test_server.py
+++ b/tests/fake_http_server/fake_test_server.py
@@ -7,6 +7,7 @@ import logging
 import os
 import sys
 import socket
+import socketserver
 
 from http.server import SimpleHTTPRequestHandler, HTTPServer
 from os import path
@@ -168,7 +169,7 @@ class Handler(SimpleHTTPRequestHandler):
         self.do_POST()
 
 
-class FakeTestServer(HTTPServer):
+class FakeTestServer(socketserver.ThreadingMixIn, HTTPServer):
     def __init__(self, addr, meta_path, target_path, srcdir=None, fail_injector=None):
         super(HTTPServer, self).__init__(server_address=addr, RequestHandlerClass=Handler)
         self.meta_path = meta_path

--- a/tests/ipsecondary_test.py
+++ b/tests/ipsecondary_test.py
@@ -15,7 +15,7 @@ from os import getcwd, chdir
 from uuid import uuid4
 from functools import wraps
 
-from fake_http_server.fake_test_server import ReUseHTTPServer as BaseTestServer
+from fake_http_server.fake_test_server import FakeTestServer
 
 logger = logging.getLogger("IPSecondaryTest")
 
@@ -89,7 +89,7 @@ class UptaneTestBackend:
         self.port = port
         self.repo = UptaneTestRepo(repo_manager_exe)
 
-        self._httpd = BaseTestServer(addr=('', port), meta_path=self.repo.root_dir,
+        self._httpd = FakeTestServer(addr=('', port), meta_path=self.repo.root_dir,
                                     target_path=self.repo.target_dir)
         self._server_process = UptaneTestBackend.Process(target=self._httpd.serve_forever)
 

--- a/tests/test_io_failure.py
+++ b/tests/test_io_failure.py
@@ -58,6 +58,7 @@ def run_test(akt_test, server, srcdir, pf, k):
                      stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=srcdir)
         if cp_err.returncode == 0:
             return True
+
         print('update failed, checking state')
         cp = run([akt_test, storage_dir, server],
                  stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=srcdir)
@@ -89,8 +90,6 @@ def main():
     args = parser.parse_args()
 
     srcdir = path.abspath(args.akt_srcdir) if args.akt_srcdir is not None else os.getcwd()
-
-    print(f'srcdir {srcdir}')
 
     with uptane_repo(args.akt_repo) as repo_dir, \
             FakeTestServerBackground(repo_dir, srcdir=srcdir) as uptane_server, \

--- a/tests/test_io_failure.py
+++ b/tests/test_io_failure.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+
+import argparse
+import contextlib
+import functools
+import multiprocessing
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+from os import path
+from subprocess import run
+
+from fake_http_server.fake_test_server import FakeTestServerBackground
+
+
+"""
+Run aktualizr provisioning and update cycles with random IO failures,
+then retry the procedure and make sure the second attempt succeeds.
+
+Right now, the executable should be aktualizr-cycle-simple which has
+been fine-tuned for this test, but others can be adapted on the same
+model.
+
+On a sample run, this test calls ~3000/4000 io syscalls, so it's recommended
+to run with pf = 1/4000 = 0.00025, so that there should be around one error
+per run, for around 4000*log(n) ~= 50000 runs
+(see https://en.wikipedia.org/wiki/Coupon_collector%27s_problem)
+"""
+
+
+@contextlib.contextmanager
+def uptane_repo(akt_repo):
+    with tempfile.TemporaryDirectory() as repo_path:
+        arepo = [akt_repo, '--keytype', 'ed25519']
+        run([*arepo, 'generate', '--path', repo_path])
+        fw_path = path.join(repo_path, 'images/firmware.txt')
+        os.makedirs(path.join(repo_path, 'images'))
+        with open(fw_path, 'wb') as f:
+            f.write(b'fw')
+        run([*arepo, 'image', '--path', repo_path, '--filename', fw_path,
+             '--targetname', 'firmware.txt'])
+        run([*arepo, 'addtarget', '--path', repo_path, '--targetname',
+             'firmware.txt', '--hwid', 'primary_hw', '--serial', 'CA:FE:A6:D2:84:9D'])
+        run([*arepo, 'signtargets', '--path', repo_path])
+        yield repo_path
+
+
+def run_test(akt_test, server, srcdir, pf, k):
+    print(f'Running test {k}')
+    with tempfile.TemporaryDirectory() as storage_dir:
+        # run once with (maybe) a fault, trying to update
+        cp_err = run(['fiu-run', '-x', '-c', f'enable_random name=posix/io/*,probability={pf}',
+                      akt_test, storage_dir, server],
+                     stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=srcdir)
+        if cp_err.returncode == 0:
+            return True
+        print('update failed, checking state')
+        cp = run([akt_test, storage_dir, server],
+                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=srcdir)
+        if cp.returncode != 0:
+            error_state_dir = f'fail_state.{path.basename(storage_dir)}'
+            print(f'Error detected, see {error_state_dir}')
+            shutil.copytree(storage_dir, error_state_dir)
+            with open(path.join(error_state_dir, 'output1.log'), 'wb') as f:
+                f.write(cp_err.stdout)
+            with open(path.join(error_state_dir, 'output2.log'), 'wb') as f:
+                f.write(cp.stdout)
+            return False
+        return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Run io failure tests')
+    parser.add_argument('-n', '--n-tests', type=int, default=100,
+                        help='number of random tests to run')
+    parser.add_argument('-j', '--jobs', type=int, default=1,
+                        help='number of parallel tests')
+    parser.add_argument('-pf', '--probability-failure', type=float, default=0.00025,
+                        help='probability of syscall failure')
+    parser.add_argument('--akt-srcdir', help='path to the aktualizr source directory')
+    parser.add_argument('--akt-repo', help='path to aktualizr-repo executable')
+    parser.add_argument('--akt-test', help='path to aktualizr cycle test')
+    parser.add_argument('--serve-only', action='store_true',
+                        help='only serve metadata, do not run tests')
+    args = parser.parse_args()
+
+    srcdir = path.abspath(args.akt_srcdir) if args.akt_srcdir is not None else os.getcwd()
+
+    print(f'srcdir {srcdir}')
+
+    with uptane_repo(args.akt_repo) as repo_dir, \
+            FakeTestServerBackground(repo_dir, srcdir=srcdir) as uptane_server, \
+            multiprocessing.Pool(args.jobs) as pool:
+
+        server = f'http://127.0.0.1:{uptane_server.port}'
+        print(f'Running tests on {server} (repo directory: {repo_dir})')
+
+        if args.serve_only:
+            while True:
+                time.sleep(1)
+            return 0
+
+        fk = functools.partial(run_test, path.abspath(args.akt_test),
+                              server, srcdir, args.probability_failure)
+        for r in pool.imap(fk, range(1, args.n_tests+1)):
+            if not r:
+                print('error found!')
+                pool.close()
+                break
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_io_failure.py
+++ b/tests/test_io_failure.py
@@ -27,7 +27,7 @@ model.
 
 On a sample run, this test calls ~3000/4000 io syscalls, so it's recommended
 to run with pf = 1/4000 = 0.00025, so that there should be around one error
-per run, for around 4000*log(n) ~= 50000 runs
+per run, for around 4000*log(4000) ~= 50000 runs
 (see https://en.wikipedia.org/wiki/Coupon_collector%27s_problem)
 """
 


### PR DESCRIPTION
What the test is doing: run a provisioning + update cycle with possible failing syscall (should be ~ 1 io syscall per run), then if an error occured, run it again with the same state but without injected error. The update should go through.

Right now the test uses the fake package manager, it could be more interesting to run it with ostree somehow (though more challenging).

I'll soon launch a long test with an atomicity bug and  see if it's caught as expected!