### PR TITLE
Increase polling_sec from 10s to 3600s

### DIFF
--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -81,7 +81,7 @@ Options for Uptane.
 [options="header"]
 |==========================================================================================
 | Name                      | Default      | Description
-| `polling_sec`             | `10`         | Interval between polls (in seconds).
+| `polling_sec`             | `3600`         | Interval between polls (in seconds).
 | `director_server`         |              | Director server URL. If empty, set to `tls.server` with `/director` appended.
 | `repo_server`             |              | Image repository server URL. If empty, set to `tls.server` with `/repo` appended.
 | `key_source`              | `"file"`     | Where to read the device's private key from. Options: `"file"`, `"pkcs11"`.

--- a/src/libaktualizr/config/config.h
+++ b/src/libaktualizr/config/config.h
@@ -52,7 +52,7 @@ struct ProvisionConfig {
 };
 
 struct UptaneConfig {
-  uint64_t polling_sec{10u};
+  uint64_t polling_sec{3600u};
   std::string director_server;
   std::string repo_server;
   CryptoSource key_source{CryptoSource::kFile};

--- a/src/libaktualizr/config/config_test.cc
+++ b/src/libaktualizr/config/config_test.cc
@@ -19,7 +19,7 @@ boost::filesystem::path build_dir;
 TEST(config, DefaultValues) {
   Config conf;
   EXPECT_EQ(conf.uptane.key_type, KeyType::kRSA2048);
-  EXPECT_EQ(conf.uptane.polling_sec, 10u);
+  EXPECT_EQ(conf.uptane.polling_sec, 3600u);
 }
 
 TEST(config, TomlBasic) {
@@ -31,7 +31,7 @@ TEST(config, TomlEmpty) {
   Config conf;
   conf.updateFromTomlString("");
   EXPECT_EQ(conf.uptane.key_type, KeyType::kRSA2048);
-  EXPECT_EQ(conf.uptane.polling_sec, 10u);
+  EXPECT_EQ(conf.uptane.polling_sec, 3600u);
 }
 
 TEST(config, TomlInt) {


### PR DESCRIPTION
This is probably woefully inadequate, but I figured I'd get the conversation started in PR form. 

Basically it looks like people are aktualizr into production with the default, so I figure the default should be pretty high and we can set it lower when we need it. Maybe this is too high? Or still too low? Let me know what you think.