### PR TITLE
Split pkg tests

### DIFF
--- a/ci/gitlab/.gitlab-ci.yml
+++ b/ci/gitlab/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 stages:
   - docker
   - test
+  - pkg-test
   - deploy
 
 variables:
@@ -17,7 +18,6 @@ variables:
 
   GIT_SUBMODULE_STRATEGY: recursive
 
-# Build the Docker image that will be used in subsequent CI/CD stages
 Docker Setup:
   image: docker:latest
   stage: docker
@@ -55,25 +55,25 @@ coverage:
     TEST_WITH_COVERAGE: '1'
     TEST_WITH_P11: '1'
     TEST_WITH_FAULT_INJECTION: '1'
-    TEST_SOTA_PACKED_CREDENTIALS: '/tmp/credentials.zip'
+    TEST_SOTA_PACKED_CREDENTIALS: "$CI_PROJECT_DIR/credentials.zip"
   image: "$UBUNTU_BIONIC_PR_IMAGE"
   stage: test
   artifacts:
     paths:
       - build-coverage/coverage/
   script:
-    - aws s3 cp s3://ota-gitlab-ci/hereotaconnect_prod.zip /tmp/credentials.zip
-    - $CI_PROJECT_DIR/scripts/test.sh
+    - aws s3 cp s3://ota-gitlab-ci/hereotaconnect_prod.zip $CI_PROJECT_DIR/credentials.zip
+    - ./scripts/test.sh
 
 nop11:
   variables:
     TEST_BUILD_DIR: 'build-nop11'
-    TEST_CMAKE_BUILD_TYPE: 'Valgrind'
-    TEST_TESTSUITE_ONLY: 'crypto'
+    TEST_CMAKE_BUILD_TYPE: 'Debug'
+    TEST_WITH_TESTSUITE: '0'
   image: "$UBUNTU_BIONIC_PR_IMAGE"
   stage: test
   script:
-    - $CI_PROJECT_DIR/scripts/test.sh
+    - ./scripts/test.sh
 
 debian-build+static:
   variables:
@@ -88,54 +88,59 @@ debian-build+static:
   image: "$DEBIAN_TESTING_PR_IMAGE"
   stage: test
   script:
-    - $CI_PROJECT_DIR/scripts/test.sh
+    - ./scripts/test.sh
 
 bionic-pkg:
-  # Build and test aktualizr bionic package
   variables:
     TEST_BUILD_DIR: 'build-bionic'
     TEST_INSTALL_RELEASE_NAME: '-ubuntu_18.04'
     TEST_INSTALL_DESTDIR: "$CI_PROJECT_DIR/build-bionic/pkg"
 
-  image: docker:latest
-  services:
-    - docker:dind
+  image: "$UBUNTU_BIONIC_PR_IMAGE"
   stage: test
   artifacts:
     paths:
-      - build-bionic/pkg/*.deb
-  before_script:
-    - docker login -u gitlab-ci-token -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
+      - build-bionic/pkg
   script:
     - mkdir -p $TEST_INSTALL_DESTDIR
-    # build package
-    - docker run -eTEST_BUILD_DIR=$TEST_BUILD_DIR -eTEST_INSTALL_RELEASE_NAME=$TEST_INSTALL_RELEASE_NAME -u $(id -u):$(id -g) -v $CI_PROJECT_DIR:$CI_PROJECT_DIR -v $TEST_INSTALL_DESTDIR:/persistent --rm $UBUNTU_BIONIC_PR_IMAGE $CI_PROJECT_DIR/scripts/build_ubuntu.sh
-    # run tests
-    - docker run --rm -v $TEST_INSTALL_DESTDIR:/persistent -v $CI_PROJECT_DIR/scripts/:/scripts/ -t $UBUNTU_BIONIC_PR_INSTALLIMAGE /scripts/test_install_garage_deploy.sh
+    - ./scripts/build_ubuntu.sh
 
 xenial-pkg:
-  # Build and test aktualizr xenial package
   variables:
     TEST_BUILD_DIR: 'build-xenial'
     TEST_INSTALL_RELEASE_NAME: '-ubuntu_16.04'
     TEST_INSTALL_DESTDIR: "$CI_PROJECT_DIR/build-xenial/pkg"
 
-  image: docker:latest
-  services:
-    - docker:dind
+  image: "$UBUNTU_XENIAL_PR_IMAGE"
   stage: test
   artifacts:
     paths:
-      - build-xenial/pkg/*.deb
-  before_script:
-    - docker login -u gitlab-ci-token -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
+      - build-xenial/pkg
   script:
     - mkdir -p $TEST_INSTALL_DESTDIR
-    # build package
-    - docker run -eTEST_BUILD_DIR="$TEST_BUILD_DIR" -eTEST_INSTALL_RELEASE_NAME="$TEST_INSTALL_RELEASE_NAME" -u $(id -u):$(id -g) -v $CI_PROJECT_DIR:$CI_PROJECT_DIR -v $TEST_INSTALL_DESTDIR:/persistent --rm $UBUNTU_XENIAL_PR_IMAGE $CI_PROJECT_DIR/scripts/build_ubuntu.sh
-    # run tests
-    - docker run --rm -v $TEST_INSTALL_DESTDIR:/persistent -v $CI_PROJECT_DIR/scripts/:/scripts/ -t $UBUNTU_XENIAL_PR_INSTALLIMAGE /scripts/test_install_garage_deploy.sh
-    - docker run --rm -v $TEST_INSTALL_DESTDIR:/persistent -v $CI_PROJECT_DIR/scripts/:/scripts/ -t $UBUNTU_XENIAL_PR_INSTALLIMAGE bash -c "/scripts/test_install_aktualizr_and_update.sh && /scripts/test_aktualizr_repo.sh"
+    - ./scripts/build_ubuntu.sh
+
+bionic-pkg-test:
+  variables:
+    TEST_INSTALL_DESTDIR: "$CI_PROJECT_DIR/build-bionic/pkg"
+
+  image: "$UBUNTU_BIONIC_PR_INSTALLIMAGE"
+  stage: pkg-test
+  script:
+    - ./scripts/test_install_garage_deploy.sh
+
+xenial-pkg-test:
+  variables:
+    TEST_INSTALL_DESTDIR: "$CI_PROJECT_DIR/build-xenial/pkg"
+
+  image: "$UBUNTU_XENIAL_PR_INSTALLIMAGE"
+  stage: pkg-test
+  script:
+    - ./scripts/test_install_garage_deploy.sh
+    - ./scripts/test_install_aktualizr_and_update.sh
+    - ./scripts/test_aktualizr_repo.sh
+
+# publish coverage results on gitlab pages
 
 pages:
   stage: deploy

--- a/scripts/selfupdate_server.py
+++ b/scripts/selfupdate_server.py
@@ -10,7 +10,7 @@ class Handler(BaseHTTPRequestHandler):
         print("GET: " + self.path)
         self.send_response(200)
         self.end_headers()
-        with open("/persistent/fake_root/repo/" + self.path, "rb") as fl:
+        with open(self.server.base_dir + "/fake_root/repo/" + self.path, "rb") as fl:
             self.wfile.write(bytearray(fl.read()))
 
     def do_POST(self):
@@ -22,14 +22,19 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
 
 
-class ReUseHTTPServer(HTTPServer):
+class SelfUpdateHTTPServer(HTTPServer):
+    def __init__(self, base_dir, *kargs, **kwargs):
+        super().__init__(*kargs, **kwargs)
+        self.base_dir = base_dir
+
     def server_bind(self):
         self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         HTTPServer.server_bind(self)
 
 
 server_address = ('', int(sys.argv[1]))
-httpd = ReUseHTTPServer(server_address, Handler)
+base_dir = sys.argv[2]
+httpd = SelfUpdateHTTPServer(base_dir, server_address, Handler)
 
 try:
     httpd.serve_forever()

--- a/scripts/test_aktualizr_repo.sh
+++ b/scripts/test_aktualizr_repo.sh
@@ -2,16 +2,18 @@
 
 set -exuo pipefail
 
-dpkg-deb -I /persistent/aktualizr*.deb && dpkg -i /persistent/aktualizr*.deb
+TEST_INSTALL_DESTDIR=${TEST_INSTALL_DESTDIR:-/persistent}
 
-export PATH=${PATH}:/persistent
+dpkg-deb -I "$TEST_INSTALL_DESTDIR"/aktualizr*.deb && dpkg -i "$TEST_INSTALL_DESTDIR"/aktualizr*.deb
+
+export PATH=${PATH}:$TEST_INSTALL_DESTDIR
 
 TMPDIR=$(mktemp -u)
-create_repo.sh $TMPDIR 127.0.0.1
+create_repo.sh "$TMPDIR" 127.0.0.1
 serve_repo.py 9000 "$TMPDIR" &
 
 aktualizr --config "${TMPDIR}/sota.toml" --run-mode once
 
 aktualizr-info --config "${TMPDIR}/sota.toml" | grep "Fetched metadata: yes" || exit 1
 
-rm -r $TMPDIR
+rm -r "$TMPDIR"

--- a/scripts/test_install_aktualizr_and_update.sh
+++ b/scripts/test_install_aktualizr_and_update.sh
@@ -2,17 +2,19 @@
 
 set -exuo pipefail
 
-/persistent/selfupdate_server.py 8000&
+TEST_INSTALL_DESTDIR=${TEST_INSTALL_DESTDIR:-/persistent}
 
-dpkg-deb -I /persistent/aktualizr*.deb && dpkg -i /persistent/aktualizr*.deb
+"$TEST_INSTALL_DESTDIR/selfupdate_server.py" 8000 "$TEST_INSTALL_DESTDIR"&
+
+dpkg-deb -I "$TEST_INSTALL_DESTDIR"/aktualizr*.deb && dpkg -i "$TEST_INSTALL_DESTDIR"/aktualizr*.deb
 akt_version=$(aktualizr --version)
-(grep "$(cat /persistent/aktualizr-version)" <<< "$akt_version") || (echo "$akt_version"; false)
+(grep "$(cat "$TEST_INSTALL_DESTDIR"/aktualizr-version)" <<< "$akt_version") || (echo "$akt_version"; false)
 
 TEMP_DIR=$(mktemp -d)
 mkdir -m 700 -p "$TEMP_DIR/import"
-cp /persistent/prov_selfupdate/* "$TEMP_DIR/import"
+cp "$TEST_INSTALL_DESTDIR"/prov_selfupdate/* "$TEMP_DIR/import"
 echo -e "[storage]\\npath = \"$TEMP_DIR\"\\n[import]\\nbase_path = \"$TEMP_DIR/import\"" > "$TEMP_DIR/conf.toml"
-aktualizr -c /persistent/selfupdate.toml -c "$TEMP_DIR/conf.toml" --run-mode=once
+aktualizr -c "$TEST_INSTALL_DESTDIR"/selfupdate.toml -c "$TEMP_DIR/conf.toml" once
 
 # check that the version was updated
 akt_version=$(aktualizr --version)

--- a/scripts/test_install_garage_deploy.sh
+++ b/scripts/test_install_garage_deploy.sh
@@ -2,6 +2,8 @@
 
 set -exuo pipefail
 
-dpkg -i /persistent/garage_deploy*.deb
+TEST_INSTALL_DESTDIR=${TEST_INSTALL_DESTDIR:-/persistent}
+
+dpkg -i "$TEST_INSTALL_DESTDIR"/garage_deploy*.deb
 garage-deploy --version
 garage-sign --help


### PR DESCRIPTION
Initially made the change because using docker volumes was broken on gitlab CI yesterday (seems to have been fixed now). But I also think it's a little bit cleaner now anyway.

I'm also thinking about removing these install tests from Jenkins and Travis, so that we can continue to clean it up some more and not have to deal with the `/persistent` business.