### PR TITLE
Revert stripping of executable in release mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,8 +162,6 @@ if(FAULT_INJECTION)
 endif(FAULT_INJECTION)
 
 # flags for different build types
-list(APPEND CMAKE_EXE_LINKER_FLAGS_RELEASE " -s")
-
 set(CMAKE_CXX_FLAGS_DEBUG "-Og -g")
 set(CMAKE_C_FLAGS_DEBUG "-Og -g")
 

--- a/scripts/build_ubuntu.sh
+++ b/scripts/build_ubuntu.sh
@@ -13,7 +13,8 @@ export TEST_WITH_TESTSUITE=0
 
 # build and copy aktualizr.deb and garage_deploy.deb to $TEST_INSTALL_DESTDIR
 mkdir -p "$TEST_INSTALL_DESTDIR"
-"$GITREPO_ROOT/scripts/test.sh"
+# note: executables are stripped, following common conventions in .deb packages
+LDFLAGS="-s" "$GITREPO_ROOT/scripts/test.sh"
 
 # copy provisioning data and scripts
 cp -rf "$GITREPO_ROOT/tests/test_data/prov_selfupdate" "$TEST_INSTALL_DESTDIR"


### PR DESCRIPTION
Was added in 299475fac6c29ff969ecc06a12b2833d92bf2538 to fix some .deb
lint warning (lintian), but bitbake doesn't like it.