### PR TITLE
Add static code scan instrumentation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,5 @@
 .gitignore export-ignore 
 .gitmodules export-ignore
 partial/extern/RIOT export-ignore
+third_party export-ignore
+.vscode export-ignore

--- a/ci/gitlab/.gitlab-ci.yml
+++ b/ci/gitlab/.gitlab-ci.yml
@@ -75,6 +75,46 @@ nop11:
   script:
     - ./scripts/test.sh
 
+scan-build:
+  stage: test
+  only:
+    - schedules
+  # prepare build to be submitted for static code analysis
+  variables:
+    TEST_BUILD_DIR: 'scan-build'
+    TEST_CMAKE_BUILD_TYPE: 'Debug'
+    TEST_INSTALL_DESTDIR: "$CI_PROJECT_DIR/scan-build/bin"
+    TEST_WITH_TESTSUITE: '0'
+    TEST_WITH_SOTA_TOOLS: '0'
+    TEST_WITH_OSTREE: '0'
+    TEST_WITH_DEB: '0'
+    TEST_WITH_ISOTP: '0'
+    TEST_WITH_PARTIAL: '0'
+  image: "$UBUNTU_BIONIC_PR_IMAGE"
+  script:
+    - mkdir -p $TEST_INSTALL_DESTDIR
+    - ./scripts/test.sh
+    - git archive -o scan.tar HEAD
+  artifacts:
+    paths:
+      - scan-build/bin
+      - scan.tar
+
+veracode-scan:
+  stage: deploy
+  only:
+    - schedules
+  dependencies:
+    - scan-build
+  before_script:
+# The lastest wrapper version can be found in https://repo1.maven.org/maven2/com/veracode/vosp/api/wrappers/vosp-api-wrappers-java/
+    - wget -q -O veracode-wrapper.jar https://repo1.maven.org/maven2/com/veracode/vosp/api/wrappers/vosp-api-wrappers-java/${VERACODE_WRAPPER_VERSION}/vosp-api-wrappers-java-${VERACODE_WRAPPER_VERSION}.jar
+  script:
+    - tar -f scan.tar --append scan-build/bin
+    - java -jar --add-modules java.se.ee veracode-wrapper.jar -vid ${VERACODE_API_ID} -vkey ${VERACODE_API_KEY}
+      -action UploadAndScan -appname "OTA Client" -createprofile true -autoscan true
+      -filepath scan.tar -version "job ${CI_JOB_ID} in pipeline ${CI_PIPELINE_ID} for ${CI_PROJECT_NAME} repo"
+
 debian-build+static:
   variables:
     TEST_BUILD_DIR: 'build-debian-testing'


### PR DESCRIPTION
This ensures that we don't export 3rd party dependencies as part of our own source archive and adds necessary instrumentation for static scan code submissions.

Note: corresponding gitlab pipelines will only be activated via schedules so normal CI shouldn't be affected.