### PR TITLE
aktualizr-lite: Fix logic for finding latest version

### DIFF
--- a/src/aktualizr_lite/CMakeLists.txt
+++ b/src/aktualizr_lite/CMakeLists.txt
@@ -1,5 +1,6 @@
 if(BUILD_OSTREE)
-add_executable(aktualizr-lite main.cc)
+set(SOURCES main.cc version.h)
+add_executable(aktualizr-lite ${SOURCES})
 target_link_libraries(aktualizr-lite aktualizr_static_lib ${AKTUALIZR_EXTERNAL_LIBS})
 
 install(TARGETS aktualizr-lite RUNTIME DESTINATION bin COMPONENT aktualizr-lite)
@@ -18,5 +19,7 @@ add_test(test_aktualizr-lite
 
 endif(BUILD_OSTREE)
 
-aktualizr_source_file_checks(main.cc)
+add_aktualizr_test(NAME lite-version SOURCES version_test.cc)
+
+aktualizr_source_file_checks(${SOURCES} version_test.cc)
 # vim: set tabstop=4 shiftwidth=4 expandtab:

--- a/src/aktualizr_lite/CMakeLists.txt
+++ b/src/aktualizr_lite/CMakeLists.txt
@@ -1,6 +1,5 @@
 if(BUILD_OSTREE)
-set(SOURCES main.cc version.h)
-add_executable(aktualizr-lite ${SOURCES})
+add_executable(aktualizr-lite main.cc version.h)
 target_link_libraries(aktualizr-lite aktualizr_static_lib ${AKTUALIZR_EXTERNAL_LIBS})
 
 install(TARGETS aktualizr-lite RUNTIME DESTINATION bin COMPONENT aktualizr-lite)
@@ -21,5 +20,5 @@ endif(BUILD_OSTREE)
 
 add_aktualizr_test(NAME lite-version SOURCES version_test.cc)
 
-aktualizr_source_file_checks(${SOURCES} version_test.cc)
+aktualizr_source_file_checks(main.cc version.h version_test.cc)
 # vim: set tabstop=4 shiftwidth=4 expandtab:

--- a/src/aktualizr_lite/test_lite.sh
+++ b/src/aktualizr_lite/test_lite.sh
@@ -34,6 +34,7 @@ add_target() {
     fi
     cat >$custom_json <<EOF
 {
+  "version": "$1",
   "hardwareIds": ["hwid-for-test"],
   "targetFormat": "OSTREE"
 }
@@ -95,10 +96,12 @@ fi
 
 ## Check that we can do the update command
 update=$(ostree admin status | head -n 1)
-name=$(echo $update | cut -d\  -f1)
+name="zlast"  # give a name that will cause the custom version to be the latest
 sha=$(echo $update | cut -d\  -f2 | sed 's/\.0$//')
 echo "Adding new target: $name / $sha"
 add_target $name $sha
 
 $valgrind $aklite --loglevel 1 -c $sota_dir/sota.toml update --update-name $name
 ostree admin status
+
+$valgrind $aklite --loglevel 1 -c $sota_dir/sota.toml update | grep "Updating to: Target(zlast"

--- a/src/aktualizr_lite/version.h
+++ b/src/aktualizr_lite/version.h
@@ -1,0 +1,10 @@
+#include <string>
+
+#include <string.h>
+
+struct Version {
+  std::string raw_ver;
+  Version(const std::string& version) : raw_ver(std::move(version)) {}
+
+  bool operator<(const Version& other) { return strverscmp(raw_ver.c_str(), other.raw_ver.c_str()) < 0; }
+};

--- a/src/aktualizr_lite/version.h
+++ b/src/aktualizr_lite/version.h
@@ -4,7 +4,7 @@
 
 struct Version {
   std::string raw_ver;
-  Version(const std::string& version) : raw_ver(std::move(version)) {}
+  Version(const std::string& version) : raw_ver(version) {}
 
   bool operator<(const Version& other) { return strverscmp(raw_ver.c_str(), other.raw_ver.c_str()) < 0; }
 };

--- a/src/aktualizr_lite/version.h
+++ b/src/aktualizr_lite/version.h
@@ -4,7 +4,7 @@
 
 struct Version {
   std::string raw_ver;
-  Version(const std::string& version) : raw_ver(version) {}
+  Version(std::string version) : raw_ver(std::move(version)) {}
 
   bool operator<(const Version& other) { return strverscmp(raw_ver.c_str(), other.raw_ver.c_str()) < 0; }
 };

--- a/src/aktualizr_lite/version_test.cc
+++ b/src/aktualizr_lite/version_test.cc
@@ -1,0 +1,28 @@
+#include <gtest/gtest.h>
+
+#include "version.h"
+
+TEST(version, bad_versions) {
+  ASSERT_TRUE(Version("bar") < Version("foo"));
+  ASSERT_TRUE(Version("1.bar") < Version("2foo"));
+  ASSERT_TRUE(Version("1..0") < Version("1.1"));
+  ASSERT_TRUE(Version("1.-1") < Version("1.1"));
+  ASSERT_TRUE(Version("1.*bad #text") < Version("1.1"));  // ord('*') < ord('1')
+}
+
+TEST(version, good_versions) {
+  ASSERT_TRUE(Version("1.0.1") < Version("1.0.1.1"));
+  ASSERT_TRUE(Version("1.0.1") < Version("1.0.2"));
+  ASSERT_TRUE(Version("0.9") < Version("1.0.1"));
+  ASSERT_TRUE(Version("1.0.0.0") < Version("1.0.0.1"));
+  ASSERT_TRUE(Version("1") < Version("1.0.0.1"));
+  ASSERT_TRUE(Version("1.9.0") < Version("1.10"));
+}
+
+#ifndef __NO_MAIN__
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+  return RUN_ALL_TESTS();
+}
+#endif


### PR DESCRIPTION
You can't assume the targets will be ordered latest->oldest. This
creates a version comparison helper that tries its best to compare
things.

Signed-off-by: Andy Doan <andy@foundries.io>