### PR TITLE
Support for ccache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ option(BUILD_LOAD_TESTS "Set to ON to build load tests" OFF)
 option(FAULT_INJECTION "Set to ON to enable fault injection" OFF)
 option(INSTALL_LIB "Set to ON to install library and headers" OFF)
 option(TESTSUITE_VALGRIND "Set to ON to make tests to run under valgrind (default when CMAKE_BUILD_TYPE=Valgrind)" ${TESTSUITE_VALGRIND_DEFAULT})
+option(CCACHE "Set to ON to use ccache if available" ON)
 
 set(SOTA_PACKED_CREDENTIALS "" CACHE STRING "Credentials.zip for tests involving the server")
 
@@ -57,6 +58,13 @@ configure_file(CTestCustom.cmake CTestCustom.cmake)
 unset(AKTUALIZR_CHECKED_SRCS CACHE)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+if (CCACHE)
+    find_program(CCACHE_PROGRAM ccache)
+    if (CCACHE_PROGRAM)
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+    endif (CCACHE_PROGRAM)
+endif (CCACHE)
 
 # find all required libraries
 set(BOOST_COMPONENTS log_setup log system filesystem program_options)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,8 +112,6 @@ if(NOT AKTUALIZR_VERSION)
     endif(GIT_EXECUTABLE)
 endif(NOT AKTUALIZR_VERSION)
 
-add_definitions(-DAKTUALIZR_VERSION="${AKTUALIZR_VERSION}")
-
 if(BUILD_OSTREE)
     find_package(OSTree REQUIRED)
     add_definitions(-DBUILD_OSTREE)

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -11,6 +11,8 @@
 #include "package_manager/ostreemanager.h"
 #include "primary/sotauptaneclient.h"
 
+#include "utilities/aktualizr_version.h"
+
 namespace bpo = boost::program_options;
 
 static std::shared_ptr<SotaUptaneClient> liteClient(Config &config) {
@@ -170,7 +172,7 @@ void check_info_options(const bpo::options_description &description, const bpo::
     exit(EXIT_SUCCESS);
   }
   if (vm.count("version") != 0) {
-    std::cout << "Current aktualizr version is: " << AKTUALIZR_VERSION << "\n";
+    std::cout << "Current aktualizr version is: " << aktualizr_version() << "\n";
     exit(EXIT_SUCCESS);
   }
 }

--- a/src/aktualizr_primary/main.cc
+++ b/src/aktualizr_primary/main.cc
@@ -10,6 +10,7 @@
 #include "logging/logging.h"
 #include "primary/aktualizr.h"
 #include "secondary.h"
+#include "utilities/aktualizr_version.h"
 #include "utilities/utils.h"
 
 namespace bpo = boost::program_options;
@@ -20,7 +21,7 @@ void check_info_options(const bpo::options_description &description, const bpo::
     exit(EXIT_SUCCESS);
   }
   if (vm.count("version") != 0) {
-    std::cout << "Current aktualizr version is: " << AKTUALIZR_VERSION << "\n";
+    std::cout << "Current aktualizr version is: " << aktualizr_version() << "\n";
     exit(EXIT_SUCCESS);
   }
 }
@@ -102,7 +103,7 @@ int main(int argc, char *argv[]) {
 
   bpo::variables_map commandline_map = parse_options(argc, argv);
 
-  LOG_INFO << "Aktualizr version " AKTUALIZR_VERSION " starting";
+  LOG_INFO << "Aktualizr version " << aktualizr_version() << " starting";
 
   int r = EXIT_FAILURE;
 

--- a/src/aktualizr_secondary/main.cc
+++ b/src/aktualizr_secondary/main.cc
@@ -8,6 +8,7 @@
 
 #include "aktualizr_secondary.h"
 #include "aktualizr_secondary_config.h"
+#include "utilities/aktualizr_version.h"
 #include "utilities/utils.h"
 
 #include "logging/logging.h"
@@ -20,7 +21,7 @@ void check_secondary_options(const bpo::options_description &description, const 
     exit(EXIT_SUCCESS);
   }
   if (vm.count("version") != 0) {
-    std::cout << "Current aktualizr-secondary version is: " << AKTUALIZR_VERSION << "\n";
+    std::cout << "Current aktualizr-secondary version is: " << aktualizr_version() << "\n";
     exit(EXIT_SUCCESS);
   }
 }
@@ -77,7 +78,7 @@ bpo::variables_map parse_options(int argc, char *argv[]) {
 int main(int argc, char *argv[]) {
   logger_init();
   logger_set_threshold(boost::log::trivial::info);
-  LOG_INFO << "Aktualizr-secondary version " AKTUALIZR_VERSION " starting";
+  LOG_INFO << "Aktualizr-secondary version " << aktualizr_version() << " starting";
 
   bpo::variables_map commandline_map = parse_options(argc, argv);
 

--- a/src/cert_provider/main.cc
+++ b/src/cert_provider/main.cc
@@ -16,6 +16,7 @@
 #include "crypto/crypto.h"
 #include "http/httpclient.h"
 #include "logging/logging.h"
+#include "utilities/aktualizr_version.h"
 #include "utilities/utils.h"
 
 namespace bpo = boost::program_options;
@@ -26,7 +27,7 @@ void check_info_options(const bpo::options_description& description, const bpo::
     exit(EXIT_SUCCESS);
   }
   if (vm.count("version") != 0) {
-    std::cout << "Current aktualizr-cert-provider version is: " << AKTUALIZR_VERSION << "\n";
+    std::cout << "Current aktualizr-cert-provider version is: " << aktualizr_version() << "\n";
     exit(EXIT_SUCCESS);
   }
 }

--- a/src/hmi_stub/main.cc
+++ b/src/hmi_stub/main.cc
@@ -14,6 +14,7 @@
 #include "config/config.h"
 #include "logging/logging.h"
 #include "primary/aktualizr.h"
+#include "utilities/aktualizr_version.h"
 #include "utilities/utils.h"
 
 namespace bpo = boost::program_options;
@@ -29,7 +30,7 @@ void check_info_options(const bpo::options_description &description, const bpo::
     exit(EXIT_SUCCESS);
   }
   if (vm.count("version") != 0) {
-    std::cout << "Current hmi_stub version is: " << AKTUALIZR_VERSION << "\n";
+    std::cout << "Current hmi_stub version is: " << aktualizr_version() << "\n";
     exit(EXIT_SUCCESS);
   }
 }
@@ -121,7 +122,7 @@ void process_event(const std::shared_ptr<event::BaseEvent> &event) {
 int main(int argc, char *argv[]) {
   logger_init();
   logger_set_threshold(boost::log::trivial::info);
-  LOG_INFO << "hmi_stub version " AKTUALIZR_VERSION " starting";
+  LOG_INFO << "hmi_stub version " << aktualizr_version() << " starting";
 
   bpo::variables_map commandline_map = parse_options(argc, argv);
 

--- a/src/libaktualizr/http/httpclient.cc
+++ b/src/libaktualizr/http/httpclient.cc
@@ -14,6 +14,7 @@
 #include <openssl/ssl.h>
 
 #include "crypto/openssl_compat.h"
+#include "utilities/aktualizr_version.h"
 #include "utilities/utils.h"
 
 struct WriteStringArg {
@@ -45,7 +46,7 @@ static size_t writeString(void* contents, size_t size, size_t nmemb, void* userp
   return size * nmemb;
 }
 
-HttpClient::HttpClient() : user_agent(std::string("Aktualizr/") + AKTUALIZR_VERSION) {
+HttpClient::HttpClient() : user_agent(std::string("Aktualizr/") + aktualizr_version()) {
   curl = curl_easy_init();
   if (curl == nullptr) {
     throw std::runtime_error("Could not initialize curl");

--- a/src/libaktualizr/utilities/CMakeLists.txt
+++ b/src/libaktualizr/utilities/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(SOURCES apiqueue.cc
+set(SOURCES aktualizr_version.cc
+            apiqueue.cc
             dequeue_buffer.cc
             sockaddr_io.cc
             timer.cc
@@ -6,6 +7,7 @@ set(SOURCES apiqueue.cc
             utils.cc)
 
 set(HEADERS apiqueue.h
+            aktualizr_version.h
             config_utils.h
             dequeue_buffer.h
             exceptions.h
@@ -15,6 +17,7 @@ set(HEADERS apiqueue.h
             types.h
             utils.h)
 
+set_property(SOURCE aktualizr_version.cc PROPERTY COMPILE_DEFINITIONS AKTUALIZR_VERSION="${AKTUALIZR_VERSION}")
 
 add_library(utilities OBJECT ${SOURCES})
 include(AddAktualizrTest)

--- a/src/libaktualizr/utilities/aktualizr_version.cc
+++ b/src/libaktualizr/utilities/aktualizr_version.cc
@@ -1,0 +1,3 @@
+#include "aktualizr_version.h"
+
+const char *aktualizr_version() { return AKTUALIZR_VERSION; }

--- a/src/libaktualizr/utilities/aktualizr_version.h
+++ b/src/libaktualizr/utilities/aktualizr_version.h
@@ -1,0 +1,10 @@
+#ifndef AKTUALIZR_VERSION_H_
+#define AKTUALIZR_VERSION_H_
+
+// This is part of a separate library which is the only one where the
+// AKTUALIZR_VERSION macro is defined, so that the rest of the code base
+// compilation can be cached (e.g: with ccache)
+
+const char *aktualizr_version();
+
+#endif  // AKTUALIZR_VERSION_H_

--- a/src/sota_tools/CMakeLists.txt
+++ b/src/sota_tools/CMakeLists.txt
@@ -2,6 +2,7 @@ include_directories("${PROJECT_SOURCE_DIR}/src/libaktualizr/third_party/jsoncpp"
 set(SOTA_TOOLS_LIB_SRC
     authenticate.cc
     deploy.cc
+    garage_tools_version.cc
     oauth2.cc
     ostree_dir_repo.cc
     ostree_hash.cc
@@ -15,6 +16,8 @@ set(SOTA_TOOLS_LIB_SRC
     treehub_server.cc)
 
 if (BUILD_SOTA_TOOLS)
+    set(GARAGE_TOOLS_VERSION "${AKTUALIZR_VERSION}")
+    set_property(SOURCE garage_tools_version.cc PROPERTY COMPILE_DEFINITIONS GARAGE_TOOLS_VERSION="${GARAGE_TOOLS_VERSION}")
     add_library(sota_tools_static_lib STATIC ${SOTA_TOOLS_LIB_SRC})
     target_include_directories(sota_tools_static_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${PROJECT_SOURCE_DIR} ${GLIB2_INCLUDE_DIRS})
 endif (BUILD_SOTA_TOOLS)
@@ -64,8 +67,6 @@ if (BUILD_SOTA_TOOLS)
     add_executable(garage-deploy ${GARAGE_DEPLOY_SRCS})
     target_link_libraries(garage-deploy sota_tools_static_lib aktualizr_static_lib ${SOTA_TOOLS_EXTERNAL_LIBS})
 
-    add_definitions(-DGARAGE_TOOLS_VERSION="${AKTUALIZR_VERSION}")
-
     add_dependencies(build_tests garage-deploy)
 
     install(TARGETS garage-deploy RUNTIME DESTINATION bin COMPONENT garage_deploy)
@@ -101,6 +102,7 @@ set(ALL_SOTA_TOOLS_HEADERS
     authenticate.h
     deploy.h
     garage_common.h
+    garage_tools_version.h
     oauth2.h
     ostree_dir_repo.h
     ostree_hash.h

--- a/src/sota_tools/garage_check.cc
+++ b/src/sota_tools/garage_check.cc
@@ -8,6 +8,7 @@
 #include "accumulator.h"
 #include "authenticate.h"
 #include "garage_common.h"
+#include "garage_tools_version.h"
 #include "logging/logging.h"
 #include "ostree_http_repo.h"
 #include "ostree_object.h"
@@ -61,7 +62,7 @@ int main(int argc, char **argv) {
       return EXIT_SUCCESS;
     }
     if (vm.count("version") != 0) {
-      LOG_INFO << "Current garage-check version is: " << GARAGE_TOOLS_VERSION;
+      LOG_INFO << "Current garage-check version is: " << garage_tools_version();
       exit(EXIT_SUCCESS);
     }
     po::notify(vm);

--- a/src/sota_tools/garage_deploy.cc
+++ b/src/sota_tools/garage_deploy.cc
@@ -7,6 +7,7 @@
 #include "authenticate.h"
 #include "deploy.h"
 #include "garage_common.h"
+#include "garage_tools_version.h"
 #include "logging/logging.h"
 #include "ostree_http_repo.h"
 
@@ -51,7 +52,7 @@ int main(int argc, char **argv) {
       return EXIT_SUCCESS;
     }
     if (vm.count("version") != 0) {
-      LOG_INFO << "Current garage-deploy version is: " << GARAGE_TOOLS_VERSION;
+      LOG_INFO << "Current garage-deploy version is: " << garage_tools_version();
       exit(EXIT_SUCCESS);
     }
     po::notify(vm);

--- a/src/sota_tools/garage_push.cc
+++ b/src/sota_tools/garage_push.cc
@@ -6,6 +6,7 @@
 #include "accumulator.h"
 #include "deploy.h"
 #include "garage_common.h"
+#include "garage_tools_version.h"
 #include "logging/logging.h"
 #include "ostree_dir_repo.h"
 #include "ostree_repo.h"
@@ -48,7 +49,7 @@ int main(int argc, char **argv) {
       return EXIT_SUCCESS;
     }
     if (vm.count("version") != 0) {
-      LOG_INFO << "Current garage-push version is: " << GARAGE_TOOLS_VERSION;
+      LOG_INFO << "Current garage-push version is: " << garage_tools_version();
       exit(EXIT_SUCCESS);
     }
     po::notify(vm);

--- a/src/sota_tools/garage_tools_version.cc
+++ b/src/sota_tools/garage_tools_version.cc
@@ -1,0 +1,3 @@
+#include "garage_tools_version.h"
+
+const char *garage_tools_version() { return GARAGE_TOOLS_VERSION; }

--- a/src/sota_tools/garage_tools_version.h
+++ b/src/sota_tools/garage_tools_version.h
@@ -1,0 +1,8 @@
+#ifndef GARAGE_TOOLS_VERSION_H_
+#define GARAGE_TOOLS_VERSION_H_
+
+// Same purpose as aktualizr_version.h
+
+const char *garage_tools_version();
+
+#endif  // GARAGE_TOOLS_VERSION_H_


### PR DESCRIPTION
Would be nice to have that as part of CI, it could maybe halve the test times. I just need to figure out why caching seems to be disabled on our shared runners.

In the meantime, it can already be used for development. The test case is:

```
apt install ccache
[...]
cd build1; cmake .. -DXXXX && ninja
cd build2; cmake .. -DXXXX && ninja  # (with same CMake options), should be MUCH faster
```