### PR TITLE
httpclient: Add ability to pass custom headers

### DIFF
--- a/src/libaktualizr/http/httpclient.cc
+++ b/src/libaktualizr/http/httpclient.cc
@@ -46,7 +46,8 @@ static size_t writeString(void* contents, size_t size, size_t nmemb, void* userp
   return size * nmemb;
 }
 
-HttpClient::HttpClient() : user_agent(std::string("Aktualizr/") + aktualizr_version()) {
+HttpClient::HttpClient(const std::vector<std::string>* extra_headers)
+    : user_agent(std::string("Aktualizr/") + aktualizr_version()) {
   curl = curl_easy_init();
   if (curl == nullptr) {
     throw std::runtime_error("Could not initialize curl");
@@ -65,6 +66,12 @@ HttpClient::HttpClient() : user_agent(std::string("Aktualizr/") + aktualizr_vers
 
   headers = curl_slist_append(headers, "Content-Type: application/json");
   headers = curl_slist_append(headers, "Accept: */*");
+
+  if (extra_headers != nullptr) {
+    for (const auto& header : *extra_headers) {
+      headers = curl_slist_append(headers, header.c_str());
+    }
+  }
   curlEasySetoptWrapper(curl, CURLOPT_HTTPHEADER, headers);
   curlEasySetoptWrapper(curl, CURLOPT_USERAGENT, user_agent.c_str());
 }

--- a/src/libaktualizr/http/httpclient.h
+++ b/src/libaktualizr/http/httpclient.h
@@ -27,7 +27,7 @@ class CurlGlobalInitWrapper {
 
 class HttpClient : public HttpInterface {
  public:
-  HttpClient();
+  HttpClient(const std::vector<std::string> *extra_headers = nullptr);
   HttpClient(const HttpClient & /*curl_in*/);
   ~HttpClient() override;
   HttpResponse get(const std::string &url, int64_t maxsize) override;

--- a/src/libaktualizr/http/httpclient_test.cc
+++ b/src/libaktualizr/http/httpclient_test.cc
@@ -30,6 +30,14 @@ TEST(GetTest, get_performed) {
   EXPECT_EQ(response["path"].asString(), path);
 }
 
+TEST(GetTestWithHeaders, get_performed) {
+  std::vector<std::string> headers = {"Authorization: Bearer token"};
+  HttpClient http(&headers);
+  std::string path = "/auth_call";
+  Json::Value response = http.get(server + path, HttpInterface::kNoLimit).getJson();
+  EXPECT_EQ(response["status"].asString(), "good");
+}
+
 /* Reject http GET responses that exceed size limit. */
 TEST(GetTest, download_size_limit) {
   HttpClient http;


### PR DESCRIPTION
This allows custom users of libaktualizr to pass custom headers
with HTTP requests sent to the server.

Signed-off-by: Andy Doan <andy@foundries.io>