### PR TITLE
Don't download targets with a length of 0.

### DIFF
--- a/src/libaktualizr/package_manager/packagemanagerinterface.cc
+++ b/src/libaktualizr/package_manager/packagemanagerinterface.cc
@@ -92,6 +92,10 @@ bool PackageManagerInterface::fetchTarget(const Uptane::Target& target, Uptane::
       LOG_INFO << "Image already downloaded skipping download";
       return true;
     }
+    if (target.length() == 0) {
+      LOG_WARNING << "Skipping download of target with length 0";
+      return true;
+    }
     DownloadMetaStruct ds(target, std::move(progress_cb), token);
     if (target_exists) {
       ds.downloaded_length = target_exists->first;


### PR DESCRIPTION
Prevents a divide-by-zero error.

I found this while seeing what happens when aktualizr tries to download an OSTree target with the fake package manager. With this fix, it "works" as much as downloading anything else "works" with the fake package manager.