### PR TITLE
Fix/ota 3057/url determination

### DIFF
--- a/docs/aktualizr-repo.adoc
+++ b/docs/aktualizr-repo.adoc
@@ -73,14 +73,14 @@ aktualizr-repo --path <repo path> --command adddelegation --dname <delegated rol
 
 To add a target to a delegated role, add the `--dname` parameter to the `image` command. The targetname must match the pattern supplied in `--dpattern` to the `adddelegation` command.
 ```
-aktualizr-repo --path <repo path> --command image --filename <image name> --targetname <target name> --dname <delegated role name>
+aktualizr-repo --path <repo path> --command image --filename <image name> --targetname <target name> --hwid <hardware ID> --dname <delegated role name>
 ```
 
 ==== Generating metadata without a real file
 
 To add a target to the images metadata without providing an actual file, you can supply alternative parameters to the `image` command:
 ```
-aktualizr-repo --path <repo path> --command image --targetname <target name> --targetsha256 <target SHA256 hash> --targetsha512 <target SHA512 hash> --targetlength <target length>
+aktualizr-repo --path <repo path> --command image --targetname <target name> --targetsha256 <target SHA256 hash> --targetsha512 <target SHA512 hash> --targetlength <target length> --hwid <hardware ID>
 ```
 
 ==== Advanced director metadata control
@@ -101,3 +101,17 @@ To sign arbitrary metadata with one of the Uptane keys, use the `sign` command:
 ```
 aktualizr-repo --path <repo path> --command sign --repotype <director|image> --keyname <role name of key> < <input data>
 ```
+
+==== Add custom URLs
+
+To add a custom URL to an image in the Targets metadata of the Images repository:
+```
+aktualizr-repo --path <repo path> --command image --filename <image name> --targetname <target name> --hwid <hardware ID> --url <URL>
+```
+
+To add a custom URL to an image in the Targets metadata of the Director:
+```
+aktualizr-repo --path <repo path> --command addtarget --targetname <image name> --hwid <hardware ID> --serial <ECU serial> --url <URL>
+```
+
+If a custom URL is set in both sets of metadata, libaktualizr will use the URL from the Director.

--- a/src/aktualizr_repo/director_repo.cc
+++ b/src/aktualizr_repo/director_repo.cc
@@ -1,7 +1,7 @@
 #include "director_repo.h"
 
 void DirectorRepo::addTarget(const std::string &target_name, const Json::Value &target, const std::string &hardware_id,
-                             const std::string &ecu_serial) {
+                             const std::string &ecu_serial, const std::string &url) {
   const boost::filesystem::path current = path_ / "repo/director/targets.json";
   const boost::filesystem::path staging = path_ / "repo/director/staging/targets.json";
 
@@ -17,6 +17,11 @@ void DirectorRepo::addTarget(const std::string &target_name, const Json::Value &
   director_targets["targets"][target_name] = target;
   director_targets["targets"][target_name]["custom"].removeMember("hardwareIds");
   director_targets["targets"][target_name]["custom"]["ecuIdentifiers"][ecu_serial]["hardwareId"] = hardware_id;
+  if (!url.empty()) {
+    director_targets["targets"][target_name]["custom"]["uri"] = url;
+  } else {
+    director_targets["targets"][target_name]["custom"].removeMember("uri");
+  }
   director_targets["version"] = (Utils::parseJSONFile(current)["signed"]["version"].asUInt()) + 1;
   Utils::writeFile(staging, Utils::jsonToCanonicalStr(director_targets));
   updateRepo();

--- a/src/aktualizr_repo/director_repo.h
+++ b/src/aktualizr_repo/director_repo.h
@@ -8,7 +8,7 @@ class DirectorRepo : public Repo {
   DirectorRepo(boost::filesystem::path path, const std::string &expires, std::string correlation_id)
       : Repo(Uptane::RepositoryType::Director(), std::move(path), expires, std::move(correlation_id)) {}
   void addTarget(const std::string &target_name, const Json::Value &target, const std::string &hardware_id,
-                 const std::string &ecu_serial);
+                 const std::string &ecu_serial, const std::string &url);
   void revokeTargets(const std::vector<std::string> &targets_to_remove);
   void signTargets();
   void emptyTargets();

--- a/src/aktualizr_repo/image_repo.cc
+++ b/src/aktualizr_repo/image_repo.cc
@@ -19,7 +19,7 @@ void ImageRepo::addImage(const std::string &name, Json::Value &target, const std
 }
 
 void ImageRepo::addBinaryImage(const boost::filesystem::path &image_path, const boost::filesystem::path &targetname,
-                               const std::string &hardware_id, const Delegation &delegation) {
+                               const std::string &hardware_id, const std::string &url, const Delegation &delegation) {
   boost::filesystem::path repo_dir(path_ / "repo/image");
 
   boost::filesystem::path targets_path = repo_dir / "targets";
@@ -37,11 +37,14 @@ void ImageRepo::addBinaryImage(const boost::filesystem::path &image_path, const 
   target["hashes"]["sha256"] = boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(image)));
   target["hashes"]["sha512"] = boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha512digest(image)));
   target["custom"]["targetFormat"] = "BINARY";
+  if (!url.empty()) {
+    target["custom"]["uri"] = url;
+  }
   addImage(targetname.string(), target, hardware_id, delegation);
 }
 
 void ImageRepo::addCustomImage(const std::string &name, const Uptane::Hash &hash, const uint64_t length,
-                               const std::string &hardware_id, const Delegation &delegation,
+                               const std::string &hardware_id, const std::string &url, const Delegation &delegation,
                                const Json::Value &custom) {
   Json::Value target;
   target["length"] = Json::UInt(length);
@@ -51,6 +54,9 @@ void ImageRepo::addCustomImage(const std::string &name, const Uptane::Hash &hash
     target["hashes"]["sha512"] = hash.HashString();
   }
   target["custom"] = custom;
+  if (!url.empty()) {
+    target["custom"]["uri"] = url;
+  }
   addImage(name, target, hardware_id, delegation);
 }
 

--- a/src/aktualizr_repo/image_repo.h
+++ b/src/aktualizr_repo/image_repo.h
@@ -8,9 +8,10 @@ class ImageRepo : public Repo {
   ImageRepo(boost::filesystem::path path, const std::string &expires, std::string correlation_id)
       : Repo(Uptane::RepositoryType::Image(), std::move(path), expires, std::move(correlation_id)) {}
   void addBinaryImage(const boost::filesystem::path &image_path, const boost::filesystem::path &targetname,
-                      const std::string &hardware_id, const Delegation &delegation = {});
+                      const std::string &hardware_id, const std::string &url, const Delegation &delegation = {});
   void addCustomImage(const std::string &name, const Uptane::Hash &hash, uint64_t length,
-                      const std::string &hardware_id, const Delegation &delegation, const Json::Value &custom = {});
+                      const std::string &hardware_id, const std::string &url, const Delegation &delegation,
+                      const Json::Value &custom = {});
   void addDelegation(const Uptane::Role &name, const Uptane::Role &parent_role, const std::string &path,
                      bool terminating, KeyType key_type);
   void revokeDelegation(const Uptane::Role &name);

--- a/src/aktualizr_repo/main.cc
+++ b/src/aktualizr_repo/main.cc
@@ -51,7 +51,8 @@ int main(int argc, char **argv) {
     ("dname", po::value<std::string>(), "delegated role name")
     ("dterm", po::bool_switch(), "if the created delegated role is terminating")
     ("dparent", po::value<std::string>()->default_value("targets"), "delegated role parent name")
-    ("dpattern", po::value<std::string>(), "delegated file path pattern");
+    ("dpattern", po::value<std::string>(), "delegated file path pattern")
+    ("url", po::value<std::string>(), "custom download URL");
 
   // clang-format on
 
@@ -115,8 +116,12 @@ int main(int argc, char **argv) {
           }
           std::cout << "Added a target " << targetname << " to a delegated role " << dname << std::endl;
         }
+        std::string url;
+        if (vm.count("url") != 0) {
+          url = vm["url"].as<std::string>();
+        }
         if (vm.count("filename") > 0) {
-          repo.addImage(vm["filename"].as<boost::filesystem::path>(), targetname, hwid, delegation);
+          repo.addImage(vm["filename"].as<boost::filesystem::path>(), targetname, hwid, url, delegation);
           std::cout << "Added a target " << targetname << " to the images metadata" << std::endl;
         } else {
           if ((vm.count("targetsha256") == 0 && vm.count("targetsha512") == 0) || vm.count("targetlength") == 0) {
@@ -142,7 +147,8 @@ int main(int argc, char **argv) {
             custom = Json::Value();
             custom["targetFormat"] = vm["targetformat"].as<std::string>();
           }
-          repo.addCustomImage(targetname.string(), *hash, vm["targetlength"].as<uint64_t>(), hwid, delegation, custom);
+          repo.addCustomImage(targetname.string(), *hash, vm["targetlength"].as<uint64_t>(), hwid, url, delegation,
+                              custom);
           std::cout << "Added a custom image target " << targetname.string() << std::endl;
         }
       } else if (command == "addtarget") {
@@ -153,7 +159,11 @@ int main(int argc, char **argv) {
         const std::string targetname = vm["targetname"].as<std::string>();
         const std::string hwid = vm["hwid"].as<std::string>();
         const std::string serial = vm["serial"].as<std::string>();
-        repo.addTarget(targetname, hwid, serial);
+        std::string url;
+        if (vm.count("url") != 0) {
+          url = vm["url"].as<std::string>();
+        }
+        repo.addTarget(targetname, hwid, serial, url);
         std::cout << "Added target " << targetname << " to director targets metadata for ECU with serial " << serial
                   << " and hardware ID " << hwid << std::endl;
       } else if (command == "adddelegation") {

--- a/src/aktualizr_repo/uptane_repo.cc
+++ b/src/aktualizr_repo/uptane_repo.cc
@@ -10,12 +10,12 @@ void UptaneRepo::generateRepo(KeyType key_type) {
   image_repo_.generateRepo(key_type);
 }
 void UptaneRepo::addTarget(const std::string &target_name, const std::string &hardware_id,
-                           const std::string &ecu_serial) {
+                           const std::string &ecu_serial, const std::string &url) {
   auto target = image_repo_.getTarget(target_name);
   if (target == Json::nullValue) {
     throw std::runtime_error("No such " + target_name + " target in the image repository");
   }
-  director_repo_.addTarget(target_name, target, hardware_id, ecu_serial);
+  director_repo_.addTarget(target_name, target, hardware_id, ecu_serial, url);
 }
 
 void UptaneRepo::addDelegation(const Uptane::Role &name, const Uptane::Role &parent_role, const std::string &path,
@@ -29,13 +29,13 @@ void UptaneRepo::revokeDelegation(const Uptane::Role &name) {
 }
 
 void UptaneRepo::addImage(const boost::filesystem::path &image_path, const boost::filesystem::path &targetname,
-                          const std::string &hardware_id, const Delegation &delegation) {
-  image_repo_.addBinaryImage(image_path, targetname, hardware_id, delegation);
+                          const std::string &hardware_id, const std::string &url, const Delegation &delegation) {
+  image_repo_.addBinaryImage(image_path, targetname, hardware_id, url, delegation);
 }
 void UptaneRepo::addCustomImage(const std::string &name, const Uptane::Hash &hash, uint64_t length,
-                                const std::string &hardware_id, const Delegation &delegation,
+                                const std::string &hardware_id, const std::string &url, const Delegation &delegation,
                                 const Json::Value &custom) {
-  image_repo_.addCustomImage(name, hash, length, hardware_id, delegation, custom);
+  image_repo_.addCustomImage(name, hash, length, hardware_id, url, delegation, custom);
 }
 
 void UptaneRepo::signTargets() { director_repo_.signTargets(); }

--- a/src/aktualizr_repo/uptane_repo.h
+++ b/src/aktualizr_repo/uptane_repo.h
@@ -8,14 +8,15 @@ class UptaneRepo {
  public:
   UptaneRepo(const boost::filesystem::path &path, const std::string &expires, const std::string &correlation_id);
   void generateRepo(KeyType key_type = KeyType::kRSA2048);
-  void addTarget(const std::string &target_name, const std::string &hardware_id, const std::string &ecu_serial);
+  void addTarget(const std::string &target_name, const std::string &hardware_id, const std::string &ecu_serial,
+                 const std::string &url);
   void addImage(const boost::filesystem::path &image_path, const boost::filesystem::path &targetname,
-                const std::string &hardware_id, const Delegation &delegation);
+                const std::string &hardware_id, const std::string &url, const Delegation &delegation);
   void addDelegation(const Uptane::Role &name, const Uptane::Role &parent_role, const std::string &path,
                      bool terminating, KeyType key_type);
   void revokeDelegation(const Uptane::Role &name);
   void addCustomImage(const std::string &name, const Uptane::Hash &hash, uint64_t length,
-                      const std::string &hardware_id, const Delegation &delegation = {},
+                      const std::string &hardware_id, const std::string &url, const Delegation &delegation = {},
                       const Json::Value &custom = {});
   void signTargets();
   void emptyTargets();

--- a/src/libaktualizr/primary/CMakeLists.txt
+++ b/src/libaktualizr/primary/CMakeLists.txt
@@ -31,9 +31,12 @@ else (BUILD_OSTREE)
 endif (BUILD_OSTREE)
 
 add_aktualizr_test(NAME reportqueue SOURCES reportqueue_test.cc PROJECT_WORKING_DIRECTORY LIBRARIES PUBLIC aktualizr_repo_lib)
-add_aktualizr_test(NAME emptytargets SOURCES empty_targets_test.cc PROJECT_WORKING_DIRECTORY
+add_aktualizr_test(NAME empty_targets SOURCES empty_targets_test.cc PROJECT_WORKING_DIRECTORY
                    ARGS "$<TARGET_FILE:aktualizr-repo>" LIBRARIES aktualizr_repo_lib)
-target_link_libraries(t_emptytargets virtual_secondary)
+target_link_libraries(t_empty_targets virtual_secondary)
+add_aktualizr_test(NAME custom_url SOURCES custom_url_test.cc PROJECT_WORKING_DIRECTORY
+                   ARGS "$<TARGET_FILE:aktualizr-repo>" LIBRARIES aktualizr_repo_lib)
+target_link_libraries(t_custom_url virtual_secondary)
 
 add_aktualizr_test(NAME device_cred_prov SOURCES device_cred_prov_test.cc PROJECT_WORKING_DIRECTORY LIBRARIES PUBLIC aktualizr_repo_lib)
 set_tests_properties(test_device_cred_prov PROPERTIES LABELS "crypto")

--- a/src/libaktualizr/primary/custom_url_test.cc
+++ b/src/libaktualizr/primary/custom_url_test.cc
@@ -1,0 +1,112 @@
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "httpfake.h"
+#include "primary/aktualizr.h"
+#include "test_utils.h"
+#include "uptane_test_common.h"
+
+boost::filesystem::path aktualizr_repo_path;
+
+class HttpCheckUrl : public HttpFake {
+ public:
+  HttpCheckUrl(const boost::filesystem::path &test_dir_in, const boost::filesystem::path &meta_dir_in)
+      : HttpFake(test_dir_in, "", meta_dir_in) {}
+  HttpResponse download(const std::string &url, curl_write_callback write_cb, curl_xferinfo_callback progress_cb,
+                        void *userp, curl_off_t from) override {
+    (void)write_cb;
+    (void)progress_cb;
+    (void)userp;
+    (void)from;
+
+    url_ = url;
+    return HttpResponse("", 200, CURLE_OK, "");
+  }
+
+  std::string url_;
+};
+
+/*
+ * If the URL from the Director is unset, but the URL from the Images repo is
+ * set, use that.
+ */
+TEST(Aktualizr, ImagesCustomUrl) {
+  TemporaryDirectory temp_dir;
+  TemporaryDirectory meta_dir;
+  auto http = std::make_shared<HttpCheckUrl>(temp_dir.Path(), meta_dir.Path() / "repo");
+  Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
+  logger_set_threshold(boost::log::trivial::trace);
+
+  Process akt_repo(aktualizr_repo_path.string());
+  akt_repo.run({"generate", "--path", meta_dir.PathString(), "--correlationid", "abc123"});
+  akt_repo.run({"image", "--path", meta_dir.PathString(), "--filename", "tests/test_data/firmware.txt", "--targetname",
+                "firmware.txt", "--hwid", "primary_hw", "--url", "test-url"});
+  akt_repo.run({"addtarget", "--path", meta_dir.PathString(), "--targetname", "firmware.txt", "--hwid", "primary_hw",
+                "--serial", "CA:FE:A6:D2:84:9D"});
+  akt_repo.run({"signtargets", "--path", meta_dir.PathString(), "--correlationid", "abc123"});
+  // Work around inconsistent directory naming.
+  Utils::copyDir(meta_dir.Path() / "repo/image", meta_dir.Path() / "repo/repo");
+
+  auto storage = INvStorage::newStorage(conf.storage);
+  UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
+  aktualizr.Initialize();
+  EXPECT_EQ(http->url_, "");
+
+  result::UpdateCheck update_result = aktualizr.CheckUpdates().get();
+  EXPECT_EQ(update_result.status, result::UpdateStatus::kUpdatesAvailable);
+
+  result::Download download_result = aktualizr.Download(update_result.updates).get();
+  EXPECT_EQ(http->url_, "test-url");
+}
+
+/*
+ * If the URL is set by both the Director and Images repo, use the version from
+ * the Director.
+ */
+TEST(Aktualizr, BothCustomUrl) {
+  TemporaryDirectory temp_dir;
+  TemporaryDirectory meta_dir;
+  auto http = std::make_shared<HttpCheckUrl>(temp_dir.Path(), meta_dir.Path() / "repo");
+  Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
+  logger_set_threshold(boost::log::trivial::trace);
+
+  Process akt_repo(aktualizr_repo_path.string());
+  akt_repo.run({"generate", "--path", meta_dir.PathString(), "--correlationid", "abc123"});
+  akt_repo.run({"image", "--path", meta_dir.PathString(), "--filename", "tests/test_data/firmware.txt", "--targetname",
+                "firmware.txt", "--hwid", "primary_hw", "--url", "test-url2"});
+  akt_repo.run({"addtarget", "--path", meta_dir.PathString(), "--targetname", "firmware.txt", "--hwid", "primary_hw",
+                "--serial", "CA:FE:A6:D2:84:9D", "--url", "test-url3"});
+  akt_repo.run({"signtargets", "--path", meta_dir.PathString(), "--correlationid", "abc123"});
+  // Work around inconsistent directory naming.
+  Utils::copyDir(meta_dir.Path() / "repo/image", meta_dir.Path() / "repo/repo");
+
+  auto storage = INvStorage::newStorage(conf.storage);
+  UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
+  aktualizr.Initialize();
+  EXPECT_EQ(http->url_, "");
+
+  result::UpdateCheck update_result = aktualizr.CheckUpdates().get();
+  EXPECT_EQ(update_result.status, result::UpdateStatus::kUpdatesAvailable);
+
+  result::Download download_result = aktualizr.Download(update_result.updates).get();
+  EXPECT_EQ(http->url_, "test-url3");
+}
+
+#ifndef __NO_MAIN__
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  if (argc != 2) {
+    std::cerr << "Error: " << argv[0] << " requires the path to the aktualizr-repo utility\n";
+    return EXIT_FAILURE;
+  }
+  aktualizr_repo_path = argv[1];
+
+  logger_init();
+  logger_set_threshold(boost::log::trivial::trace);
+
+  return RUN_ALL_TESTS();
+}
+#endif
+
+// vim: set tabstop=2 shiftwidth=2 expandtab:

--- a/src/libaktualizr/primary/empty_targets_test.cc
+++ b/src/libaktualizr/primary/empty_targets_test.cc
@@ -2,13 +2,10 @@
 
 #include <string>
 
-#include <boost/process.hpp>
-
 #include "httpfake.h"
 #include "primary/aktualizr.h"
 #include "test_utils.h"
 #include "uptane_test_common.h"
-
 #include "utilities/fault_injection.h"
 
 boost::filesystem::path aktualizr_repo_path;

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -41,8 +41,7 @@ class SotaUptaneClient {
 
   void initialize();
   void addNewSecondary(const std::shared_ptr<Uptane::SecondaryInterface> &sec);
-  result::Download downloadImages(const std::vector<Uptane::Target> &targets,
-                                  const api::FlowControlToken *token = nullptr);
+  result::Download downloadImages(std::vector<Uptane::Target> targets, const api::FlowControlToken *token = nullptr);
   void reportPause();
   void reportResume();
   void sendDeviceData();
@@ -116,7 +115,8 @@ class SotaUptaneClient {
 
   bool putManifestSimple(const Json::Value &custom = Json::nullValue);
   bool getNewTargets(std::vector<Uptane::Target> *new_targets, unsigned int *ecus_count = nullptr);
-  std::pair<bool, Uptane::Target> downloadImage(Uptane::Target target, const api::FlowControlToken *token = nullptr);
+  std::pair<bool, Uptane::Target> downloadImage(const Uptane::Target &target,
+                                                const api::FlowControlToken *token = nullptr);
   void rotateSecondaryRoot(Uptane::RepositoryType repo, Uptane::SecondaryInterface &secondary);
   bool updateDirectorMeta();
   bool checkDirectorMetaOffline();

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -41,7 +41,8 @@ class SotaUptaneClient {
 
   void initialize();
   void addNewSecondary(const std::shared_ptr<Uptane::SecondaryInterface> &sec);
-  result::Download downloadImages(std::vector<Uptane::Target> targets, const api::FlowControlToken *token = nullptr);
+  result::Download downloadImages(const std::vector<Uptane::Target> &targets,
+                                  const api::FlowControlToken *token = nullptr);
   void reportPause();
   void reportResume();
   void sendDeviceData();

--- a/src/libaktualizr/uptane/tuf.cc
+++ b/src/libaktualizr/uptane/tuf.cc
@@ -218,8 +218,9 @@ bool Target::MatchTarget(const Target &t2) const {
   // type_ (targetFormat) is only provided by the Images repo.
   // ecus_ is only provided by the Images repo.
   // correlation_id_ is only provided by the Director.
-  // uri_ is unchecked because Uptane mentions it should be provided by the
-  // Director, although it can be provided by the Image repository as well.
+  // uri_ is not matched. If the Director provides it, we use that. If not, but
+  // the Image repository does, use that. Otherwise, leave it empty and use the
+  // default.
   if (filename_ != t2.filename_) {
     return false;
   }

--- a/src/libaktualizr/uptane/tuf.h
+++ b/src/libaktualizr/uptane/tuf.h
@@ -245,6 +245,7 @@ class Target {
   uint64_t length() const { return length_; }
   bool IsValid() const { return valid; }
   std::string uri() const { return uri_; };
+  void setUri(std::string uri) { uri_ = std::move(uri); };
   bool MatchHash(const Hash &hash) const;
 
   bool IsForSecondary(const EcuSerial &ecuIdentifier) const {

--- a/tests/metafake.h
+++ b/tests/metafake.h
@@ -31,17 +31,17 @@ class MetaFake {
 
       // add image for "has update" meta
       file_name = "dummy_firmware.txt";
-      repo.addImage(work_dir / file_name, file_name, "dummy", delegation);
+      repo.addImage(work_dir / file_name, file_name, "dummy", "", delegation);
 
       file_name = "primary_firmware.txt";
       hwid = "primary_hw";
-      repo.addImage(work_dir / file_name, file_name, hwid, delegation);
-      repo.addTarget(file_name.string(), hwid, "CA:FE:A6:D2:84:9D");
+      repo.addImage(work_dir / file_name, file_name, hwid, "", delegation);
+      repo.addTarget(file_name.string(), hwid, "CA:FE:A6:D2:84:9D", "");
 
       file_name = "secondary_firmware.txt";
       hwid = "secondary_hw";
-      repo.addImage(work_dir / file_name, file_name, hwid, delegation);
-      repo.addTarget(file_name.string(), hwid, "secondary_ecu_serial");
+      repo.addImage(work_dir / file_name, file_name, hwid, "", delegation);
+      repo.addTarget(file_name.string(), hwid, "secondary_ecu_serial", "");
 
       repo.signTargets();
       rename("_hasupdates");
@@ -50,7 +50,7 @@ class MetaFake {
       restore();
 
       file_name = "dummy_firmware.txt";
-      repo.addImage(work_dir / file_name, file_name, "dummy", delegation);
+      repo.addImage(work_dir / file_name, file_name, "dummy", "", delegation);
 
       repo.signTargets();
       rename("_noupdates");
@@ -59,17 +59,17 @@ class MetaFake {
       restore();
 
       file_name = "dummy_firmware.txt";
-      repo.addImage(work_dir / file_name, file_name, "dummy", delegation);
+      repo.addImage(work_dir / file_name, file_name, "dummy", "", delegation);
 
       file_name = "secondary_firmware.txt";
       hwid = "sec_hw1";
-      repo.addImage(work_dir / file_name, file_name, hwid, delegation);
-      repo.addTarget(file_name.string(), hwid, "sec_serial1");
+      repo.addImage(work_dir / file_name, file_name, hwid, "", delegation);
+      repo.addTarget(file_name.string(), hwid, "sec_serial1", "");
 
       file_name = "secondary_firmware2.txt";
       hwid = "sec_hw2";
-      repo.addImage(work_dir / file_name, file_name, hwid, delegation);
-      repo.addTarget(file_name.string(), hwid, "sec_serial2");
+      repo.addImage(work_dir / file_name, file_name, hwid, "", delegation);
+      repo.addTarget(file_name.string(), hwid, "sec_serial2", "");
 
       repo.signTargets();
       rename("_multisec");


### PR DESCRIPTION
The most interesting part is in sotauptaneclient.cc, where if the custom URL is not set in the Director target metadata, we check if it is set in the Images repo target metadata and use that if it is.

A lot of the changes relate to aktualizr-repo, where I added parameters to set the custom URL.