### PR TITLE
Send device data before UptaneCycle or RunForever.

### DIFF
--- a/src/aktualizr_primary/main.cc
+++ b/src/aktualizr_primary/main.cc
@@ -158,8 +158,10 @@ int main(int argc, char *argv[]) {
       result::UpdateCheck update_result = aktualizr.CheckUpdates().get();
       aktualizr.Install(update_result.updates).get();
     } else if (run_mode == "once") {
+      aktualizr.SendDeviceData().get();
       aktualizr.UptaneCycle();
     } else {
+      aktualizr.SendDeviceData().get();
       aktualizr.RunForever().get();
     }
     r = EXIT_SUCCESS;


### PR DESCRIPTION
It was only being sent on the check run mode, but it should also be sent on once and full (the default).