### PR TITLE
Fix/ota 3059/target check sooner

### DIFF
--- a/src/libaktualizr/primary/CMakeLists.txt
+++ b/src/libaktualizr/primary/CMakeLists.txt
@@ -37,6 +37,9 @@ target_link_libraries(t_empty_targets virtual_secondary)
 add_aktualizr_test(NAME custom_url SOURCES custom_url_test.cc PROJECT_WORKING_DIRECTORY
                    ARGS "$<TARGET_FILE:aktualizr-repo>" LIBRARIES aktualizr_repo_lib)
 target_link_libraries(t_custom_url virtual_secondary)
+add_aktualizr_test(NAME target_mismatch SOURCES target_mismatch_test.cc PROJECT_WORKING_DIRECTORY
+                   ARGS "$<TARGET_FILE:aktualizr-repo>" LIBRARIES aktualizr_repo_lib)
+target_link_libraries(t_target_mismatch virtual_secondary)
 
 add_aktualizr_test(NAME device_cred_prov SOURCES device_cred_prov_test.cc PROJECT_WORKING_DIRECTORY LIBRARIES PUBLIC aktualizr_repo_lib)
 set_tests_properties(test_device_cred_prov PROPERTIES LABELS "crypto")

--- a/src/libaktualizr/primary/target_mismatch_test.cc
+++ b/src/libaktualizr/primary/target_mismatch_test.cc
@@ -1,0 +1,59 @@
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "httpfake.h"
+#include "primary/aktualizr.h"
+#include "test_utils.h"
+#include "uptane_test_common.h"
+
+boost::filesystem::path aktualizr_repo_path;
+
+/*
+ * Detect a mismatch in the Targets metadata from Director and Images repo.
+ */
+TEST(Aktualizr, HardwareMismatch) {
+  TemporaryDirectory temp_dir;
+  TemporaryDirectory meta_dir;
+  auto http = std::make_shared<HttpFake>(temp_dir.Path(), "", meta_dir.Path() / "repo");
+  Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
+  logger_set_threshold(boost::log::trivial::trace);
+
+  Process akt_repo(aktualizr_repo_path.string());
+  akt_repo.run({"generate", "--path", meta_dir.PathString(), "--correlationid", "abc123"});
+  // Note bad hardware ID in the image repo metadata. If we were to use an
+  // invalid value in the Director, it gets rejected even earlier.
+  akt_repo.run({"image", "--path", meta_dir.PathString(), "--filename", "tests/test_data/firmware.txt", "--targetname",
+                "firmware.txt", "--hwid", "hw-mismatch", "--url", "test-url"});
+  akt_repo.run({"addtarget", "--path", meta_dir.PathString(), "--targetname", "firmware.txt", "--hwid", "primary_hw",
+                "--serial", "CA:FE:A6:D2:84:9D"});
+  akt_repo.run({"signtargets", "--path", meta_dir.PathString()});
+  // Work around inconsistent directory naming.
+  Utils::copyDir(meta_dir.Path() / "repo/image", meta_dir.Path() / "repo/repo");
+
+  auto storage = INvStorage::newStorage(conf.storage);
+  UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
+  aktualizr.Initialize();
+
+  result::UpdateCheck update_result = aktualizr.CheckUpdates().get();
+  EXPECT_EQ(update_result.status, result::UpdateStatus::kError);
+  EXPECT_EQ(update_result.message, "Target mismatch.");
+}
+
+#ifndef __NO_MAIN__
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  if (argc != 2) {
+    std::cerr << "Error: " << argv[0] << " requires the path to the aktualizr-repo utility\n";
+    return EXIT_FAILURE;
+  }
+  aktualizr_repo_path = argv[1];
+
+  logger_init();
+  logger_set_threshold(boost::log::trivial::trace);
+
+  return RUN_ALL_TESTS();
+}
+#endif
+
+// vim: set tabstop=2 shiftwidth=2 expandtab:

--- a/src/libaktualizr/uptane/uptane_test.cc
+++ b/src/libaktualizr/uptane/uptane_test.cc
@@ -778,18 +778,15 @@ TEST(Uptane, ProvisionOnServer) {
 
   // We need to fetch metadata, but we currently expect a target hash mismatch
   // since our update is bogus.
-  up->fetchMeta();  // TODO check that it failed with return value
+  auto result = up->fetchMeta();
+  EXPECT_EQ(result.status, result::UpdateStatus::kError);
+  EXPECT_EQ(result.message, "Could not update metadata.");
   EXPECT_EQ(http->manifest_count, 2);
 
-  // Testing downloading is not strictly necessary here and will not work due to
-  // the metadata concerns anyway.
+  // Test installation to make sure the metadata put to the server is correct.
+  // Fake the metadata without actually trying to download anything.
   std::vector<Uptane::Target> packages_to_install =
       UptaneTestCommon::makePackage(config.provision.primary_ecu_serial, config.provision.primary_ecu_hardware_id);
-  result::Download result = up->downloadImages(packages_to_install);
-  EXPECT_EQ(result.updates.size(), 0);
-  EXPECT_EQ(result.status, result::DownloadStatus::kError);
-
-  // Test installation to make sure the metadata put to the server is correct.
   up->uptaneInstall(packages_to_install);
   up->putManifest();
 


### PR DESCRIPTION
Note that this will soon be followed up with a PR that will move `uptaneOfflineIteration` to be used before downloading and installing so that metadata will get quickly re-checked before allowing either of those operations to proceed. We can optionally hold this back until that work is ready. That work will also expand the new target_mismatch_test.cc file. 