### PR TITLE
Configurable reboot command

### DIFF
--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -165,4 +165,5 @@ Options for configuring boot-specific behavior
 | `rollback_mode`        | `"none"`                        | Controls rollback on supported platforms, see link:{aktualizr-github-url}/docs/rollback.adoc[]. Options: `"none"`, `"uboot_generic"`, `"uboot_masked"`
 | `reboot_sentinel_dir`  | `"/var/run/aktualizr-session"`  | Base directory for reboot detection sentinel. Must reside in a temporary file system.
 | `reboot_sentinel_name` | `"need_reboot"`                 | Name of the reboot detection sentinel.
+| `reboot_command`       | `"/sbin/reboot"`                | Command to reboot the system after update completes. Applicable only if `uptane::force_install_completion` is set to `true`.
 |==========================================================================================

--- a/src/libaktualizr/bootloader/bootloader.h
+++ b/src/libaktualizr/bootloader/bootloader.h
@@ -29,6 +29,7 @@ class Bootloader {
 
   INvStorage& storage_;
   boost::filesystem::path reboot_sentinel_;
+  std::string reboot_command_;
   bool reboot_detect_supported_{false};
 };
 

--- a/src/libaktualizr/bootloader/bootloader_config.cc
+++ b/src/libaktualizr/bootloader/bootloader_config.cc
@@ -37,10 +37,12 @@ void BootloaderConfig::updateFromPropertyTree(const boost::property_tree::ptree&
   CopyFromConfig(rollback_mode, "rollback_mode", pt);
   CopyFromConfig(reboot_sentinel_dir, "reboot_sentinel_dir", pt);
   CopyFromConfig(reboot_sentinel_name, "reboot_sentinel_name", pt);
+  CopyFromConfig(reboot_command, "reboot_command", pt);
 }
 
 void BootloaderConfig::writeToStream(std::ostream& out_stream) const {
   writeOption(out_stream, rollback_mode, "rollback_mode");
   writeOption(out_stream, reboot_sentinel_dir, "reboot_sentinel_dir");
   writeOption(out_stream, reboot_sentinel_name, "reboot_sentinel_name");
+  writeOption(out_stream, reboot_command, "reboot_command");
 }

--- a/src/libaktualizr/bootloader/bootloader_config.h
+++ b/src/libaktualizr/bootloader/bootloader_config.h
@@ -12,6 +12,7 @@ struct BootloaderConfig {
   RollbackMode rollback_mode{RollbackMode::kBootloaderNone};
   boost::filesystem::path reboot_sentinel_dir{"/var/run/aktualizr-session"};
   boost::filesystem::path reboot_sentinel_name{"need_reboot"};
+  std::string reboot_command{"/sbin/reboot"};
 
   void updateFromPropertyTree(const boost::property_tree::ptree& pt);
   void writeToStream(std::ostream& out_stream) const;


### PR DESCRIPTION
This is replacement for https://github.com/advancedtelematic/aktualizr/pull/1148 to trigger the gitlab CI. 

This patch mainly aims to add a graceful way to reboot the system by
executing a user preferred reboot command rather than calling reboot
system call. The reboot command could be set in 'bootloader' section of
a config file, it defaults to be '/sbin/reboot'.

Signed-off-by: Mykhaylo Sul <ext-mykhaylo.sul@here.com>