### PR TITLE
Added exclusion of test code.

### DIFF
--- a/.ort.yml
+++ b/.ort.yml
@@ -1,0 +1,8 @@
+excludes:
+  paths:
+  - pattern: "tests/**"
+    reason: "TEST_TOOL_OF"
+    comment: "This directory contains tests which are not distributed."
+  - pattern: "third_party/googletest/**"
+    reason: "TEST_TOOL_OF"
+    comment: "This directory contains tests which are not distributed."

--- a/.ort.yml
+++ b/.ort.yml
@@ -1,8 +1,14 @@
 excludes:
   paths:
+  - pattern: "partial/extern/**"
+    reason: "TEST_TOOL_OF"
+    comment: "This directory contains external dependencies only used by examples which are not distributed."
   - pattern: "tests/**"
     reason: "TEST_TOOL_OF"
     comment: "This directory contains tests which are not distributed."
   - pattern: "third_party/googletest/**"
     reason: "TEST_TOOL_OF"
     comment: "This directory contains tests which are not distributed."
+  - pattern: "thirdparty.spdx"
+    reason: "TEST_TOOL_OF"
+    comment: "This file contains metadata which are not distributed."


### PR DESCRIPTION
The important part is to ignore the third-party libraries pulled in. ORT
mostly complains about Python libraries used by tuf-test-vectors. The
test code in the src directory is probably fine.