### PR TITLE
libaktualizr-c: don't set rpath for api-test

### DIFF
--- a/src/libaktualizr-c/test/CMakeLists.txt
+++ b/src/libaktualizr-c/test/CMakeLists.txt
@@ -1,6 +1,8 @@
 SET(TARGET_NAME api-test)
 SET(SOURCES api-test.c)
 
+SET(CMAKE_SKIP_RPATH TRUE)
+
 add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL ${SOURCES})
 add_dependencies(build_tests ${TARGET_NAME})
 target_link_libraries(${TARGET_NAME} aktualizr-c)


### PR DESCRIPTION
By default, cmake adds all paths to the shared libraries during the linking process to rpath and removes it only on install step. This makes bitbake unhappy.

Signed-off-by: Eugene Smirnov <evgenii.smirnov@here.com>