### PR TITLE
TEST Target: aktualizr-cycle-simple depends on OSTree lib

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -188,18 +188,21 @@ add_test(NAME test_ip_secondary
          COMMAND ${PROJECT_SOURCE_DIR}/tests/ipsecondary_test.py
          --build-dir ${PROJECT_BINARY_DIR} --src-dir ${PROJECT_SOURCE_DIR})
 
-add_executable(aktualizr-cycle-simple aktualizr_cycle_simple.cc)
-target_link_libraries(aktualizr-cycle-simple aktualizr_static_lib ${AKTUALIZR_EXTERNAL_LIBS})
-aktualizr_source_file_checks(aktualizr_cycle_simple.cc)
-add_dependencies(build_tests aktualizr-cycle-simple)
+if(BUILD_OSTREE)
+    add_executable(aktualizr-cycle-simple aktualizr_cycle_simple.cc)
+    target_link_libraries(aktualizr-cycle-simple aktualizr_static_lib ${AKTUALIZR_EXTERNAL_LIBS})
+    aktualizr_source_file_checks(aktualizr_cycle_simple.cc)
+    add_dependencies(build_tests aktualizr-cycle-simple)
 
-if(FAULT_INJECTION)
-    # run with a very small amount of tests on CI, should be more useful when
-    # run for several hours
-    add_test(NAME test_io_failure COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_io_failure.py
-        --akt-repo $<TARGET_FILE:aktualizr-repo> --akt-test $<TARGET_FILE:aktualizr-cycle-simple> -n 50 -j 10
-        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
-endif(FAULT_INJECTION)
+    if(FAULT_INJECTION)
+        # run with a very small amount of tests on CI, should be more useful when
+        # run for several hours
+        add_test(NAME test_io_failure COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_io_failure.py
+            --akt-repo $<TARGET_FILE:aktualizr-repo> --akt-test $<TARGET_FILE:aktualizr-cycle-simple> -n 50 -j 10
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    endif(FAULT_INJECTION)
+
+endif(BUILD_OSTREE)
 
 add_dependencies(qa check)
 


### PR DESCRIPTION
Signed-off-by: Kostiantyn Bushko <kbushko@intellias.com>

Test target "aktualizr-cycle-simple" indirectly depends on OSTree library since it use OstreeManager class.