### PR TITLE
Do not use the api_gateway.url.

### DIFF
--- a/docs/provisioning-methods-and-credentialszip.adoc
+++ b/docs/provisioning-methods-and-credentialszip.adoc
@@ -13,6 +13,7 @@ The following files are present in credentials.zip:
 [options="header"]
 |======================
 | Filename in zip | Purpose | Used by
+| api_gateway.url | URL for gateway to Director | garage-sign
 | treehub.json | URL and OAuth2 authentication for treehub and Uptane repo | garage-sign, garage-push, garage-deploy
 | client_auth.p12 | TLS client credentials for authentication with treehub | garage-push, garage-deploy
 | autoprov_credentials.p12 | TLS client credentials that are required when provisioning devices with shared credentials | aktualizr, aktualizr-cert-provider

--- a/tests/sota_tools/cert_generation/api_gateway.url
+++ b/tests/sota_tools/cert_generation/api_gateway.url
@@ -1,1 +1,0 @@
-https://localhost:1443/api/v3

--- a/tests/sota_tools/cert_generation/generate-zips.sh
+++ b/tests/sota_tools/cert_generation/generate-zips.sh
@@ -12,10 +12,18 @@ DEST_DIR="$1"
 mkdir -p "$DEST_DIR"
 trap 'rm -rf "$DEST_DIR"' ERR
 
+TREEHUB="{\
+  \"ostree\": {\
+    \"server\": \"https://localhost:1443/\"\
+  }\
+}"
+
+echo $TREEHUB > "$DEST_DIR/treehub.json"
+
 cp "$SRC_DIR/client_good.p12" "$DEST_DIR/client_auth.p12"
-zip -j "$DEST_DIR/good.zip" "$DEST_DIR/client_auth.p12" "$SRC_DIR/api_gateway.url"
+zip -j "$DEST_DIR/good.zip" "$DEST_DIR/client_auth.p12" "$DEST_DIR/treehub.json" "$SRC_DIR/tufrepo.url"
 rm "$DEST_DIR/client_auth.p12"
 
 cp "$SRC_DIR/client_bad.p12" "$DEST_DIR/client_auth.p12"
-zip -j "$DEST_DIR/bad.zip" "$DEST_DIR/client_auth.p12" "$SRC_DIR/api_gateway.url"
+zip -j "$DEST_DIR/bad.zip" "$DEST_DIR/client_auth.p12" "$DEST_DIR/treehub.json" "$SRC_DIR/tufrepo.url"
 rm "$DEST_DIR/client_auth.p12"

--- a/tests/sota_tools/cert_generation/tufrepo.url
+++ b/tests/sota_tools/cert_generation/tufrepo.url
@@ -1,0 +1,1 @@
+https://localhost:1443/


### PR DESCRIPTION
Continue to use the old URLs provided by treehub.url and the ostree.server field of treehub.json.

This is a partial revert of 67949117.