### PR TITLE
aktualizr-lite: Improve logic for pacman->getCurrent()

### DIFF
--- a/src/aktualizr_lite/CMakeLists.txt
+++ b/src/aktualizr_lite/CMakeLists.txt
@@ -15,10 +15,11 @@ add_test(test_aktualizr-lite
         ${PROJECT_SOURCE_DIR}/tests
         ${RUN_VALGRIND}
 )
+add_library(t_lite-mock SHARED ostree_mock.cc)
 
 endif(BUILD_OSTREE)
 
 add_aktualizr_test(NAME lite-version SOURCES version_test.cc)
 
-aktualizr_source_file_checks(main.cc version.h version_test.cc)
+aktualizr_source_file_checks(main.cc version.h version_test.cc ostree_mock.cc)
 # vim: set tabstop=4 shiftwidth=4 expandtab:

--- a/src/aktualizr_lite/ostree_mock.cc
+++ b/src/aktualizr_lite/ostree_mock.cc
@@ -1,0 +1,12 @@
+#include <ostree.h>
+
+extern "C" OstreeDeployment *ostree_sysroot_get_booted_deployment(OstreeSysroot *self) {
+  (void)self;
+  const char *hash = getenv("OSTREE_HASH");
+  return ostree_deployment_new(0, "dummy-os", hash, 1, hash, 1);
+}
+
+extern "C" const char *ostree_deployment_get_csum(OstreeDeployment *self) {
+  (void)self;
+  return getenv("OSTREE_HASH");
+}

--- a/src/aktualizr_lite/test_lite.sh
+++ b/src/aktualizr_lite/test_lite.sh
@@ -107,3 +107,10 @@ OSTREE_HASH=$sha LD_PRELOAD=$mock_ostree $valgrind $aklite --loglevel 1 -c $sota
 ostree admin status
 
 OSTREE_HASH=$sha LD_PRELOAD=$mock_ostree $valgrind $aklite --loglevel 1 -c $sota_dir/sota.toml update | grep "Updating to: Target(zlast"
+
+out=$(OSTREE_HASH="$sha" LD_PRELOAD=$mock_ostree $valgrind $aklite --loglevel 1 -c $sota_dir/sota.toml status)
+if [[ ! "$out" =~ "Active image is: zlast	sha256:$sha" ]] ; then
+    echo "ERROR: status incorrect:"
+    echo $out
+    exit 1
+fi

--- a/src/aktualizr_lite/test_lite.sh
+++ b/src/aktualizr_lite/test_lite.sh
@@ -7,6 +7,7 @@ akrepo_bin=$2
 tests_dir=$3
 #valgrind=$4
 valgrind=""
+mock_ostree=$(dirname $aklite)/libt_lite-mock.so
 
 dest_dir=$(mktemp -d)
 
@@ -85,7 +86,7 @@ EOF
 $valgrind $aklite -h | grep "Command to execute: status, list, update"
 
 ## Check that we can do the list command
-out=$($valgrind $aklite --loglevel 1 -c $sota_dir/sota.toml list)
+out=$(OSTREE_HASH="foobar" LD_PRELOAD=$mock_ostree $valgrind $aklite --loglevel 1 -c $sota_dir/sota.toml list)
 if [[ ! "$out" =~ "foo1" ]] ; then
     echo "ERROR: foo1 update missing"
     exit 1
@@ -102,7 +103,7 @@ sha=$(echo $update | cut -d\  -f2 | sed 's/\.0$//')
 echo "Adding new target: $name / $sha"
 add_target $name $sha
 
-$valgrind $aklite --loglevel 1 -c $sota_dir/sota.toml update --update-name $name
+OSTREE_HASH=$sha LD_PRELOAD=$mock_ostree $valgrind $aklite --loglevel 1 -c $sota_dir/sota.toml update --update-name $name
 ostree admin status
 
-$valgrind $aklite --loglevel 1 -c $sota_dir/sota.toml update | grep "Updating to: Target(zlast"
+OSTREE_HASH=$sha LD_PRELOAD=$mock_ostree $valgrind $aklite --loglevel 1 -c $sota_dir/sota.toml update | grep "Updating to: Target(zlast"

--- a/src/libaktualizr/package_manager/ostreemanager.cc
+++ b/src/libaktualizr/package_manager/ostreemanager.cc
@@ -272,8 +272,8 @@ Uptane::Target OstreeManager::getCurrent() const {
   storage_->loadPrimaryInstalledVersions(&installed_versions, nullptr, nullptr);
 
   // Version should be in installed versions
-  std::vector<Uptane::Target>::iterator it;
-  for (it = installed_versions.begin(); it != installed_versions.end(); it++) {
+  std::vector<Uptane::Target>::reverse_iterator it;
+  for (it = installed_versions.rbegin(); it != installed_versions.rend(); it++) {
     if (it->sha256Hash() == current_hash) {
       return *it;
     }

--- a/src/libaktualizr/package_manager/ostreemanager.cc
+++ b/src/libaktualizr/package_manager/ostreemanager.cc
@@ -271,7 +271,10 @@ Uptane::Target OstreeManager::getCurrent() const {
   std::vector<Uptane::Target> installed_versions;
   storage_->loadPrimaryInstalledVersions(&installed_versions, nullptr, nullptr);
 
-  // Version should be in installed versions
+  // Version should be in installed versions. Its possible that multiple
+  // targets could have the same sha256Hash. In this case the safest assumption
+  // is that the most recent (the reverse of the vector) target is what we
+  // should return.
   std::vector<Uptane::Target>::reverse_iterator it;
   for (it = installed_versions.rbegin(); it != installed_versions.rend(); it++) {
     if (it->sha256Hash() == current_hash) {

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -58,6 +58,7 @@ class SotaUptaneClient {
   bool isInstallCompletionRequired();
   void completeInstall();
   Uptane::LazyTargetsList allTargets();
+  Uptane::Target getCurrent() { return package_manager_->getCurrent(); }
 
   bool updateImagesMeta();  // TODO: make private once aktualizr has a proper TUF API
   bool checkImagesMetaOffline();


### PR DESCRIPTION
This is a 3 part change I've been carrying out-of-tree for a few weeks that I think makes aktualizr-lite act a little more like aktualizr. The first change allows aktualizr-lite to call getCurrent in CI. The second change finalizes installs in a similar way to the sotauptaneclient which then lets us change aktualizr-lite to use getCurrent the in last commit.