### PR TITLE
httpclient: Always set path to CA certs

### DIFF
--- a/src/libaktualizr/http/httpclient.cc
+++ b/src/libaktualizr/http/httpclient.cc
@@ -45,6 +45,7 @@ HttpClient::HttpClient(const std::vector<std::string>* extra_headers) {
   curlEasySetoptWrapper(curl, CURLOPT_NOSIGNAL, 1L);
   curlEasySetoptWrapper(curl, CURLOPT_TIMEOUT, 60L);
   curlEasySetoptWrapper(curl, CURLOPT_CONNECTTIMEOUT, 60L);
+  curlEasySetoptWrapper(curl, CURLOPT_CAPATH, Utils::getCaPath());
 
   // let curl use our write function
   curlEasySetoptWrapper(curl, CURLOPT_WRITEFUNCTION, writeString);

--- a/src/libaktualizr/utilities/utils.cc
+++ b/src/libaktualizr/utilities/utils.cc
@@ -777,6 +777,12 @@ const char *Utils::getUserAgent() {
 
 std::string Utils::user_agent_;
 
+void Utils::setCaPath(boost::filesystem::path path) { ca_path_ = std::move(path); }
+
+const char *Utils::getCaPath() { return ca_path_.c_str(); }
+
+boost::filesystem::path Utils::ca_path_{"/etc/ssl/certs"};
+
 TemporaryFile::TemporaryFile(const std::string &hint)
     : tmp_name_(SafeTempRoot::Get() / boost::filesystem::unique_path(std::string("%%%%-%%%%-").append(hint))) {}
 

--- a/src/libaktualizr/utilities/utils.h
+++ b/src/libaktualizr/utilities/utils.h
@@ -55,9 +55,13 @@ struct Utils {
   static void setUserAgent(std::string user_agent);
   static const char *getUserAgent();
 
+  static void setCaPath(boost::filesystem::path path);
+  static const char *getCaPath();
+
  private:
   static std::string storage_root_path_;
   static std::string user_agent_;
+  static boost::filesystem::path ca_path_;
 };
 
 /**


### PR DESCRIPTION
Fixes https://github.com/advancedtelematic/aktualizr/issues/1273

Some versions of OE don't explicitly set a default path to the
CA certs directory. This ensures its set and can be overidden if
needed.

Signed-off-by: Andy Doan <andy@foundries.io>