### PR TITLE
Don't send device data twice by default.

### DIFF
--- a/src/aktualizr_primary/main.cc
+++ b/src/aktualizr_primary/main.cc
@@ -161,7 +161,6 @@ int main(int argc, char *argv[]) {
       aktualizr.SendDeviceData().get();
       aktualizr.UptaneCycle();
     } else {
-      aktualizr.SendDeviceData().get();
       aktualizr.RunForever().get();
     }
     r = EXIT_SUCCESS;


### PR DESCRIPTION
This is a partial revert of 1df4c1652ee50b467bbcb09d519fb7bd9b558e09.

I overzealously added a SendDeviceData before the call to RunForever,
despite that RunForever also calls SendDeviceData. This removes that
redundancy.

This does not change the behavior of "aktualizr once" (which uses
UptaneCycle). It still calls SendDeviceData before UptaneCycle, which
seems to roughly match user expectations.