### PR TITLE
Fix/ota 3060/check targets before download

### DIFF
--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -169,14 +169,11 @@ static std::unique_ptr<Uptane::Target> find_target(const std::shared_ptr<SotaUpt
 }
 
 static int do_update(SotaUptaneClient &client, INvStorage &storage, Uptane::Target &target) {
-  std::vector<Uptane::Target> targets{target};
-  auto result = client.downloadImages(targets);
-  if (result.status != result::DownloadStatus::kSuccess &&
-      result.status != result::DownloadStatus::kNothingToDownload) {
-    LOG_ERROR << "Unable to download update: " + result.message;
+  if (!client.downloadImage(target).first) {
     return 1;
   }
 
+  // TODO make pacman->verifyTarget something we can get to via client->
   auto iresult = client.PackageInstall(target);
   if (iresult.result_code.num_code == data::ResultCode::Numeric::kNeedCompletion) {
     LOG_INFO << "Update complete. Please reboot the device to activate";

--- a/src/libaktualizr/package_manager/CMakeLists.txt
+++ b/src/libaktualizr/package_manager/CMakeLists.txt
@@ -38,7 +38,7 @@ if(BUILD_OSTREE)
                       ${PROJECT_SOURCE_DIR} ${PROJECT_BINARY_DIR})
     add_dependencies(build_tests make_ostree_sysroot)
 
-    add_aktualizr_test(NAME ostree SOURCES ostreemanager_test.cc PROJECT_WORKING_DIRECTORY NO_VALGRIND
+    add_aktualizr_test(NAME ostreemanager SOURCES ostreemanager_test.cc PROJECT_WORKING_DIRECTORY NO_VALGRIND
                        ARGS ${PROJECT_BINARY_DIR}/ostree_repo)
 
     if(BUILD_DOCKERAPP)

--- a/src/libaktualizr/package_manager/dockerappmanager.cc
+++ b/src/libaktualizr/package_manager/dockerappmanager.cc
@@ -108,3 +108,11 @@ data::InstallationResult DockerAppManager::install(const Uptane::Target &target)
   }
   return res;
 }
+
+TargetStatus DockerAppManager::verifyTarget(const Uptane::Target &target) const {
+  if (target.IsOstree()) {
+    return OstreeManager::verifyTarget(target);
+  }
+  // TODO: verify DockerApp targets
+  return TargetStatus::kGood;
+}

--- a/src/libaktualizr/package_manager/dockerappmanager.h
+++ b/src/libaktualizr/package_manager/dockerappmanager.h
@@ -16,6 +16,7 @@ class DockerAppManager : public OstreeManager {
   bool fetchTarget(const Uptane::Target &target, Uptane::Fetcher &fetcher, const KeyManager &keys,
                    FetcherProgressCb progress_cb, const api::FlowControlToken *token) override;
   data::InstallationResult install(const Uptane::Target &target) const override;
+  TargetStatus verifyTarget(const Uptane::Target &target) const override;
   std::string name() const override { return "ostree+docker-app"; }
 
  private:

--- a/src/libaktualizr/package_manager/ostreemanager.cc
+++ b/src/libaktualizr/package_manager/ostreemanager.cc
@@ -239,7 +239,7 @@ bool OstreeManager::fetchTarget(const Uptane::Target &target, Uptane::Fetcher &f
   return OstreeManager::pull(config.sysroot, config.ostree_server, keys, target, token, progress_cb).success;
 }
 
-bool OstreeManager::verifyTarget(const Uptane::Target &target) const {
+TargetStatus OstreeManager::verifyTarget(const Uptane::Target &target) const {
   const std::string refhash = target.sha256Hash();
   GError *error = nullptr;
 
@@ -248,7 +248,7 @@ bool OstreeManager::verifyTarget(const Uptane::Target &target) const {
   if (error != nullptr) {
     LOG_ERROR << "Could not get OSTree repo";
     g_error_free(error);
-    return false;
+    return TargetStatus::kNotFound;
   }
 
   GHashTable *ref_list = nullptr;
@@ -257,7 +257,7 @@ bool OstreeManager::verifyTarget(const Uptane::Target &target) const {
     g_hash_table_destroy(ref_list);  // OSTree creates the table with destroy notifiers, so no memory leaks expected
     // should never be greater than 1, but use >= for robustness
     if (length >= 1) {
-      return true;
+      return TargetStatus::kGood;
     }
   }
   if (error != nullptr) {
@@ -266,7 +266,7 @@ bool OstreeManager::verifyTarget(const Uptane::Target &target) const {
   }
 
   LOG_ERROR << "Could not find OSTree commit";
-  return false;
+  return TargetStatus::kNotFound;
 }
 
 Json::Value OstreeManager::getInstalledPackages() const {

--- a/src/libaktualizr/package_manager/ostreemanager.h
+++ b/src/libaktualizr/package_manager/ostreemanager.h
@@ -51,6 +51,7 @@ class OstreeManager : public PackageManagerInterface {
   data::InstallationResult finalizeInstall(const Uptane::Target &target) const override;
   bool fetchTarget(const Uptane::Target &target, Uptane::Fetcher &fetcher, const KeyManager &keys,
                    FetcherProgressCb progress_cb, const api::FlowControlToken *token) override;
+  bool verifyTarget(const Uptane::Target &target) const override;
 
   GObjectUniquePtr<OstreeDeployment> getStagedDeployment() const;
   static GObjectUniquePtr<OstreeSysroot> LoadSysroot(const boost::filesystem::path &path);

--- a/src/libaktualizr/package_manager/ostreemanager.h
+++ b/src/libaktualizr/package_manager/ostreemanager.h
@@ -51,7 +51,7 @@ class OstreeManager : public PackageManagerInterface {
   data::InstallationResult finalizeInstall(const Uptane::Target &target) const override;
   bool fetchTarget(const Uptane::Target &target, Uptane::Fetcher &fetcher, const KeyManager &keys,
                    FetcherProgressCb progress_cb, const api::FlowControlToken *token) override;
-  bool verifyTarget(const Uptane::Target &target) const override;
+  TargetStatus verifyTarget(const Uptane::Target &target) const override;
 
   GObjectUniquePtr<OstreeDeployment> getStagedDeployment() const;
   static GObjectUniquePtr<OstreeSysroot> LoadSysroot(const boost::filesystem::path &path);

--- a/src/libaktualizr/package_manager/packagemanagerfake_test.cc
+++ b/src/libaktualizr/package_manager/packagemanagerfake_test.cc
@@ -17,6 +17,10 @@
 
 /*
  * Verify a stored target.
+ * Verify that a target is unavailable.
+ * Reject a target whose hash does not match the metadata.
+ * Reject an oversized target.
+ * Reject an incomplete target.
  */
 TEST(PackageManagerFake, Verify) {
   TemporaryDirectory temp_dir;
@@ -26,30 +30,43 @@ TEST(PackageManagerFake, Verify) {
   std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
 
   Uptane::EcuMap primary_ecu{{Uptane::EcuSerial("primary"), Uptane::HardwareIdentifier("primary_hw")}};
-  Uptane::Target target_good("some-pkg", primary_ecu, {Uptane::Hash(Uptane::Hash::Type::kSha256, "hash-good")}, 4, "");
-  Uptane::Target target_bad("some-pkg", primary_ecu, {Uptane::Hash(Uptane::Hash::Type::kSha256, "hash-bad")}, 4, "");
+  const int length = 4;
+  uint8_t content[length];
+  memcpy(content, "good", length);
+  MultiPartSHA256Hasher hasher;
+  hasher.update(content, length);
+  const std::string hash = hasher.getHexDigest();
+  Uptane::Target target("some-pkg", primary_ecu, {Uptane::Hash(Uptane::Hash::Type::kSha256, hash)}, length, "");
 
   PackageManagerFake fakepm(config.pacman, storage, nullptr, nullptr);
-  EXPECT_FALSE(fakepm.verifyTarget(target_good));
+  // Target is not yet available.
+  EXPECT_EQ(fakepm.verifyTarget(target), TargetStatus::kNotFound);
 
-  // Write the target with a different hash.
-  {
-    std::unique_ptr<StorageTargetWHandle> fhandle = storage->allocateTargetFile(false, target_bad);
-    const uint8_t wb[] = "bad ";
-    fhandle->wfeed(wb, 4);
-    fhandle->wcommit();
-  }
-  EXPECT_FALSE(fakepm.verifyTarget(target_good));
+  // Target has a bad hash.
+  auto whandle = storage->allocateTargetFile(false, target);
+  uint8_t content_bad[length + 1];
+  memset(content_bad, 0, length + 1);
+  EXPECT_EQ(whandle->wfeed(content_bad, length), length);
+  whandle->wcommit();
+  EXPECT_EQ(fakepm.verifyTarget(target), TargetStatus::kHashMismatch);
 
-  // Write the target with the expected hash.
-  storage->removeTargetFile(target_good.filename());
-  {
-    std::unique_ptr<StorageTargetWHandle> fhandle = storage->allocateTargetFile(false, target_good);
-    const uint8_t wb[] = "good";
-    fhandle->wfeed(wb, 4);
-    fhandle->wcommit();
-  }
-  EXPECT_TRUE(fakepm.verifyTarget(target_good));
+  // Target is oversized.
+  whandle = storage->allocateTargetFile(false, target);
+  EXPECT_EQ(whandle->wfeed(content_bad, length + 1), length + 1);
+  whandle->wcommit();
+  EXPECT_EQ(fakepm.verifyTarget(target), TargetStatus::kOversized);
+
+  // Target is incomplete.
+  whandle = storage->allocateTargetFile(false, target);
+  EXPECT_EQ(whandle->wfeed(content, length - 1), length - 1);
+  whandle->wcommit();
+  EXPECT_EQ(fakepm.verifyTarget(target), TargetStatus::kIncomplete);
+
+  // Target is good.
+  whandle = storage->allocateTargetFile(false, target);
+  EXPECT_EQ(whandle->wfeed(content, length), length);
+  whandle->wcommit();
+  EXPECT_EQ(fakepm.verifyTarget(target), TargetStatus::kGood);
 }
 
 TEST(PackageManagerFake, FinalizeAfterReboot) {

--- a/src/libaktualizr/package_manager/packagemanagerinterface.cc
+++ b/src/libaktualizr/package_manager/packagemanagerinterface.cc
@@ -89,7 +89,7 @@ bool PackageManagerInterface::fetchTarget(const Uptane::Target& target, Uptane::
     }
     auto target_exists = storage_->checkTargetFile(target);
     if (target_exists && (*target_exists).first == target.length()) {
-      LOG_INFO << "Image already downloaded skipping download";
+      LOG_INFO << "Image already downloaded; skipping download";
       return true;
     }
     if (target.length() == 0) {
@@ -143,4 +143,9 @@ bool PackageManagerInterface::fetchTarget(const Uptane::Target& target, Uptane::
     LOG_WARNING << "Error while downloading a target: " << e.what();
   }
   return result;
+}
+
+bool PackageManagerInterface::verifyTarget(const Uptane::Target& target) const {
+  auto target_exists = storage_->checkTargetFile(target);
+  return !!target_exists;
 }

--- a/src/libaktualizr/package_manager/packagemanagerinterface.h
+++ b/src/libaktualizr/package_manager/packagemanagerinterface.h
@@ -29,6 +29,8 @@ enum class TargetStatus {
   kOversized,
   /* Target was found, but hash did not match the metadata. */
   kHashMismatch,
+  /* Target was found and has valid metadata but the content is not suitable for the packagemanager */
+  kInvalid,
 };
 
 class PackageManagerInterface {

--- a/src/libaktualizr/package_manager/packagemanagerinterface.h
+++ b/src/libaktualizr/package_manager/packagemanagerinterface.h
@@ -15,6 +15,22 @@
 
 using FetcherProgressCb = std::function<void(const Uptane::Target&, const std::string&, unsigned int)>;
 
+/**
+ * Status of downloaded target.
+ */
+enum class TargetStatus {
+  /* Target has been downloaded and verified. */
+  kGood = 0,
+  /* Target was not found. */
+  kNotFound,
+  /* Target was found, but is incomplete. */
+  kIncomplete,
+  /* Target was found, but is larger than expected. */
+  kOversized,
+  /* Target was found, but hash did not match the metadata. */
+  kHashMismatch,
+};
+
 class PackageManagerInterface {
  public:
   PackageManagerInterface(PackageConfig pconfig, std::shared_ptr<INvStorage> storage,
@@ -33,7 +49,7 @@ class PackageManagerInterface {
   virtual bool imageUpdated() = 0;
   virtual bool fetchTarget(const Uptane::Target& target, Uptane::Fetcher& fetcher, const KeyManager& keys,
                            FetcherProgressCb progress_cb, const api::FlowControlToken* token);
-  virtual bool verifyTarget(const Uptane::Target& target) const;
+  virtual TargetStatus verifyTarget(const Uptane::Target& target) const;
 
   // only returns the version
   Json::Value getManifest(const Uptane::EcuSerial& ecu_serial) const {

--- a/src/libaktualizr/package_manager/packagemanagerinterface.h
+++ b/src/libaktualizr/package_manager/packagemanagerinterface.h
@@ -33,6 +33,7 @@ class PackageManagerInterface {
   virtual bool imageUpdated() = 0;
   virtual bool fetchTarget(const Uptane::Target& target, Uptane::Fetcher& fetcher, const KeyManager& keys,
                            FetcherProgressCb progress_cb, const api::FlowControlToken* token);
+  virtual bool verifyTarget(const Uptane::Target& target) const;
 
   // only returns the version
   Json::Value getManifest(const Uptane::EcuSerial& ecu_serial) const {

--- a/src/libaktualizr/primary/aktualizr_fullostree_test.cc
+++ b/src/libaktualizr/primary/aktualizr_fullostree_test.cc
@@ -65,12 +65,13 @@ TEST(Aktualizr, FullOstreeUpdate) {
     result::UpdateCheck update_result = aktualizr.CheckUpdates().get();
     ASSERT_EQ(update_result.status, result::UpdateStatus::kUpdatesAvailable);
     // Verify the target has not yet been downloaded.
-    EXPECT_FALSE(aktualizr.uptane_client()->package_manager_->verifyTarget(update_result.updates[0]));
+    EXPECT_EQ(aktualizr.uptane_client()->package_manager_->verifyTarget(update_result.updates[0]),
+              TargetStatus::kNotFound);
 
     result::Download download_result = aktualizr.Download(update_result.updates).get();
     EXPECT_EQ(download_result.status, result::DownloadStatus::kSuccess);
     // Verify the target has been downloaded.
-    EXPECT_TRUE(aktualizr.uptane_client()->package_manager_->verifyTarget(update_result.updates[0]));
+    EXPECT_EQ(aktualizr.uptane_client()->package_manager_->verifyTarget(update_result.updates[0]), TargetStatus::kGood);
 
     result::Install install_result = aktualizr.Install(update_result.updates).get();
     EXPECT_EQ(install_result.ecu_reports.size(), 1);
@@ -102,7 +103,7 @@ TEST(Aktualizr, FullOstreeUpdate) {
     Uptane::EcuMap primary_ecu{{Uptane::EcuSerial(conf.provision.primary_ecu_serial),
                                 Uptane::HardwareIdentifier(conf.provision.primary_ecu_hardware_id)}};
     Uptane::Target target_bad("some-pkg", primary_ecu, {Uptane::Hash(Uptane::Hash::Type::kSha256, "hash-bad")}, 4, "");
-    EXPECT_FALSE(aktualizr.uptane_client()->package_manager_->verifyTarget(target_bad));
+    EXPECT_EQ(aktualizr.uptane_client()->package_manager_->verifyTarget(target_bad), TargetStatus::kNotFound);
   }
 }
 

--- a/src/libaktualizr/primary/aktualizr_fullostree_test.cc
+++ b/src/libaktualizr/primary/aktualizr_fullostree_test.cc
@@ -59,15 +59,18 @@ TEST(Aktualizr, FullOstreeUpdate) {
   LOG_INFO << "conf: " << conf;
 
   {
-    Aktualizr aktualizr(conf);
-
+    UptaneTestCommon::TestAktualizr aktualizr(conf);
     aktualizr.Initialize();
 
     result::UpdateCheck update_result = aktualizr.CheckUpdates().get();
     ASSERT_EQ(update_result.status, result::UpdateStatus::kUpdatesAvailable);
+    // Verify the target has not yet been downloaded.
+    EXPECT_FALSE(aktualizr.uptane_client()->package_manager_->verifyTarget(update_result.updates[0]));
 
     result::Download download_result = aktualizr.Download(update_result.updates).get();
     EXPECT_EQ(download_result.status, result::DownloadStatus::kSuccess);
+    // Verify the target has been downloaded.
+    EXPECT_TRUE(aktualizr.uptane_client()->package_manager_->verifyTarget(update_result.updates[0]));
 
     result::Install install_result = aktualizr.Install(update_result.updates).get();
     EXPECT_EQ(install_result.ecu_reports.size(), 1);
@@ -90,6 +93,16 @@ TEST(Aktualizr, FullOstreeUpdate) {
     // check new version
     const auto target = aktualizr.uptane_client()->package_manager_->getCurrent();
     EXPECT_EQ(target.sha256Hash(), new_rev);
+    // TODO: verify the target. It doesn't work because
+    // ostree_repo_list_commit_objects_starting_with() doesn't find the commit.
+    // The already mocked functions are not enough to do this; it seems the
+    // commit is not written with the correct hash. See OTA-3659.
+
+    // Verify a bogus target is not present.
+    Uptane::EcuMap primary_ecu{{Uptane::EcuSerial(conf.provision.primary_ecu_serial),
+                                Uptane::HardwareIdentifier(conf.provision.primary_ecu_hardware_id)}};
+    Uptane::Target target_bad("some-pkg", primary_ecu, {Uptane::Hash(Uptane::Hash::Type::kSha256, "hash-bad")}, 4, "");
+    EXPECT_FALSE(aktualizr.uptane_client()->package_manager_->verifyTarget(target_bad));
   }
 }
 
@@ -101,7 +114,7 @@ int main(int argc, char **argv) {
 
   if (argc != 3) {
     std::cerr << "Error: " << argv[0] << " requires the path to the uptane-generator utility "
-              << "and an OStree sysroot\n";
+              << "and an OSTree sysroot\n";
     return EXIT_FAILURE;
   }
   uptane_generator_path = argv[1];

--- a/src/libaktualizr/primary/aktualizr_test.cc
+++ b/src/libaktualizr/primary/aktualizr_test.cc
@@ -1150,7 +1150,7 @@ TEST(Aktualizr, DownloadWithUpdates) {
         EXPECT_EQ(event->variant, "AllDownloadsComplete");
         const auto downloads_complete = dynamic_cast<event::AllDownloadsComplete*>(event.get());
         EXPECT_EQ(downloads_complete->result.updates.size(), 0);
-        EXPECT_EQ(downloads_complete->result.status, result::DownloadStatus::kNothingToDownload);
+        EXPECT_EQ(downloads_complete->result.status, result::DownloadStatus::kError);
         break;
       }
       case 1: {
@@ -1199,7 +1199,7 @@ TEST(Aktualizr, DownloadWithUpdates) {
   // First try downloading nothing. Nothing should happen.
   result::Download result = aktualizr.Download(std::vector<Uptane::Target>()).get();
   EXPECT_EQ(result.updates.size(), 0);
-  EXPECT_EQ(result.status, result::DownloadStatus::kNothingToDownload);
+  EXPECT_EQ(result.status, result::DownloadStatus::kError);
   result::UpdateCheck update_result = aktualizr.CheckUpdates().get();
   aktualizr.Download(update_result.updates);
 

--- a/src/libaktualizr/primary/download_nonostree_test.cc
+++ b/src/libaktualizr/primary/download_nonostree_test.cc
@@ -32,7 +32,7 @@ TEST(Aktualizr, DownloadNonOstreeBin) {
     std::shared_ptr<INvStorage> storage = INvStorage::newStorage(conf.storage);
     auto uptane_client = SotaUptaneClient::newDefaultClient(conf, storage);
     uptane_client->initialize();
-    EXPECT_FALSE(uptane_client->uptaneIteration());
+    EXPECT_FALSE(uptane_client->uptaneIteration(nullptr, nullptr));
     EXPECT_STREQ(uptane_client->getLastException().what(),
                  "The target had a non-OSTree package that can not be installed on an OSTree system.");
   }

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -841,9 +841,9 @@ result::Install SotaUptaneClient::uptaneInstall(const std::vector<Uptane::Target
 
   // Recheck the downloaded update hashes.
   for (const auto &update : updates) {
-    if (!package_manager_->verifyTarget(update)) {
+    if (package_manager_->verifyTarget(update) != TargetStatus::kGood) {
       result.dev_report = {false, data::ResultCode::Numeric::kInternalError, ""};
-      storage->storeDeviceInstallationResult(result.dev_report, "Downloaded target's hash is invalid", correlation_id);
+      storage->storeDeviceInstallationResult(result.dev_report, "Downloaded target is invalid", correlation_id);
       sendEvent<event::AllInstallsComplete>(result);
       return result;
     }

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -97,9 +97,9 @@ class SotaUptaneClient {
   friend class CheckForUpdate;       // for load tests
   friend class ProvisionDeviceTask;  // for load tests
 
-  bool updateMeta();
-  bool uptaneIteration();
+  bool uptaneIteration(std::vector<Uptane::Target> *targets, unsigned int *ecus_count);
   bool uptaneOfflineIteration(std::vector<Uptane::Target> *targets, unsigned int *ecus_count);
+  result::UpdateStatus checkUpdatesOffline(const std::vector<Uptane::Target> &targets);
   Json::Value AssembleManifest();
   std::string secondaryTreehubCredentials() const;
   Uptane::Exception getLastException() const { return last_exception; }
@@ -156,6 +156,15 @@ class SotaUptaneClient {
   // ecu_serial => secondary*
   std::map<Uptane::EcuSerial, std::shared_ptr<Uptane::SecondaryInterface>> secondaries;
   std::mutex download_mutex;
+};
+
+class TargetCompare {
+ public:
+  explicit TargetCompare(const Uptane::Target &target_in) : target(target_in) {}
+  bool operator()(const Uptane::Target &in) const { return (in.MatchTarget(target)); }
+
+ private:
+  const Uptane::Target &target;
 };
 
 class SerialCompare {

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -124,9 +124,10 @@ class SotaUptaneClient {
   bool updateDirectorMeta();
   bool checkDirectorMetaOffline();
   void computeDeviceInstallationResult(data::InstallationResult *result, const std::string &correlation_id);
-  std::unique_ptr<Uptane::Target> findTargetInDelegationTree(const Uptane::Target &target);
+  std::unique_ptr<Uptane::Target> findTargetInDelegationTree(const Uptane::Target &target, bool offline);
   std::unique_ptr<Uptane::Target> findTargetHelper(const Uptane::Targets &cur_targets,
-                                                   const Uptane::Target &queried_target, int level, bool terminating);
+                                                   const Uptane::Target &queried_target, int level, bool terminating,
+                                                   bool offline);
 
   template <class T, class... Args>
   void sendEvent(Args &&... args) {

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -43,6 +43,8 @@ class SotaUptaneClient {
   void addNewSecondary(const std::shared_ptr<Uptane::SecondaryInterface> &sec);
   result::Download downloadImages(const std::vector<Uptane::Target> &targets,
                                   const api::FlowControlToken *token = nullptr);
+  std::pair<bool, Uptane::Target> downloadImage(const Uptane::Target &target,
+                                                const api::FlowControlToken *token = nullptr);
   void reportPause();
   void reportResume();
   void sendDeviceData();
@@ -118,8 +120,6 @@ class SotaUptaneClient {
 
   bool putManifestSimple(const Json::Value &custom = Json::nullValue);
   bool getNewTargets(std::vector<Uptane::Target> *new_targets, unsigned int *ecus_count = nullptr);
-  std::pair<bool, Uptane::Target> downloadImage(const Uptane::Target &target,
-                                                const api::FlowControlToken *token = nullptr);
   void rotateSecondaryRoot(Uptane::RepositoryType repo, Uptane::SecondaryInterface &secondary);
   bool updateDirectorMeta();
   bool checkDirectorMetaOffline();

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -82,7 +82,7 @@ class SotaUptaneClient {
   FRIEND_TEST(DockerAppManager, DockerApp_Fetch);
   FRIEND_TEST(Uptane, AssembleManifestGood);
   FRIEND_TEST(Uptane, AssembleManifestBad);
-  FRIEND_TEST(Uptane, InstallFake);
+  FRIEND_TEST(Uptane, InstallFakeGood);
   FRIEND_TEST(Uptane, restoreVerify);
   FRIEND_TEST(Uptane, PutManifest);
   FRIEND_TEST(Uptane, offlineIteration);

--- a/src/libaktualizr/uptane/iterator.h
+++ b/src/libaktualizr/uptane/iterator.h
@@ -7,7 +7,7 @@
 namespace Uptane {
 
 Targets getTrustedDelegation(const Role &delegate_role, const Targets &parent_targets,
-                             const ImagesRepository &images_repo, INvStorage &storage, Fetcher &fetcher);
+                             const ImagesRepository &images_repo, INvStorage &storage, Fetcher &fetcher, bool offline);
 
 class LazyTargetsList {
  public:

--- a/tests/uptane_vector_tests.cc
+++ b/tests/uptane_vector_tests.cc
@@ -126,7 +126,7 @@ TEST_P(UptaneVector, Test) {
        *
        * It would be simpler to just call fetchMeta() here, but that calls
        * putManifestSimple(), which will fail here. */
-      if (!uptane_client->uptaneIteration()) {
+      if (!uptane_client->uptaneIteration(nullptr, nullptr)) {
         ASSERT_TRUE(should_fail) << "uptaneIteration unexpectedly failed.";
         throw uptane_client->getLastException();
       }


### PR DESCRIPTION
~~This is still a work in progress, as there is additional work I'd like to include before merging. Also, `test_aktualizr-lite` is failing because of my changes and I'd like to discuss with @doanac how to reach a mutually satisfactory solution.~~

As to the changes, the biggest part is to recheck the Uptane metadata before downloading or installing a target. `uptaneIteration()` is now exclusively used during the check for updates, and it actually fetches the necessary metadata. `uptaneOfflineIteration()` is now exclusively used during downloading and installing to verify the integrity of the stored metadata. If a user then attempts to install a target that doesn't match the stored metadata, it will be rejected.
    
That stipulation required a lot of reworking of the Uptane tests, because several of them installed fake packages as a shortcut. That no longer works, so I had to expand several of the tests quite a bit. As a result, several of these tests are now rather redundant. We should re-evaluate the test cases in uptane_test and aktualizr_test and determine which are still meaningful and unique.

The other notable change is to only drop Director targets after a failed installation attempt. Otherwise this prevents being able to split updates into multiple individual calls to the Install API call. ~~(A unit test is pending.)~~ This still isn't my favorite fix for this problem, but in the short term, it's an improvement. [That was already merged in https://github.com/advancedtelematic/aktualizr/pull/1301.]