### PR TITLE
Report failed downloads in an installation report.

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/pages/fault-injection.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/fault-injection.adoc
@@ -28,9 +28,10 @@ Usage is as follow:
 
 Please try to keep this list up-to-date when inserting/removing fail points.
 
-- `fake_package_install`: make the fake package manager installation to fail, optionally with a failure code supplied via `failinfo`
-- `secondary_install_xxx` (xxx is a virtual secondary ecu id): make a virtual secondary installation to fail, optionally with a failure code supplied via `failinfo`
-- `fake_install_finalization_failure`: make the fake package manager installation finalization to fail
+- `fake_package_download`: force the fake package manager download to fail, optionally with a failure code supplied via `failinfo`
+- `fake_package_install`: force the fake package manager installation to fail, optionally with a failure code supplied via `failinfo`
+- `secondary_install_xxx` (xxx is a virtual secondary ecu id): force a virtual secondary installation to fail, optionally with a failure code supplied via `failinfo`
+- `fake_install_finalization_failure`: force the fake package manager installation finalization to fail
 
 == Use in unit tests
 

--- a/src/libaktualizr/package_manager/CMakeLists.txt
+++ b/src/libaktualizr/package_manager/CMakeLists.txt
@@ -12,7 +12,7 @@ aktualizr_source_file_checks(${SOURCES} packagemanagerconfig.cc ${HEADERS})
 
 target_sources(config PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/packagemanagerconfig.cc)
 
-add_aktualizr_test(NAME packagemanagerfake SOURCES packagemanagerfake_test.cc)
+add_aktualizr_test(NAME packagemanagerfake SOURCES packagemanagerfake_test.cc LIBRARIES PUBLIC uptane_generator_lib)
 
 # Debian backend
 if(BUILD_DEB)

--- a/src/libaktualizr/package_manager/packagemanagerfake.h
+++ b/src/libaktualizr/package_manager/packagemanagerfake.h
@@ -21,6 +21,8 @@ class PackageManagerFake : public PackageManagerInterface {
   data::InstallationResult install(const Uptane::Target &target) const override;
   void completeInstall() const override;
   data::InstallationResult finalizeInstall(const Uptane::Target &target) const override;
+  bool fetchTarget(const Uptane::Target &target, Uptane::Fetcher &fetcher, const KeyManager &keys,
+                   FetcherProgressCb progress_cb, const api::FlowControlToken *token) override;
 };
 
 #endif  // PACKAGEMANAGERFAKE_H_

--- a/src/libaktualizr/package_manager/packagemanagerfake_test.cc
+++ b/src/libaktualizr/package_manager/packagemanagerfake_test.cc
@@ -8,6 +8,7 @@
 #include <boost/filesystem.hpp>
 
 #include "config/config.h"
+#include "httpfake.h"
 #include "package_manager/packagemanagerfake.h"
 #include "storage/invstorage.h"
 #include "uptane/tuf.h"
@@ -40,7 +41,38 @@ TEST(PackageManagerFake, FinalizeAfterReboot) {
 
 #include "utilities/fault_injection.h"
 
-TEST(PackageManagerFake, FailureInjection) {
+TEST(PackageManagerFake, DownloadFailureInjection) {
+  TemporaryDirectory temp_dir;
+  Config config;
+  config.pacman.type = PackageManager::kNone;
+  config.storage.path = temp_dir.Path();
+  std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
+  auto http = std::make_shared<HttpFake>(temp_dir.Path());
+  Uptane::Fetcher uptane_fetcher(config, http);
+  KeyManager keys(storage, config.keymanagerConfig());
+
+  PackageManagerFake fakepm(config.pacman, storage, nullptr, http);
+
+  fault_injection_init();
+
+  // no fault
+  Uptane::EcuMap primary_ecu{{Uptane::EcuSerial("primary"), Uptane::HardwareIdentifier("primary_hw")}};
+  Uptane::Target target("pkg", primary_ecu, {Uptane::Hash(Uptane::Hash::Type::kSha256, "hash")}, 0, "");
+  EXPECT_TRUE(fakepm.fetchTarget(target, uptane_fetcher, keys, nullptr, nullptr));
+
+  // fault
+  fault_injection_enable("fake_package_download", 1, "", 0);
+  EXPECT_FALSE(fakepm.fetchTarget(target, uptane_fetcher, keys, nullptr, nullptr));
+  fault_injection_disable("fake_package_download");
+
+  // fault with custom data (through pid file). Unfortunately no easy way to
+  // test the custom emssage.
+  fault_injection_enable("fake_package_download", 1, "RANDOM_DOWNLOAD_CAUSE", 0);
+  EXPECT_FALSE(fakepm.fetchTarget(target, uptane_fetcher, keys, nullptr, nullptr));
+  fault_injection_disable("fake_package_download");
+}
+
+TEST(PackageManagerFake, InstallFailureInjection) {
   TemporaryDirectory temp_dir;
   Config config;
   config.pacman.type = PackageManager::kNone;
@@ -49,7 +81,7 @@ TEST(PackageManagerFake, FailureInjection) {
 
   PackageManagerFake fakepm(config.pacman, storage, nullptr, nullptr);
 
-  fiu_init(0);
+  fault_injection_init();
 
   // no fault
   Uptane::EcuMap primary_ecu{{Uptane::EcuSerial("primary"), Uptane::HardwareIdentifier("primary_hw")}};
@@ -64,9 +96,9 @@ TEST(PackageManagerFake, FailureInjection) {
   fault_injection_disable("fake_package_install");
 
   // fault with custom data (through pid file)
-  fault_injection_enable("fake_package_install", 1, "RANDOM_CAUSE", 0);
+  fault_injection_enable("fake_package_install", 1, "RANDOM_INSTALL_CAUSE", 0);
   result = fakepm.install(target);
-  EXPECT_EQ(result.result_code, data::ResultCode(data::ResultCode::Numeric::kInstallFailed, "RANDOM_CAUSE"));
+  EXPECT_EQ(result.result_code, data::ResultCode(data::ResultCode::Numeric::kInstallFailed, "RANDOM_INSTALL_CAUSE"));
   fault_injection_disable("fake_package_install");
 }
 

--- a/src/libaktualizr/primary/aktualizr_test.cc
+++ b/src/libaktualizr/primary/aktualizr_test.cc
@@ -704,7 +704,7 @@ TEST(Aktualizr, FinalizationFailure) {
 
   {
     // now try to finalize the previously installed updates with enabled failure injection
-    fiu_init(0);
+    fault_injection_init();
     fiu_enable("fake_install_finalization_failure", 1, nullptr, 0);
     http_server_mock->clearReportEvents();
 
@@ -785,7 +785,7 @@ TEST(Aktualizr, InstallationFailure) {
     Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http_server_mock->tls_server);
     auto storage = INvStorage::newStorage(conf.storage);
 
-    fiu_init(0);
+    fault_injection_init();
     fiu_enable("fake_package_install", 1, nullptr, 0);
 
     UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http_server_mock);
@@ -845,7 +845,7 @@ TEST(Aktualizr, InstallationFailure) {
     auto storage = INvStorage::newStorage(conf.storage);
     const std::string sec_fault_name = std::string("secondary_install_") + secondary_ecu_id;
 
-    fiu_init(0);
+    fault_injection_init();
     fault_injection_enable("fake_package_install", 1, "PRIMFAIL", 0);
     fault_injection_enable(sec_fault_name.c_str(), 1, "SECFAIL", 0);
 

--- a/src/libaktualizr/primary/empty_targets_test.cc
+++ b/src/libaktualizr/primary/empty_targets_test.cc
@@ -96,7 +96,11 @@ TEST(Aktualizr, EmptyTargets) {
 
 #ifdef FIU_ENABLE
 
-/* Check that Aktualizr switches back to empty targets after completing an
+// TODO: also check download failure. However, this depends on what the server
+// actually sends in response to download failure, which currently does not work
+// as expected (OTA-3169).
+
+/* Check that Aktualizr switches back to empty targets after failing an
  * installation attempt (OTA-2587) */
 TEST(Aktualizr, EmptyTargetsAfterInstall) {
   TemporaryDirectory temp_dir;
@@ -127,10 +131,9 @@ TEST(Aktualizr, EmptyTargetsAfterInstall) {
     result::Download download_result = aktualizr.Download(update_result.updates).get();
     EXPECT_EQ(download_result.status, result::DownloadStatus::kSuccess);
 
-    update_result = aktualizr.CheckUpdates().get();
     fiu_init(0);
     fault_injection_enable("fake_package_install", 1, "", 0);
-    result::Install install_result = aktualizr.Install(update_result.updates).get();
+    result::Install install_result = aktualizr.Install(download_result.updates).get();
     EXPECT_EQ(install_result.ecu_reports.size(), 1);
     EXPECT_EQ(install_result.ecu_reports[0].install_res.result_code.num_code,
               data::ResultCode::Numeric::kInstallFailed);

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -561,6 +561,8 @@ result::Download SotaUptaneClient::downloadImages(const std::vector<Uptane::Targ
       data::InstallationResult device_installation_result =
           data::InstallationResult(data::ResultCode::Numeric::kDownloadFailed, "Target download failed");
       storage->storeDeviceInstallationResult(device_installation_result, "", correlation_id);
+      // Fix for OTA-2587, listen to backend again after end of install.
+      director_repo.dropTargets(*storage);
     }
 
   } else {

--- a/src/libaktualizr/utilities/fault_injection.h
+++ b/src/libaktualizr/utilities/fault_injection.h
@@ -113,6 +113,17 @@ static inline int fault_injection_enable(const char *name, int failnum, const st
   return fiu_enable(name, failnum, reinterpret_cast<void *>(failinfo_id), flags);
 }
 
+// proxy for fiu_init, but also explicitly clears the persisted failinfo, in
+// case it is lingering from a previous test case.
+static inline void fault_injection_init() {
+  fiu_init(0);
+  std::ofstream f;
+  try {
+    f.open(fault_injection_info_fn(), std::ios::binary);
+  } catch (std::ofstream::failure &e) {
+  }
+}
+
 #define fault_injection_disable fiu_disable
 
 #endif /* FIU_ENABLE */

--- a/src/libaktualizr/utilities/types.cc
+++ b/src/libaktualizr/utilities/types.cc
@@ -64,6 +64,7 @@ const std::map<data::ResultCode::Numeric, const char *> data::ResultCode::string
     {ResultCode::Numeric::kAlreadyProcessed, "ALREADY_PROCESSED"},
     {ResultCode::Numeric::kValidationFailed, "VALIDATION_FAILED"},
     {ResultCode::Numeric::kInstallFailed, "INSTALL_FAILED"},
+    {ResultCode::Numeric::kDownloadFailed, "DOWNLOAD_FAILED"},
     {ResultCode::Numeric::kInternalError, "INTERNAL_ERROR"},
     {ResultCode::Numeric::kGeneralError, "GENERAL_ERROR"},
     {ResultCode::Numeric::kNeedCompletion, "NEED_COMPLETION"},

--- a/src/libaktualizr/utilities/types.h
+++ b/src/libaktualizr/utilities/types.h
@@ -130,6 +130,8 @@ struct ResultCode {
     kValidationFailed = 3,
     /// Package installation failed
     kInstallFailed = 4,
+    /// Package download failed
+    kDownloadFailed = 5,
     /// SWM Internal integrity error
     kInternalError = 18,
     /// Other error


### PR DESCRIPTION
This should inform the Director that the update failed.

This appears to fix the bug, but it is not perfect:
1) ~~There is no test, because we don't have a way to fake a download failure. It's probably doable with libfiu and the fake package manager, though.~~ This is now covered by tests.
2) There is the same problem with empty targets metadata that occurs with installation failure. It ~~could be~~ has been handled the same way, ~~although~~ despite that I don't like the solution of dropping metadata.
3) The installation report does not contain any information about how, why, or which download failed. That could be improved if anyone wants to see that.

We might want to consider merging testing and merging this as is anyway just to get the fix out the door, but further consideration is necessary to address the above issues.