### PR TITLE
Fix path to uptane-generator for Doxygen.

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -820,7 +820,7 @@ INPUT                  = @CMAKE_SOURCE_DIR@/docs \
                          @CMAKE_SOURCE_DIR@/src/libaktualizr/utilities \
                          @CMAKE_SOURCE_DIR@/src/load_tests \
                          @CMAKE_SOURCE_DIR@/src/sota_tools \
-                         @CMAKE_SOURCE_DIR@/src/uptane-generator \
+                         @CMAKE_SOURCE_DIR@/src/uptane_generator \
                          @CMAKE_SOURCE_DIR@/CONTRIBUTING.md \
                          @CMAKE_SOURCE_DIR@/CHANGELOG.md
 


### PR DESCRIPTION
Just a typo, my own fault while trying to help resolve merge failures.