### PR TITLE
Remove deprecated function call

### DIFF
--- a/src/aktualizr_get/main.cc
+++ b/src/aktualizr_get/main.cc
@@ -1,7 +1,6 @@
 #include <unistd.h>
 #include <iostream>
 
-#include <openssl/ssl.h>
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 
@@ -59,10 +58,6 @@ int main(int argc, char *argv[]) {
   int r = EXIT_FAILURE;
   try {
     Config config(commandline_map);
-    if (config.logger.loglevel <= boost::log::trivial::debug) {
-      SSL_load_error_strings();
-    }
-
     std::string body = aktualizrGet(config, commandline_map["url"].as<std::string>());
     std::cout << body;
 

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -1,7 +1,6 @@
 #include <unistd.h>
 #include <iostream>
 
-#include <openssl/ssl.h>
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 #include <boost/uuid/uuid_generators.hpp>
@@ -305,9 +304,6 @@ int main(int argc, char *argv[]) {
 
     Config config(commandline_map);
     config.storage.uptane_metadata_path = BasedPath(config.storage.path / "metadata");
-    if (config.logger.loglevel <= boost::log::trivial::debug) {
-      SSL_load_error_strings();
-    }
     LOG_DEBUG << "Current directory: " << boost::filesystem::current_path().string();
 
     std::string cmd = commandline_map["command"].as<std::string>();

--- a/src/aktualizr_primary/main.cc
+++ b/src/aktualizr_primary/main.cc
@@ -1,6 +1,5 @@
 #include <iostream>
 
-#include <openssl/ssl.h>
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 #include <boost/property_tree/ini_parser.hpp>
@@ -113,9 +112,6 @@ int main(int argc, char *argv[]) {
                      "should be run as root for proper functionality.\033[0m\n";
     }
     Config config(commandline_map);
-    if (config.logger.loglevel <= boost::log::trivial::debug) {
-      SSL_load_error_strings();
-    }
     LOG_DEBUG << "Current directory: " << boost::filesystem::current_path().string();
 
     Aktualizr aktualizr(config);

--- a/src/aktualizr_secondary/main.cc
+++ b/src/aktualizr_secondary/main.cc
@@ -4,8 +4,6 @@
 #include <memory>
 #include <thread>
 
-#include <openssl/ssl.h>
-
 #include "aktualizr_secondary.h"
 #include "aktualizr_secondary_config.h"
 #include "utilities/aktualizr_version.h"
@@ -85,9 +83,6 @@ int main(int argc, char *argv[]) {
   int ret = EXIT_SUCCESS;
   try {
     AktualizrSecondaryConfig config(commandline_map);
-    if (config.logger.loglevel <= boost::log::trivial::debug) {
-      SSL_load_error_strings();
-    }
     LOG_DEBUG << "Current directory: " << boost::filesystem::current_path().string();
 
     // storage (share class with primary)

--- a/src/cert_provider/main.cc
+++ b/src/cert_provider/main.cc
@@ -8,7 +8,6 @@
 #include <boost/program_options.hpp>
 #include <utility>
 
-#include <openssl/ssl.h>
 #include "json/json.h"
 
 #include "bootstrap/bootstrap.h"
@@ -340,7 +339,6 @@ int main(int argc, char* argv[]) {
   int exit_code = EXIT_FAILURE;
 
   logger_init();
-  SSL_load_error_strings();
   logger_set_threshold(static_cast<boost::log::trivial::severity_level>(2));
 
   try {
@@ -575,6 +573,5 @@ int main(int argc, char* argv[]) {
     exit_code = EXIT_FAILURE;
   }
 
-  ERR_free_strings();
   return exit_code;
 }


### PR DESCRIPTION
Deprecated since openssl 1.1.0

See https://www.openssl.org/docs/man1.1.0/man3/SSL_load_error_strings.html