### PR TITLE
OTA-3594: Including first two pieces of content from meta-updater

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/nav.adoc
+++ b/docs/ota-client-guide/modules/ROOT/nav.adoc
@@ -78,7 +78,8 @@ ifndef::env-github[:pageroot:]
 
 .Reference
 // MC: Do in second iteration: * xref:{pageroot}otaconnect-identifiers.adoc[Identifiers]
-* xref:{pageroot}aktualizr-config-options.adoc[Configuration Options]
+* xref:{pageroot}aktualizr-config-options.adoc[Client Configuration Options]
+* xref:{pageroot}build-configuration.adoc[Build Configuration Options]
 * xref:{pageroot}aktualizr-runningmodes-finegrained-commandline-control.adoc[Client Commands]
 * xref:{pageroot}provisioning-methods-and-credentialszip.adoc[Contents of the credentials file]
 * xref:{pageroot}useful-bitbake-commands.adoc[Bitbake commands]

--- a/docs/ota-client-guide/modules/ROOT/pages/add-ota-functonality-existing-yocto-project.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/add-ota-functonality-existing-yocto-project.adoc
@@ -14,55 +14,6 @@ If you already have a Yocto-based project that you want to update using {product
 
 You can then build your image as usual, with bitbake. After building the root file system, bitbake will then create an https://ostree.readthedocs.io/en/latest/manual/adapting-existing/[OSTree-enabled version] of it, commit it to your local OSTree repo, and push it to OTA Connect. Additionally, a live disk image will be created (normally named $\{IMAGE_NAME}.-sdimg-ota e.g. core-image-raspberrypi3.rpi-sdimg-ota). You can control this behavior through xref:add-ota-functonality-existing-yocto-project.adoc#_sota_related_variables_in_local_conf[OTA Connect-related variables in your local.conf].
 
-== Supported boards
-
-// MC: Copied over from meta-updater on 29.07.2019
-
-Currently supported platforms are:
-
-* https://github.com/advancedtelematic/meta-updater-raspberrypi[Raspberry Pi 2 and 3]
-* https://github.com/advancedtelematic/meta-updater-minnowboard[Intel Minnowboard]
-* https://github.com/advancedtelematic/meta-updater-qemux86-64[Native QEMU emulation]
-* Renesas R-Car H3 and M3
-* https://github.com/advancedtelematic/meta-updater-ti/[TI BeagleBone Black] (rocko only, using TI SDK 05.03)
-* https://github.com/advancedtelematic/meta-updater-ti/[TI AM65x industrial development kit] (rocko only, using TI SDK 05.03)
-
-Additionally, there is community support for https://github.com/ricardosalveti/meta-updater-riscv[RISC-V] boards, in particular the Freedom U540.
-
-We also historically supported the https://github.com/advancedtelematic/meta-updater-porter[Renesas Porter] board.
-
-=== Adding support for your board
-
-If your board isn't supported yet, you can add board integration code yourself. The main purpose of this code is to provide a bootloader that will be able to use https://ostree.readthedocs.io/en/latest/manual/atomic-upgrades/[OSTree's boot directory]. In the meta-updater integration layers we have written so far, the basic steps are:
-
-1.  Make the board boot into http://www.denx.de/wiki/U-Boot[U-Boot]
-2.  Make U-boot import variables from /boot/loader/uEnv.txt and load the kernel with initramfs and kernel command-line arguments according to what is set in this file.
-
-You may take a look into https://github.com/advancedtelematic/meta-updater-minnowboard[Minnowboard] or https://github.com/advancedtelematic/meta-updater-raspberrypi[Raspberry Pi] integration layers for examples.
-
-Although we have focused on U-Boot and GRUB so far, other bootloaders can be configured to work with OSTree as well.
-
-Your images will also need network connectivity to be able to reach an actual OTA backend. Our 'poky-sota' distribution does not mandate or install a default network manager but our supported platforms use the `virtual/network-configuration` recipe, which can be used as a starting example.
-
-== SOTA-related variables in local.conf
-
-* `OSTREE_BRANCHNAME` - OSTree branch name. Defaults to `${SOTA_HARDWARE_ID}`. Particularly useful for grouping similar images.
-* `OSTREE_REPO` - path to your OSTree repository. Defaults to `$\{DEPLOY_DIR_IMAGE}/ostree_repo`
-* `OSTREE_OSNAME` - OS deployment name on your target device. For more information about deployments and osnames see the https://ostree.readthedocs.io/en/latest/manual/deployment/[OSTree documentation]. Defaults to "poky".
-* `OSTREE_COMMIT_BODY` - Message attached to OSTree commit. Empty by default.
-* `OSTREE_COMMIT_SUBJECT` - Commit subject used by OSTree. Defaults to `Commit-id: ${IMAGE_NAME}`
-* `OSTREE_UPDATE_SUMMARY` - Set this to '1' to update summary of OSTree repository on each commit. '0' by default.
-* `OSTREE_DEPLOY_DEVICETREE` - Set this to '1' to include devicetree(s) to boot
-* `GARAGE_SIGN_AUTOVERSION` - Set this to '1' to automatically fetch the last version of the garage tools installed by the aktualizr-native. Otherwise use the fixed version specified in the recipe.
-* `INITRAMFS_IMAGE` - initramfs/initrd image that is used as a proxy while booting into OSTree deployment. Do not change this setting unless you are sure that your initramfs can serve as such a proxy.
-* `SOTA_PACKED_CREDENTIALS` - when set, your ostree commit will be pushed to a remote repo as a bitbake step. This should be the path to a zipped credentials file in https://github.com/advancedtelematic/aktualizr/blob/master/docs/credentials.adoc[the format accepted by garage-push].
-* `SOTA_DEPLOY_CREDENTIALS` - when set to '1' (default value), deploys credentials to the built image. Override it in `local.conf` to built a generic image that can be provisioned manually after the build.
-* `SOTA_CLIENT_PROV` - which provisioning method to use. Valid options are `aktualizr-shared-prov`, `aktualizr-device-prov`, and `aktualizr-device-prov-hsm`. For more information on these provisioning methods, see the https://docs.ota.here.com/client-config/client-provisioning-methods.html[OTA Connect documentation]. The default is `aktualizr-shared-prov`. This can also be set to an empty string to avoid using a provisioning recipe.
-* `SOTA_CLIENT_FEATURES` - extensions to aktualizr. The only valid options are `hsm` (to build with HSM support) and `secondary-network` (to set up a simulated 'in-vehicle' network with support for a primary node with a DHCP server and a secondary node with a DHCP client).
-* `SOTA_SECONDARY_CONFIG` - a file containing JSON configuration for secondaries. It will be installed into `/etc/sota/ecus` on the device and automatically provided to aktualizr. See link:https://github.com/advancedtelematic/aktualizr/blob/master/docs/posix-secondaries-bitbaking.adoc[here] for more details.
-* `SOTA_HARDWARE_ID` - a custom hardware ID that will be written to the aktualizr config. Defaults to MACHINE if not set.
-* `SOTA_MAIN_DTB` - base device tree to use with the kernel. Used together with FIT images. You can change it, and the device tree will also be changed after the update.
-* `SOTA_DT_OVERLAYS` - whitespace-separated list of used device tree overlays for FIT image. This list is OSTree-updateable as well.
-* `SOTA_EXTRA_CONF_FRAGS` - extra https://lxr.missinglinkelectronics.com/uboot/doc/uImage.FIT/overlay-fdt-boot.txt[configuration fragments] for FIT image.
-* `RESOURCE_xxx_pn-aktualizr` - controls maximum resource usage of the aktualizr service, when `aktualizr-resource-control` is installed on the image. See <<aktualizr service resource control>> for details.
-* `SOTA_POLLING_SEC` - sets polling interval for aktualizr to check for updates if aktualizr-polling-sec is included in the image.
+See also:
+* xref:supported-boards.adoc[Supported boards]
+* xref:build-configuration.adoc[Build configuration options]

--- a/docs/ota-client-guide/modules/ROOT/pages/build-configuration.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-configuration.adoc
@@ -1,0 +1,4 @@
+include::dev@ota-build:ROOT:page$sota-variables.adoc[]
+
+// MC: Included from: meta-updater/docs/modules/ROOT/pages/sota-variables.adoc
+

--- a/docs/ota-client-guide/modules/ROOT/pages/supported-boards.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/supported-boards.adoc
@@ -1,29 +1,3 @@
-== Supported boards
+include::dev@ota-build:ROOT:page$supported-boards.adoc[]
 
-// MC: Copied over from meta-updater on 29.07.2019
-
-Currently supported platforms are:
-
-* https://github.com/advancedtelematic/meta-updater-raspberrypi[Raspberry Pi 2 and 3]
-* https://github.com/advancedtelematic/meta-updater-minnowboard[Intel Minnowboard]
-* https://github.com/advancedtelematic/meta-updater-qemux86-64[Native QEMU emulation]
-* Renesas R-Car H3 and M3
-* https://github.com/advancedtelematic/meta-updater-ti/[TI BeagleBone Black] (rocko only, using TI SDK 05.03)
-* https://github.com/advancedtelematic/meta-updater-ti/[TI AM65x industrial development kit] (rocko only, using TI SDK 05.03)
-
-Additionally, there is community support for https://github.com/ricardosalveti/meta-updater-riscv[RISC-V] boards, in particular the Freedom U540.
-
-We also historically supported the https://github.com/advancedtelematic/meta-updater-porter[Renesas Porter] board.
-
-=== Adding support for your board
-
-If your board isn't supported yet, you can add board integration code yourself. The main purpose of this code is to provide a bootloader that will be able to use https://ostree.readthedocs.io/en/latest/manual/atomic-upgrades/[OSTree's boot directory]. In the meta-updater integration layers we have written so far, the basic steps are:
-
-1.  Make the board boot into http://www.denx.de/wiki/U-Boot[U-Boot]
-2.  Make U-boot import variables from /boot/loader/uEnv.txt and load the kernel with initramfs and kernel command-line arguments according to what is set in this file.
-
-You may take a look into https://github.com/advancedtelematic/meta-updater-minnowboard[Minnowboard] or https://github.com/advancedtelematic/meta-updater-raspberrypi[Raspberry Pi] integration layers for examples.
-
-Although we have focused on U-Boot and GRUB so far, other bootloaders can be configured to work with OSTree as well.
-
-Your images will also need network connectivity to be able to reach an actual OTA backend. Our 'poky-sota' distribution does not mandate or install a default network manager but our supported platforms use the `virtual/network-configuration` recipe, which can be used as a starting example.
+// MC: Included from: meta-updater/docs/modules/ROOT/pages/supported-boards.adoc


### PR DESCRIPTION
Preparing content so that it gets included from the meta updater repo and added to the developer guide (currently the source content is on the branch "meta-updater/docs/OTA-3594/antora-merge")

The first two items are:
* The "local.conf variables descriptions which are now in the "Reference" chapter
* The "supported software" topic which now pulls directly from meta-updater (instead of being a copy)

Signed-off-by: Merlin Carter <merlin.carter@here.com>