### PR TITLE
Refactor/repo naming

### DIFF
--- a/scripts/selfupdate_server.py
+++ b/scripts/selfupdate_server.py
@@ -9,10 +9,6 @@ class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
         local_path = self.path
         print("GET: " + local_path)
-        # Fix annoying issue where uptane-generator generates metadata for the
-        # images repository in /image but aktualizr expects /repo.
-        if local_path.startswith("/repo/"):
-            local_path = local_path.replace('/repo/', '/image/', 1)
         self.send_response(200)
         self.end_headers()
         with open(self.server.base_dir + "/fake_root/repo/" + local_path, "rb") as fl:

--- a/src/aktualizr_lite/test_lite.sh
+++ b/src/aktualizr_lite/test_lite.sh
@@ -65,7 +65,7 @@ mkdir $sota_dir
 chmod 700 $sota_dir
 cat >$sota_dir/sota.toml <<EOF
 [uptane]
-repo_server = "http://localhost:$port/repo/image"
+repo_server = "http://localhost:$port/repo/repo"
 
 [provision]
 primary_ecu_hardware_id = "hwid-for-test"

--- a/src/libaktualizr/package_manager/dockerapp_test_repo.sh
+++ b/src/libaktualizr/package_manager/dockerapp_test_repo.sh
@@ -29,6 +29,6 @@ uptane_gen --command signtargets
 
 cd $DEST_DIR
 echo "Target.json is: "
-cat repo/image/targets.json
+cat repo/repo/targets.json
 echo "Running repo server port on $PORT"
 exec python3 -m http.server $PORT

--- a/src/libaktualizr/package_manager/dockerappmanager_test.cc
+++ b/src/libaktualizr/package_manager/dockerappmanager_test.cc
@@ -73,7 +73,7 @@ TEST(DockerAppManager, DockerApp_Fetch) {
   config.pacman.docker_apps.push_back("app1");
   config.pacman.docker_app_bin = config.pacman.docker_compose_bin = "src/libaktualizr/package_manager/docker_fake.sh";
   config.pacman.ostree_server = treehub_server;
-  config.uptane.repo_server = repo_server + "/repo/image";
+  config.uptane.repo_server = repo_server + "/repo/repo";
   TemporaryDirectory dir;
   config.storage.path = dir.Path();
 
@@ -83,7 +83,7 @@ TEST(DockerAppManager, DockerApp_Fetch) {
   auto client = newTestClient(config, storage, http, nullptr);
   ASSERT_TRUE(client->updateImagesMeta());
 
-  std::string targets = Utils::readFile(repo / "repo/image/targets.json");
+  std::string targets = Utils::readFile(repo / "repo/repo/targets.json");
   LOG_INFO << "Repo targets " << targets;
 
   bool result = client->package_manager_->fetchTarget(target, *(client->uptane_fetcher), keys, progress_cb, nullptr);

--- a/src/libaktualizr/primary/aktualizr_fullostree_test.cc
+++ b/src/libaktualizr/primary/aktualizr_fullostree_test.cc
@@ -154,8 +154,6 @@ int main(int argc, char **argv) {
                   "--serial", "CA:FE:A6:D2:84:9D"});
   uptane_gen.run({"signtargets", "--path", meta_dir.PathString(), "--correlationid", "abc123"});
   LOG_INFO << uptane_gen.lastStdOut();
-  // Work around inconsistent directory naming.
-  Utils::copyDir(meta_dir.Path() / "repo/image", meta_dir.Path() / "repo/repo");
 
   return RUN_ALL_TESTS();
 }

--- a/src/libaktualizr/primary/aktualizr_test.cc
+++ b/src/libaktualizr/primary/aktualizr_test.cc
@@ -1704,7 +1704,7 @@ class HttpFakeNoCorrelationId : public HttpFake {
 TEST(Aktualizr, FullNoCorrelationId) {
   TemporaryDirectory temp_dir;
   TemporaryDirectory meta_dir;
-  Utils::copyDir(uptane_repos_dir / "full_no_correlation_id/repo/image", meta_dir.Path() / "repo");
+  Utils::copyDir(uptane_repos_dir / "full_no_correlation_id/repo/repo", meta_dir.Path() / "repo");
   Utils::copyDir(uptane_repos_dir / "full_no_correlation_id/repo/director", meta_dir.Path() / "director");
   auto http = std::make_shared<HttpFakeNoCorrelationId>(temp_dir.Path(), meta_dir.Path());
 

--- a/src/libaktualizr/primary/custom_url_test.cc
+++ b/src/libaktualizr/primary/custom_url_test.cc
@@ -45,8 +45,6 @@ TEST(Aktualizr, ImagesCustomUrl) {
   uptane_gen.run({"addtarget", "--path", meta_dir.PathString(), "--targetname", "firmware.txt", "--hwid", "primary_hw",
                   "--serial", "CA:FE:A6:D2:84:9D"});
   uptane_gen.run({"signtargets", "--path", meta_dir.PathString(), "--correlationid", "abc123"});
-  // Work around inconsistent directory naming.
-  Utils::copyDir(meta_dir.Path() / "repo/image", meta_dir.Path() / "repo/repo");
 
   auto storage = INvStorage::newStorage(conf.storage);
   UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
@@ -78,8 +76,6 @@ TEST(Aktualizr, BothCustomUrl) {
   uptane_gen.run({"addtarget", "--path", meta_dir.PathString(), "--targetname", "firmware.txt", "--hwid", "primary_hw",
                   "--serial", "CA:FE:A6:D2:84:9D", "--url", "test-url3"});
   uptane_gen.run({"signtargets", "--path", meta_dir.PathString(), "--correlationid", "abc123"});
-  // Work around inconsistent directory naming.
-  Utils::copyDir(meta_dir.Path() / "repo/image", meta_dir.Path() / "repo/repo");
 
   auto storage = INvStorage::newStorage(conf.storage);
   UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);

--- a/src/libaktualizr/primary/download_nonostree_test.cc
+++ b/src/libaktualizr/primary/download_nonostree_test.cc
@@ -87,8 +87,6 @@ int main(int argc, char **argv) {
   uptane_gen.run({"addtarget", "--path", meta_dir.PathString(), "--targetname", "update_1.0", "--hwid", "primary_hw",
                   "--serial", "CA:FE:A6:D2:84:9D"});
   uptane_gen.run({"signtargets", "--path", meta_dir.PathString(), "--correlationid", "abc123"});
-  // Work around inconsistent directory naming.
-  Utils::copyDir(meta_dir.Path() / "repo/image", meta_dir.Path() / "repo/repo");
 
   return RUN_ALL_TESTS();
 }

--- a/src/libaktualizr/primary/empty_targets_test.cc
+++ b/src/libaktualizr/primary/empty_targets_test.cc
@@ -47,8 +47,6 @@ TEST(Aktualizr, EmptyTargets) {
   uptane_gen.run({"addtarget", "--path", meta_dir.PathString(), "--targetname", "firmware.txt", "--hwid", "primary_hw",
                   "--serial", "CA:FE:A6:D2:84:9D"});
   uptane_gen.run({"signtargets", "--path", meta_dir.PathString(), "--correlationid", "abc123"});
-  // Work around inconsistent directory naming.
-  Utils::copyDir(meta_dir.Path() / "repo/image", meta_dir.Path() / "repo/repo");
 
   auto storage = INvStorage::newStorage(conf.storage);
   {
@@ -112,8 +110,6 @@ TEST(Aktualizr, EmptyTargetsAfterDownload) {
   uptane_gen.run({"addtarget", "--path", meta_dir.PathString(), "--targetname", "firmware.txt", "--hwid", "primary_hw",
                   "--serial", "CA:FE:A6:D2:84:9D"});
   uptane_gen.run({"signtargets", "--path", meta_dir.PathString(), "--correlationid", "abc123"});
-  // Work around inconsistent directory naming.
-  Utils::copyDir(meta_dir.Path() / "repo/image", meta_dir.Path() / "repo/repo");
 
   // failing download
   fault_injection_init();
@@ -161,8 +157,6 @@ TEST(Aktualizr, EmptyTargetsAfterInstall) {
   uptane_gen.run({"addtarget", "--path", meta_dir.PathString(), "--targetname", "firmware.txt", "--hwid", "primary_hw",
                   "--serial", "CA:FE:A6:D2:84:9D"});
   uptane_gen.run({"signtargets", "--path", meta_dir.PathString(), "--correlationid", "abc123"});
-  // Work around inconsistent directory naming.
-  Utils::copyDir(meta_dir.Path() / "repo/image", meta_dir.Path() / "repo/repo");
 
   // failing install
   fault_injection_init();

--- a/src/libaktualizr/primary/target_mismatch_test.cc
+++ b/src/libaktualizr/primary/target_mismatch_test.cc
@@ -28,8 +28,6 @@ TEST(Aktualizr, HardwareMismatch) {
   uptane_gen.run({"addtarget", "--path", meta_dir.PathString(), "--targetname", "firmware.txt", "--hwid", "primary_hw",
                   "--serial", "CA:FE:A6:D2:84:9D"});
   uptane_gen.run({"signtargets", "--path", meta_dir.PathString()});
-  // Work around inconsistent directory naming.
-  Utils::copyDir(meta_dir.Path() / "repo/image", meta_dir.Path() / "repo/repo");
 
   auto storage = INvStorage::newStorage(conf.storage);
   UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);

--- a/src/libaktualizr/uptane/uptane_delegation_test.cc
+++ b/src/libaktualizr/uptane/uptane_delegation_test.cc
@@ -38,10 +38,7 @@ void delegation_nested(const boost::filesystem::path& delegation_path, bool revo
 class HttpFakeDelegation : public HttpFake {
  public:
   HttpFakeDelegation(const boost::filesystem::path& test_dir_in)
-      : HttpFake(test_dir_in, "", test_dir_in / "delegation_test/repo") {
-    // Work around inconsistent directory naming.
-    Utils::copyDir(test_dir_in / "delegation_test/repo/image", test_dir_in / "delegation_test/repo/repo");
-  }
+      : HttpFake(test_dir_in, "", test_dir_in / "delegation_test/repo") {}
 
   HttpResponse handle_event(const std::string& url, const Json::Value& data) override {
     (void)url;

--- a/src/uptane_generator/director_repo.cc
+++ b/src/uptane_generator/director_repo.cc
@@ -2,8 +2,8 @@
 
 void DirectorRepo::addTarget(const std::string &target_name, const Json::Value &target, const std::string &hardware_id,
                              const std::string &ecu_serial, const std::string &url) {
-  const boost::filesystem::path current = path_ / "repo/director/targets.json";
-  const boost::filesystem::path staging = path_ / "repo/director/staging/targets.json";
+  const boost::filesystem::path current = path_ / DirectorRepo::dir / "targets.json";
+  const boost::filesystem::path staging = path_ / DirectorRepo::dir / "staging/targets.json";
 
   Json::Value director_targets;
   if (boost::filesystem::exists(staging)) {
@@ -28,7 +28,7 @@ void DirectorRepo::addTarget(const std::string &target_name, const Json::Value &
 }
 
 void DirectorRepo::revokeTargets(const std::vector<std::string> &targets_to_remove) {
-  auto targets_path = path_ / "repo/director/targets.json";
+  auto targets_path = path_ / DirectorRepo::dir / "targets.json";
   auto targets_unsigned = Utils::parseJSONFile(targets_path)["signed"];
 
   Json::Value new_targets;
@@ -39,14 +39,14 @@ void DirectorRepo::revokeTargets(const std::vector<std::string> &targets_to_remo
   }
   targets_unsigned["targets"] = new_targets;
   targets_unsigned["version"] = (targets_unsigned["version"].asUInt()) + 1;
-  Utils::writeFile(path_ / "repo/director/targets.json",
+  Utils::writeFile(path_ / DirectorRepo::dir / "targets.json",
                    Utils::jsonToCanonicalStr(signTuf(Uptane::Role::Targets(), targets_unsigned)));
   updateRepo();
 }
 
 void DirectorRepo::signTargets() {
-  const boost::filesystem::path current = path_ / "repo/director/targets.json";
-  const boost::filesystem::path staging = path_ / "repo/director/staging/targets.json";
+  const boost::filesystem::path current = path_ / DirectorRepo::dir / "targets.json";
+  const boost::filesystem::path staging = path_ / DirectorRepo::dir / "staging/targets.json";
   Json::Value targets_unsigned;
 
   if (boost::filesystem::exists(staging)) {
@@ -58,15 +58,15 @@ void DirectorRepo::signTargets() {
                              "!");
   }
 
-  Utils::writeFile(path_ / "repo/director/targets.json",
+  Utils::writeFile(path_ / DirectorRepo::dir / "targets.json",
                    Utils::jsonToCanonicalStr(signTuf(Uptane::Role::Targets(), targets_unsigned)));
-  boost::filesystem::remove(path_ / "repo/director/staging/targets.json");
+  boost::filesystem::remove(path_ / DirectorRepo::dir / "staging/targets.json");
   updateRepo();
 }
 
 void DirectorRepo::emptyTargets() {
-  const boost::filesystem::path current = path_ / "repo/director/targets.json";
-  const boost::filesystem::path staging = path_ / "repo/director/staging/targets.json";
+  const boost::filesystem::path current = path_ / DirectorRepo::dir / "targets.json";
+  const boost::filesystem::path staging = path_ / DirectorRepo::dir / "staging/targets.json";
 
   Json::Value targets_current = Utils::parseJSONFile(current);
   Json::Value targets_unsigned;
@@ -82,8 +82,8 @@ void DirectorRepo::emptyTargets() {
 }
 
 void DirectorRepo::oldTargets() {
-  const boost::filesystem::path current = path_ / "repo/director/targets.json";
-  const boost::filesystem::path staging = path_ / "repo/director/staging/targets.json";
+  const boost::filesystem::path current = path_ / DirectorRepo::dir / "targets.json";
+  const boost::filesystem::path staging = path_ / DirectorRepo::dir / "staging/targets.json";
 
   if (!boost::filesystem::exists(current)) {
     throw std::runtime_error(std::string("targets.json not found at ") + current.c_str() + "!");

--- a/src/uptane_generator/director_repo.h
+++ b/src/uptane_generator/director_repo.h
@@ -13,6 +13,8 @@ class DirectorRepo : public Repo {
   void signTargets();
   void emptyTargets();
   void oldTargets();
+
+  static constexpr const char *dir{"repo/director"};
 };
 
 #endif  // DIRECTOR_REPO_H_

--- a/src/uptane_generator/image_repo.cc
+++ b/src/uptane_generator/image_repo.cc
@@ -2,7 +2,7 @@
 
 void ImageRepo::addImage(const std::string &name, Json::Value &target, const std::string &hardware_id,
                          const Delegation &delegation) {
-  boost::filesystem::path repo_dir(path_ / "repo/image");
+  boost::filesystem::path repo_dir(path_ / ImageRepo::dir);
 
   boost::filesystem::path targets_path =
       delegation ? ((repo_dir / "delegations") / delegation.name).string() + ".json" : repo_dir / "targets.json";
@@ -20,7 +20,7 @@ void ImageRepo::addImage(const std::string &name, Json::Value &target, const std
 
 void ImageRepo::addBinaryImage(const boost::filesystem::path &image_path, const boost::filesystem::path &targetname,
                                const std::string &hardware_id, const std::string &url, const Delegation &delegation) {
-  boost::filesystem::path repo_dir(path_ / "repo/image");
+  boost::filesystem::path repo_dir(path_ / ImageRepo::dir);
   boost::filesystem::path targets_path = repo_dir / "targets";
 
   auto targetname_dir = targetname.parent_path();
@@ -67,7 +67,7 @@ void ImageRepo::addDelegation(const Uptane::Role &name, const Uptane::Role &pare
     throw std::runtime_error("Delegation name " + name.ToString() + " is reserved.");
   }
 
-  boost::filesystem::path repo_dir(path_ / "repo/image");
+  boost::filesystem::path repo_dir(path_ / ImageRepo::dir);
 
   boost::filesystem::path parent_path(repo_dir);
   if (parent_role.IsDelegation()) {
@@ -108,7 +108,7 @@ void ImageRepo::addDelegation(const Uptane::Role &name, const Uptane::Role &pare
 }
 
 void ImageRepo::removeDelegationRecursive(const Uptane::Role &name, const Uptane::Role &parent_name) {
-  boost::filesystem::path repo_dir(path_ / "repo/image");
+  boost::filesystem::path repo_dir(path_ / ImageRepo::dir);
   if (parent_name.IsDelegation()) {
     repo_dir = repo_dir / "delegations";
   }
@@ -142,7 +142,7 @@ void ImageRepo::revokeDelegation(const Uptane::Role &name) {
   boost::filesystem::path keys_dir = path_ / ("keys/image/" + name.ToString());
   boost::filesystem::remove_all(keys_dir);
 
-  boost::filesystem::path repo_dir(path_ / "repo/image");
+  boost::filesystem::path repo_dir(path_ / ImageRepo::dir);
 
   boost::filesystem::remove(repo_dir / "delegations" / (name.ToString() + ".json"));
 
@@ -152,7 +152,7 @@ void ImageRepo::revokeDelegation(const Uptane::Role &name) {
 
 std::vector<std::string> ImageRepo::getDelegationTargets(const Uptane::Role &name) {
   std::vector<std::string> result;
-  boost::filesystem::path repo_dir(path_ / "repo/image");
+  boost::filesystem::path repo_dir(path_ / ImageRepo::dir);
   auto targets = Utils::parseJSONFile((repo_dir / "delegations") / (name.ToString() + ".json"))["signed"]["targets"];
   for (Json::ValueIterator it = targets.begin(); it != targets.end(); ++it) {
     result.push_back(it.key().asString());

--- a/src/uptane_generator/image_repo.h
+++ b/src/uptane_generator/image_repo.h
@@ -17,7 +17,9 @@ class ImageRepo : public Repo {
   void revokeDelegation(const Uptane::Role &name);
   std::vector<std::string> getDelegationTargets(const Uptane::Role &name);
 
-  static constexpr const char *dir{"repo/image"};
+  // note: it used to be "repo/image" which is way less confusing but we've just
+  // given up and adopted what the backend does
+  static constexpr const char *dir{"repo/repo"};
 
  private:
   void addImage(const std::string &name, Json::Value &target, const std::string &hardware_id,

--- a/src/uptane_generator/image_repo.h
+++ b/src/uptane_generator/image_repo.h
@@ -17,6 +17,8 @@ class ImageRepo : public Repo {
   void revokeDelegation(const Uptane::Role &name);
   std::vector<std::string> getDelegationTargets(const Uptane::Role &name);
 
+  static constexpr const char *dir{"repo/image"};
+
  private:
   void addImage(const std::string &name, Json::Value &target, const std::string &hardware_id,
                 const Delegation &delegation = {});

--- a/src/uptane_generator/repo.h
+++ b/src/uptane_generator/repo.h
@@ -18,22 +18,7 @@ struct KeyPair {
 
 struct Delegation {
   Delegation() = default;
-  Delegation(const boost::filesystem::path &repo_path, std::string delegation_name) : name(std::move(delegation_name)) {
-    if (Uptane::Role::IsReserved(name)) {
-      throw std::runtime_error("Delegation name " + name + " is reserved.");
-    }
-    boost::filesystem::path delegation_path(((repo_path / "repo/image/delegations") / name).string() + ".json");
-    boost::filesystem::path targets_path(repo_path / "repo/image/targets.json");
-    if (!boost::filesystem::exists(delegation_path) || !boost::filesystem::exists(targets_path)) {
-      throw std::runtime_error(std::string("delegation ") + delegation_path.string() + " does not exist");
-    }
-
-    pattern = findPatternInTree(repo_path, name, Utils::parseJSONFile(targets_path)["signed"]);
-
-    if (pattern.empty()) {
-      throw std::runtime_error("Could not find delegation role in the delegation tree");
-    }
-  }
+  Delegation(const boost::filesystem::path &repo_path, std::string delegation_name);
   bool isMatched(const boost::filesystem::path &image_path) {
     return (fnmatch(pattern.c_str(), image_path.c_str(), 0) == 0);
   }
@@ -62,6 +47,7 @@ class Repo {
   void updateRepo();
   Uptane::RepositoryType repo_type_;
   boost::filesystem::path path_;
+  boost::filesystem::path repo_dir_;
   std::string correlation_id_;
   std::string expiration_time_;
   std::map<Uptane::Role, KeyPair> keys_;

--- a/src/uptane_generator/run/serve_repo.py
+++ b/src/uptane_generator/run/serve_repo.py
@@ -16,7 +16,7 @@ class Handler(BaseHTTPRequestHandler):
         if self.path.startswith('/director/'):
             self.do_get_static(top_path + "/uptane/repo/director/", self.path[10:])
         elif self.path.startswith('/repo/'):
-            self.do_get_static(top_path + "/uptane/repo/image/", self.path[6:])
+            self.do_get_static(top_path + "/uptane/repo/repo/", self.path[6:])
         elif self.path.startswith('/treehub/'):
             self.do_get_static(top_path + "/uptane/repo/ostree/", self.path[9:])
         else:

--- a/tests/fake_http_server/fake_api_server.py
+++ b/tests/fake_http_server/fake_api_server.py
@@ -11,7 +11,7 @@ class Handler(BaseHTTPRequestHandler):
         self.send_response(200)
         self.end_headers()
         if self.path == "/api/v1/user_repo/targets.json":
-            with open(os.path.join(sys.argv[2], "repo/image/targets.json")) as f:
+            with open(os.path.join(sys.argv[2], "repo/repo/targets.json")) as f:
                 self.wfile.write(bytes(f.read(), "utf8"))
 
     def do_POST(self):

--- a/tests/fake_http_server/fake_test_server.py
+++ b/tests/fake_http_server/fake_test_server.py
@@ -62,7 +62,7 @@ class Handler(SimpleHTTPRequestHandler):
             self.send_response(200)
             self.end_headers()
             role = self.path[len("/repo/"):]
-            self.serve_meta('/repo/image/' + role)
+            self.serve_meta('/repo/repo/' + role)
         elif self.path.startswith("/repo/targets"):
             self.send_response(200)
             self.end_headers()
@@ -181,7 +181,7 @@ class FakeTestServer(socketserver.ThreadingMixIn, HTTPServer):
         if target_path is not None:
             self.target_path = target_path
         elif meta_path is not None:
-            self.target_path = path.join(meta_path, 'repo/image/targets')
+            self.target_path = path.join(meta_path, 'repo/repo/targets')
         else:
             self.target_path = None
         self.fail_injector = fail_injector

--- a/tests/ipsecondary_test.py
+++ b/tests/ipsecondary_test.py
@@ -23,8 +23,8 @@ logger = logging.getLogger("IPSecondaryTest")
 class UptaneTestRepo:
 
     def __init__(self, repo_manager_exe):
-        self.image_rel_dir = 'repo/image'
-        self.target_rel_dir = 'repo/image/targets'
+        self.image_rel_dir = 'repo/repo'
+        self.target_rel_dir = 'repo/repo/targets'
 
         self._repo_manager_exe = repo_manager_exe
         self._repo_root_dir = tempfile.TemporaryDirectory()

--- a/tests/metafake.h
+++ b/tests/metafake.h
@@ -75,8 +75,8 @@ class MetaFake {
       rename("_multisec");
 
       // copy meta to work_dir
-      Utils::copyDir(work_dir / "repo/image", meta_dir / "repo");
-      Utils::copyDir(work_dir / "repo/director", meta_dir / "director");
+      Utils::copyDir(work_dir / ImageRepo::dir, meta_dir / "repo");
+      Utils::copyDir(work_dir / DirectorRepo::dir, meta_dir / "director");
       if (!boost::filesystem::exists(meta_dir / "campaigner") &&
            boost::filesystem::is_directory("tests/test_data/campaigner")) {
           Utils::copyDir("tests/test_data/campaigner", meta_dir / "campaigner");
@@ -95,16 +95,16 @@ class MetaFake {
   }
 
   void backup(void) {
-      backup_files.push_back(work_dir / "repo/director/targets.json");
+      backup_files.push_back(work_dir / DirectorRepo::dir / "targets.json");
       backup_content.push_back(Utils::readFile(backup_files[0], false));
 
-      backup_files.push_back(work_dir / "repo/image/snapshot.json");
+      backup_files.push_back(work_dir / ImageRepo::dir / "snapshot.json");
       backup_content.push_back(Utils::readFile(backup_files[1], false));
 
-      backup_files.push_back(work_dir / "repo/image/targets.json");
+      backup_files.push_back(work_dir / ImageRepo::dir / "targets.json");
       backup_content.push_back(Utils::readFile(backup_files[2], false));
 
-      backup_files.push_back(work_dir / "repo/image/timestamp.json");
+      backup_files.push_back(work_dir / ImageRepo::dir / "timestamp.json");
       backup_content.push_back(Utils::readFile(backup_files[3], false));
   }
 

--- a/tests/sota_tools/cert_generation/generate-zips.sh
+++ b/tests/sota_tools/cert_generation/generate-zips.sh
@@ -9,16 +9,23 @@ fi
 SRC_DIR=$(dirname "$0")
 DEST_DIR="$1"
 
+if [[ -f $DEST_DIR/good.zip && \
+    $DEST_DIR/good.zip -nt $SRC_DIR/client_good.p12 && \
+    $DEST_DIR/good.zip -nt $SRC_DIR/client_bad.p12 && \
+    $DEST_DIR/good.zip -nt $SRC_DIR/turepo.url ]]; then
+    exit 0
+fi
+
 mkdir -p "$DEST_DIR"
 trap 'rm -rf "$DEST_DIR"' ERR
 
-TREEHUB="{\
-  \"ostree\": {\
-    \"server\": \"https://localhost:1443/\"\
-  }\
-}"
-
-echo $TREEHUB > "$DEST_DIR/treehub.json"
+cat << 'EOF' > "$DEST_DIR/treehub.json"
+{
+  "ostree": {
+    "server": "https://localhost:1443/"
+  }
+}
+EOF
 
 cp "$SRC_DIR/client_good.p12" "$DEST_DIR/client_auth.p12"
 zip -j "$DEST_DIR/good.zip" "$DEST_DIR/client_auth.p12" "$DEST_DIR/treehub.json" "$SRC_DIR/tufrepo.url"


### PR DESCRIPTION
Replaces the "image" directory generated by uptane-generator with "repo", to match backend more closely.

Includes a small refactor to make it easier to change that in one place.