### PR TITLE
Add automatic removal of old installed targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Our versioning scheme is `YEAR.N` where `N` is incremented whenever a new releas
 
 ## [??? (unreleased)]
 
+### Added
+
+- `GetInstallationLog` API method: [PR](https://github.com/advancedtelematic/aktualizr/pull/1318)
+- The aktualizr daemon will now automatically remove old downloaded targets to free up disk space: [PR](https://github.com/advancedtelematic/aktualizr/pull/1318)
+
 ## [2019.6] - 2019-08-21
 
 ### Added

--- a/actions.md
+++ b/actions.md
@@ -173,6 +173,7 @@ These are the primary actions that a user of libaktualizr can perform through th
   - [x] Store negative device installation result when an ECU installation failed (aktualizr_test.cc)
   - [x] Update is not in pending state anymore after failed installation (aktualizr_test.cc)
   - [x] Send AllInstallsComplete event after all installations are finished (aktualizr_test.cc)
+  - [x] Automatically remove old targets during installation cycles (aktualizr_test.cc)
 - [x] Send installation report
   - [x] Generate and send manifest (see below)
   - [x] Send PutManifestComplete event if send is successful (aktualizr_test.cc)

--- a/config/sql/migration/migrate.20.sql
+++ b/config/sql/migration/migrate.20.sql
@@ -1,0 +1,13 @@
+-- Don't modify this! Create a new migration instead--see docs/schema-migrations.adoc
+SAVEPOINT MIGRATION;
+
+ALTER TABLE installed_versions RENAME TO installed_versions_old;
+CREATE TABLE installed_versions(id INTEGER PRIMARY KEY, ecu_serial TEXT NOT NULL, sha256 TEXT NOT NULL, name TEXT NOT NULL, hashes TEXT NOT NULL, length INTEGER NOT NULL DEFAULT 0, correlation_id TEXT NOT NULL DEFAULT '', is_current INTEGER NOT NULL CHECK (is_current IN (0,1)) DEFAULT 0, is_pending INTEGER NOT NULL CHECK (is_pending IN (0,1)) DEFAULT 0, was_installed INTEGER NOT NULL CHECK (was_installed IN (0,1)) DEFAULT 0);
+INSERT INTO installed_versions(ecu_serial, sha256, name, hashes, length, correlation_id, is_current, is_pending, was_installed) SELECT installed_versions_old.ecu_serial, installed_versions_old.sha256, installed_versions_old.name, installed_versions_old.hashes, installed_versions_old.length, installed_versions_old.correlation_id, installed_versions_old.is_current, installed_versions_old.is_pending, 1 FROM installed_versions_old ORDER BY rowid;
+
+DROP TABLE installed_versions_old;
+
+DELETE FROM version;
+INSERT INTO version VALUES(20);
+
+RELEASE MIGRATION;

--- a/config/sql/rollback/rollback.20.sql
+++ b/config/sql/rollback/rollback.20.sql
@@ -1,0 +1,13 @@
+-- Don't modify this! Create a new migration instead--see docs/schema-migrations.adoc
+SAVEPOINT ROLLBACK_MIGRATION;
+
+CREATE TABLE installed_versions_migrate(ecu_serial TEXT NOT NULL, sha256 TEXT NOT NULL, name TEXT NOT NULL, hashes TEXT NOT NULL, length INTEGER NOT NULL DEFAULT 0, correlation_id TEXT NOT NULL DEFAULT '', is_current INTEGER NOT NULL CHECK (is_current IN (0,1)) DEFAULT 0, is_pending INTEGER NOT NULL CHECK (is_pending IN (0,1)) DEFAULT 0, UNIQUE(ecu_serial, sha256, name));
+INSERT INTO installed_versions_migrate(ecu_serial, sha256, name, hashes, length, correlation_id, is_current, is_pending) SELECT installed_versions.ecu_serial, installed_versions.sha256, installed_versions.name, installed_versions.hashes, installed_versions.length, installed_versions.correlation_id, installed_versions.is_current, installed_versions.is_pending FROM installed_versions;
+
+DROP TABLE installed_versions;
+ALTER TABLE installed_versions_migrate RENAME TO installed_versions;
+
+DELETE FROM version;
+INSERT INTO version VALUES(19);
+
+RELEASE ROLLBACK_MIGRATION;

--- a/config/sql/schema.sql
+++ b/config/sql/schema.sql
@@ -1,9 +1,9 @@
 CREATE TABLE version(version INTEGER);
-INSERT INTO version(rowid,version) VALUES(1,19);
+INSERT INTO version(rowid,version) VALUES(1,20);
 CREATE TABLE device_info(unique_mark INTEGER PRIMARY KEY CHECK (unique_mark = 0), device_id TEXT, is_registered INTEGER NOT NULL DEFAULT 0 CHECK (is_registered IN (0,1)));
 CREATE TABLE ecu_serials(id INTEGER PRIMARY KEY, serial TEXT UNIQUE, hardware_id TEXT NOT NULL, is_primary INTEGER NOT NULL DEFAULT 0 CHECK (is_primary IN (0,1)));
 CREATE TABLE misconfigured_ecus(serial TEXT UNIQUE, hardware_id TEXT NOT NULL, state INTEGER NOT NULL CHECK (state IN (0,1)));
-CREATE TABLE installed_versions(ecu_serial TEXT NOT NULL, sha256 TEXT NOT NULL, name TEXT NOT NULL, hashes TEXT NOT NULL, length INTEGER NOT NULL DEFAULT 0, correlation_id TEXT NOT NULL DEFAULT '', is_current INTEGER NOT NULL CHECK (is_current IN (0,1)) DEFAULT 0, is_pending INTEGER NOT NULL CHECK (is_pending IN (0,1)) DEFAULT 0, UNIQUE(ecu_serial, sha256, name));
+CREATE TABLE installed_versions(id INTEGER PRIMARY KEY, ecu_serial TEXT NOT NULL, sha256 TEXT NOT NULL, name TEXT NOT NULL, hashes TEXT NOT NULL, length INTEGER NOT NULL DEFAULT 0, correlation_id TEXT NOT NULL DEFAULT '', is_current INTEGER NOT NULL CHECK (is_current IN (0,1)) DEFAULT 0, is_pending INTEGER NOT NULL CHECK (is_pending IN (0,1)) DEFAULT 0, was_installed INTEGER NOT NULL CHECK (was_installed IN (0,1)) DEFAULT 0);
 CREATE TABLE primary_keys(unique_mark INTEGER PRIMARY KEY CHECK (unique_mark = 0), private TEXT, public TEXT);
 CREATE TABLE tls_creds(ca_cert BLOB, ca_cert_format TEXT,
                        client_cert BLOB, client_cert_format TEXT,

--- a/src/aktualizr_lite/ostree_mock.cc
+++ b/src/aktualizr_lite/ostree_mock.cc
@@ -1,4 +1,5 @@
 #include <ostree.h>
+#include <stdlib.h>
 
 extern "C" OstreeDeployment *ostree_sysroot_get_booted_deployment(OstreeSysroot *self) {
   (void)self;

--- a/src/aktualizr_primary/main.cc
+++ b/src/aktualizr_primary/main.cc
@@ -87,7 +87,7 @@ bpo::variables_map parse_options(int argc, char *argv[]) {
 }
 
 void process_event(const std::shared_ptr<event::BaseEvent> &event) {
-  if (event->isTypeOf(event::DownloadProgressReport::TypeName)) {
+  if (event->isTypeOf<event::DownloadProgressReport>()) {
     // Do nothing; libaktualizr already logs it.
   } else if (event->variant == "UpdateCheckComplete") {
     // Do nothing; libaktualizr already logs it.

--- a/src/aktualizr_primary/main.cc
+++ b/src/aktualizr_primary/main.cc
@@ -8,6 +8,7 @@
 #include "config/config.h"
 #include "logging/logging.h"
 #include "primary/aktualizr.h"
+#include "primary/aktualizr_helpers.h"
 #include "secondary.h"
 #include "utilities/aktualizr_version.h"
 #include "utilities/utils.h"
@@ -157,6 +158,9 @@ int main(int argc, char *argv[]) {
       aktualizr.SendDeviceData().get();
       aktualizr.UptaneCycle();
     } else {
+      boost::signals2::connection ac_conn =
+          aktualizr.SetSignalHandler(std::bind(targets_autoclean_cb, std::ref(aktualizr), std::placeholders::_1));
+
       aktualizr.RunForever().get();
     }
     r = EXIT_SUCCESS;

--- a/src/libaktualizr/package_manager/androidmanager.cc
+++ b/src/libaktualizr/package_manager/androidmanager.cc
@@ -55,7 +55,7 @@ Uptane::Target AndroidManager::getCurrent() const {
     qi::phrase_parse(getprop_output.crbegin(), getprop_output.crend(),
                      *(xdigit[push_front(boost::phoenix::ref(hash), _1)]), boost::spirit::ascii::cntrl);
     std::vector<Uptane::Target> installed_versions;
-    storage_->loadPrimaryInstalledVersions(&installed_versions, nullptr, nullptr);
+    storage_->loadPrimaryInstallationLog(&installed_versions, false);
     for (const auto& target : installed_versions) {
       if (std::equal(hash.cbegin(), hash.cend(), target.sha256Hash().cbegin())) {
         return target;

--- a/src/libaktualizr/package_manager/debianmanager.cc
+++ b/src/libaktualizr/package_manager/debianmanager.cc
@@ -31,12 +31,11 @@ data::InstallationResult DebianManager::install(const Uptane::Target &target) co
 }
 
 Uptane::Target DebianManager::getCurrent() const {
-  std::vector<Uptane::Target> installed_versions;
-  size_t current_k = SIZE_MAX;
-  storage_->loadPrimaryInstalledVersions(&installed_versions, &current_k, nullptr);
+  boost::optional<Uptane::Target> current_version;
+  storage_->loadPrimaryInstalledVersions(&current_version, nullptr);
 
-  if (current_k != SIZE_MAX) {
-    return installed_versions.at(current_k);
+  if (!!current_version) {
+    return *current_version;
   }
 
   return Uptane::Target::Unknown();

--- a/src/libaktualizr/package_manager/ostreemanager.cc
+++ b/src/libaktualizr/package_manager/ostreemanager.cc
@@ -299,7 +299,7 @@ Uptane::Target OstreeManager::getCurrent() const {
   std::string current_hash = ostree_deployment_get_csum(booted_deployment);
 
   std::vector<Uptane::Target> installed_versions;
-  storage_->loadPrimaryInstalledVersions(&installed_versions, nullptr, nullptr);
+  storage_->loadPrimaryInstallationLog(&installed_versions, false);
 
   // Version should be in installed versions. Its possible that multiple
   // targets could have the same sha256Hash. In this case the safest assumption

--- a/src/libaktualizr/primary/CMakeLists.txt
+++ b/src/libaktualizr/primary/CMakeLists.txt
@@ -1,10 +1,12 @@
 set(SOURCES aktualizr.cc
+            aktualizr_helpers.cc
             initializer.cc
             reportqueue.cc
             sotauptaneclient.cc)
 
 set(HEADERS secondary_config.h
             aktualizr.h
+            aktualizr_helpers.h
             events.h
             initializer.h
             reportqueue.h
@@ -32,8 +34,7 @@ if (BUILD_OSTREE)
         LABELS "noptest")
     target_link_libraries(t_download_nonostree virtual_secondary)
 else (BUILD_OSTREE)
-    aktualizr_source_file_checks(aktualizr_fullostree_test.cc)
-    aktualizr_source_file_checks(download_nonostree_test.cc)
+    aktualizr_source_file_checks(aktualizr_fullostree_test.cc download_nonostree_test.cc)
 endif (BUILD_OSTREE)
 
 add_aktualizr_test(NAME reportqueue SOURCES reportqueue_test.cc PROJECT_WORKING_DIRECTORY LIBRARIES PUBLIC uptane_generator_lib)

--- a/src/libaktualizr/primary/aktualizr.cc
+++ b/src/libaktualizr/primary/aktualizr.cc
@@ -170,6 +170,28 @@ boost::signals2::connection Aktualizr::SetSignalHandler(
   return sig_->connect(handler);
 }
 
+Aktualizr::InstallationLog Aktualizr::GetInstallationLog() {
+  std::vector<Aktualizr::InstallationLogEntry> ilog;
+
+  EcuSerials serials;
+  if (!storage_->loadEcuSerials(&serials)) {
+    throw std::runtime_error("Could not load ecu serials");
+  }
+
+  ilog.reserve(serials.size());
+  for (const auto &s : serials) {
+    Uptane::EcuSerial serial = s.first;
+    std::vector<Uptane::Target> installs;
+
+    std::vector<Uptane::Target> log;
+    storage_->loadInstallationLog(serial.ToString(), &log, true);
+
+    ilog.emplace_back(Aktualizr::InstallationLogEntry{serial, std::move(log)});
+  }
+
+  return ilog;
+}
+
 std::vector<Uptane::Target> Aktualizr::GetStoredTargets() { return storage_->getTargetFiles(); }
 
 void Aktualizr::DeleteStoredTarget(const Uptane::Target &target) { storage_->removeTargetFile(target.filename()); }

--- a/src/libaktualizr/primary/aktualizr.h
+++ b/src/libaktualizr/primary/aktualizr.h
@@ -83,7 +83,9 @@ class Aktualizr {
   std::future<result::Download> Download(const std::vector<Uptane::Target>& updates);
 
   /**
-   * Get log of installations
+   * Get log of installations. The log is indexed for every ECU and contains
+   * every change of versions ordered by time. It may contain duplicates in
+   * case of rollbacks.
    * @return installation log
    */
   struct InstallationLogEntry {

--- a/src/libaktualizr/primary/aktualizr.h
+++ b/src/libaktualizr/primary/aktualizr.h
@@ -1,7 +1,7 @@
 #ifndef AKTUALIZR_H_
 #define AKTUALIZR_H_
 
-#include <atomic>
+#include <future>
 #include <memory>
 
 #include <boost/signals2.hpp>
@@ -81,6 +81,17 @@ class Aktualizr {
    * @return std::future object with information about download results.
    */
   std::future<result::Download> Download(const std::vector<Uptane::Target>& updates);
+
+  /**
+   * Get log of installations
+   * @return installation log
+   */
+  struct InstallationLogEntry {
+    Uptane::EcuSerial ecu;
+    std::vector<Uptane::Target> installs;
+  };
+  using InstallationLog = std::vector<InstallationLogEntry>;
+  InstallationLog GetInstallationLog();
 
   /**
    * Get list of targets currently in storage. This is intended to be used with

--- a/src/libaktualizr/primary/aktualizr_helpers.cc
+++ b/src/libaktualizr/primary/aktualizr_helpers.cc
@@ -1,0 +1,36 @@
+#include <set>
+
+#include "aktualizr_helpers.h"
+
+void targets_autoclean_cb(Aktualizr &aktualizr, const std::shared_ptr<event::BaseEvent> &event) {
+  if (!event->isTypeOf<event::AllInstallsComplete>()) {
+    return;
+  }
+
+  std::vector<Uptane::Target> installed_targets = aktualizr.GetStoredTargets();
+  std::vector<bool> to_remove(installed_targets.size(), true);
+
+  Aktualizr::InstallationLog log = aktualizr.GetInstallationLog();
+
+  // keep the last two installed targets for each ecu
+  for (const Aktualizr::InstallationLogEntry &entry : log) {
+    auto start = entry.installs.size() >= 2 ? entry.installs.end() - 2 : entry.installs.begin();
+    for (auto it = start; it != entry.installs.end(); it++) {
+      auto fit = std::find_if(installed_targets.begin(), installed_targets.end(),
+                              [&it](const Uptane::Target &t2) { return it->sha256Hash() == t2.sha256Hash(); });
+
+      if (fit == installed_targets.end()) {
+        continue;
+      }
+
+      size_t rem_idx = static_cast<size_t>(fit - installed_targets.begin());
+      to_remove[rem_idx] = false;
+    }
+  }
+
+  for (size_t k = 0; k < installed_targets.size(); k++) {
+    if (to_remove[k]) {
+      aktualizr.DeleteStoredTarget(installed_targets[k]);
+    }
+  }
+}

--- a/src/libaktualizr/primary/aktualizr_helpers.h
+++ b/src/libaktualizr/primary/aktualizr_helpers.h
@@ -1,0 +1,11 @@
+#ifndef AKTUALIZR_HELPERS_H_
+#define AKTUALIZR_HELPERS_H_
+
+#include <memory>
+#include "aktualizr.h"
+
+// add as a signal handler to remove old targets just after an installation
+// completes
+void targets_autoclean_cb(Aktualizr &aktualizr, const std::shared_ptr<event::BaseEvent> &event);
+
+#endif  // AKTUALIZR_HELPERS_H_

--- a/src/libaktualizr/primary/aktualizr_helpers.h
+++ b/src/libaktualizr/primary/aktualizr_helpers.h
@@ -4,8 +4,11 @@
 #include <memory>
 #include "aktualizr.h"
 
-// add as a signal handler to remove old targets just after an installation
-// completes
+/*
+ * Signal handler to remove old targets just after an installation completes
+ *
+ * To be attached with Aktualizr::SetSignalHandler
+ */
 void targets_autoclean_cb(Aktualizr &aktualizr, const std::shared_ptr<event::BaseEvent> &event);
 
 #endif  // AKTUALIZR_HELPERS_H_

--- a/src/libaktualizr/primary/aktualizr_test.cc
+++ b/src/libaktualizr/primary/aktualizr_test.cc
@@ -79,7 +79,7 @@ TEST(Aktualizr, FullNoUpdates) {
   ev_state.future = ev_state.promise.get_future();
 
   auto f_cb = [&ev_state](const std::shared_ptr<event::BaseEvent>& event) {
-    if (event->isTypeOf(event::DownloadProgressReport::TypeName)) {
+    if (event->isTypeOf<event::DownloadProgressReport>()) {
       return;
     }
     LOG_INFO << "Got " << event->variant;
@@ -256,7 +256,7 @@ TEST(Aktualizr, FullWithUpdates) {
   ev_state.future = ev_state.promise.get_future();
 
   auto f_cb = [&ev_state](const std::shared_ptr<event::BaseEvent>& event) {
-    if (event->isTypeOf(event::DownloadProgressReport::TypeName)) {
+    if (event->isTypeOf<event::DownloadProgressReport>()) {
       return;
     }
     LOG_INFO << "Got " << event->variant;
@@ -1065,7 +1065,7 @@ TEST(Aktualizr, CheckNoUpdates) {
   ev_state.future = ev_state.promise.get_future();
 
   auto f_cb = [&ev_state](const std::shared_ptr<event::BaseEvent>& event) {
-    if (event->isTypeOf(event::DownloadProgressReport::TypeName)) {
+    if (event->isTypeOf<event::DownloadProgressReport>()) {
       return;
     }
     LOG_INFO << "Got " << event->variant;
@@ -1141,7 +1141,7 @@ TEST(Aktualizr, DownloadWithUpdates) {
   ev_state.future = ev_state.promise.get_future();
 
   auto f_cb = [&ev_state](const std::shared_ptr<event::BaseEvent>& event) {
-    if (event->isTypeOf(event::DownloadProgressReport::TypeName)) {
+    if (event->isTypeOf<event::DownloadProgressReport>()) {
       return;
     }
     LOG_INFO << "Got " << event->variant;
@@ -1263,12 +1263,12 @@ TEST(Aktualizr, DownloadFailures) {
     void operator()(const std::shared_ptr<event::BaseEvent>& event) {
       ASSERT_NE(event, nullptr);
 
-      if (event->isTypeOf(event::DownloadTargetComplete::TypeName)) {
+      if (event->isTypeOf<event::DownloadTargetComplete>()) {
         auto download_target_complete_event = dynamic_cast<event::DownloadTargetComplete*>(event.get());
         auto target_filename = download_target_complete_event->update.filename();
         download_status[target_filename] = download_target_complete_event->success;
 
-      } else if (event->isTypeOf(event::AllDownloadsComplete::TypeName)) {
+      } else if (event->isTypeOf<event::AllDownloadsComplete>()) {
         auto all_download_complete_event = dynamic_cast<event::AllDownloadsComplete*>(event.get());
         all_download_completed_status = all_download_complete_event->result;
       }
@@ -1386,7 +1386,7 @@ TEST(Aktualizr, InstallWithUpdates) {
   auto f_cb = [&ev_state](const std::shared_ptr<event::BaseEvent>& event) {
     // Note that we do not expect a PutManifestComplete since we don't call
     // UptaneCycle() and that's the only function that generates that.
-    if (event->isTypeOf(event::DownloadProgressReport::TypeName)) {
+    if (event->isTypeOf<event::DownloadProgressReport>()) {
       return;
     }
     LOG_INFO << "Got " << event->variant;
@@ -1545,7 +1545,7 @@ TEST(Aktualizr, ReportDownloadProgress) {
   std::function<void(std::shared_ptr<event::BaseEvent> event)> report_event_hdlr =
       [&](const std::shared_ptr<event::BaseEvent>& event) {
         ASSERT_NE(event, nullptr);
-        if (!event->isTypeOf(event::DownloadProgressReport::TypeName)) {
+        if (!event->isTypeOf<event::DownloadProgressReport>()) {
           return;
         }
 

--- a/src/libaktualizr/primary/aktualizr_test.cc
+++ b/src/libaktualizr/primary/aktualizr_test.cc
@@ -1332,6 +1332,10 @@ TEST(Aktualizr, DownloadListRemove) {
   EXPECT_EQ(targets.size(), 0);
 }
 
+/*
+ * Automatically remove old targets during installation cycles.
+ * Get log of installation.
+ */
 TEST(Aktualizr, TargetAutoremove) {
   TemporaryDirectory temp_dir;
   const boost::filesystem::path local_metadir = temp_dir / "metadir";

--- a/src/libaktualizr/primary/events.h
+++ b/src/libaktualizr/primary/events.h
@@ -26,7 +26,10 @@ class BaseEvent {
   BaseEvent(std::string variant_in) : variant(std::move(variant_in)) {}
   virtual ~BaseEvent() = default;
 
-  bool isTypeOf(const std::string& type_to_cmp) { return (variant == type_to_cmp); }
+  template <typename T>
+  bool isTypeOf() {
+    return variant == T::TypeName;
+  }
 
   std::string variant;
 };
@@ -36,7 +39,9 @@ class BaseEvent {
  */
 class SendDeviceDataComplete : public BaseEvent {
  public:
-  SendDeviceDataComplete() { variant = "SendDeviceDataComplete"; }
+  static constexpr const char* TypeName{"SendDeviceDataComplete"};
+
+  SendDeviceDataComplete() { variant = TypeName; }
 };
 
 /**
@@ -44,7 +49,8 @@ class SendDeviceDataComplete : public BaseEvent {
  */
 class PutManifestComplete : public BaseEvent {
  public:
-  explicit PutManifestComplete(bool success_in) : success(success_in) { variant = "PutManifestComplete"; }
+  static constexpr const char* TypeName{"PutManifestComplete"};
+  explicit PutManifestComplete(bool success_in) : success(success_in) { variant = TypeName; }
   bool success;
 };
 
@@ -53,9 +59,8 @@ class PutManifestComplete : public BaseEvent {
  */
 class UpdateCheckComplete : public BaseEvent {
  public:
-  explicit UpdateCheckComplete(result::UpdateCheck result_in) : result(std::move(result_in)) {
-    variant = "UpdateCheckComplete";
-  }
+  static constexpr const char* TypeName{"UpdateCheckComplete"};
+  explicit UpdateCheckComplete(result::UpdateCheck result_in) : result(std::move(result_in)) { variant = TypeName; }
 
   result::UpdateCheck result;
 };
@@ -118,7 +123,9 @@ class AllDownloadsComplete : public BaseEvent {
  */
 class InstallStarted : public BaseEvent {
  public:
-  explicit InstallStarted(Uptane::EcuSerial serial_in) : serial(std::move(serial_in)) { variant = "InstallStarted"; }
+  static constexpr const char* TypeName{"InstallStarted"};
+
+  explicit InstallStarted(Uptane::EcuSerial serial_in) : serial(std::move(serial_in)) { variant = TypeName; }
   Uptane::EcuSerial serial;
 };
 
@@ -127,9 +134,11 @@ class InstallStarted : public BaseEvent {
  */
 class InstallTargetComplete : public BaseEvent {
  public:
+  static constexpr const char* TypeName{"InstallTargetComplete"};
+
   InstallTargetComplete(Uptane::EcuSerial serial_in, bool success_in)
       : serial(std::move(serial_in)), success(success_in) {
-    variant = "InstallTargetComplete";
+    variant = TypeName;
   }
 
   Uptane::EcuSerial serial;
@@ -141,9 +150,9 @@ class InstallTargetComplete : public BaseEvent {
  */
 class AllInstallsComplete : public BaseEvent {
  public:
-  explicit AllInstallsComplete(result::Install result_in) : result(std::move(result_in)) {
-    variant = "AllInstallsComplete";
-  }
+  static constexpr const char* TypeName{"AllInstallsComplete"};
+
+  explicit AllInstallsComplete(result::Install result_in) : result(std::move(result_in)) { variant = TypeName; }
 
   result::Install result;
 };
@@ -153,9 +162,9 @@ class AllInstallsComplete : public BaseEvent {
  */
 class CampaignCheckComplete : public BaseEvent {
  public:
-  explicit CampaignCheckComplete(result::CampaignCheck result_in) : result(std::move(result_in)) {
-    variant = "CampaignCheckComplete";
-  }
+  static constexpr const char* TypeName{"CampaignCheckComplete"};
+
+  explicit CampaignCheckComplete(result::CampaignCheck result_in) : result(std::move(result_in)) { variant = TypeName; }
 
   result::CampaignCheck result;
 };
@@ -165,17 +174,23 @@ class CampaignCheckComplete : public BaseEvent {
  */
 class CampaignAcceptComplete : public BaseEvent {
  public:
-  CampaignAcceptComplete() { variant = "CampaignAcceptComplete"; }
+  static constexpr const char* TypeName{"CampaignAcceptComplete"};
+
+  CampaignAcceptComplete() { variant = TypeName; }
 };
 
 class CampaignDeclineComplete : public BaseEvent {
  public:
-  CampaignDeclineComplete() { variant = "CampaignDeclineComplete"; }
+  static constexpr const char* TypeName{"CampaignDeclineComplete"};
+
+  CampaignDeclineComplete() { variant = TypeName; }
 };
 
 class CampaignPostponeComplete : public BaseEvent {
  public:
-  CampaignPostponeComplete() { variant = "CampaignPostponeComplete"; }
+  static constexpr const char* TypeName{"CampaignPostponeComplete"};
+
+  CampaignPostponeComplete() { variant = TypeName; }
 };
 
 using Channel = boost::signals2::signal<void(std::shared_ptr<event::BaseEvent>)>;

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -134,7 +134,7 @@ class SotaUptaneClient {
     std::shared_ptr<event::BaseEvent> event = std::make_shared<T>(std::forward<Args>(args)...);
     if (events_channel) {
       (*events_channel)(std::move(event));
-    } else if (!event->isTypeOf(event::DownloadProgressReport::TypeName)) {
+    } else if (!event->isTypeOf<event::DownloadProgressReport>()) {
       LOG_INFO << "got " << event->variant << " event";
     }
   }

--- a/src/libaktualizr/storage/invstorage.cc
+++ b/src/libaktualizr/storage/invstorage.cc
@@ -70,7 +70,7 @@ void INvStorage::importPrimaryKeys(const boost::filesystem::path& base_path, con
 void INvStorage::importInstalledVersions(const boost::filesystem::path& base_path) {
   std::vector<Uptane::Target> installed_versions;
   const boost::filesystem::path file_path = BasedPath("installed_versions").get(base_path);
-  loadPrimaryInstalledVersions(&installed_versions, nullptr, nullptr);
+  loadPrimaryInstallationLog(&installed_versions, false);
   if (!installed_versions.empty()) {
     return;
   }

--- a/src/libaktualizr/storage/invstorage.h
+++ b/src/libaktualizr/storage/invstorage.h
@@ -164,8 +164,10 @@ class INvStorage {
 
   virtual void saveInstalledVersion(const std::string& ecu_serial, const Uptane::Target& target,
                                     InstalledVersionUpdateMode update_mode) = 0;
-  virtual bool loadInstalledVersions(const std::string& ecu_serial, std::vector<Uptane::Target>* installed_versions,
-                                     size_t* current_version, size_t* pending_version) = 0;
+  virtual bool loadInstalledVersions(const std::string& ecu_serial, boost::optional<Uptane::Target>* current_version,
+                                     boost::optional<Uptane::Target>* pending_version) = 0;
+  virtual bool loadInstallationLog(const std::string& ecu_serial, std::vector<Uptane::Target>* log,
+                                   bool only_installed) = 0;
   virtual bool hasPendingInstall() = 0;
   virtual void clearInstalledVersions() = 0;
 
@@ -199,12 +201,15 @@ class INvStorage {
 
   // Not purely virtual
   void importData(const ImportConfig& import_config);
-  bool loadPrimaryInstalledVersions(std::vector<Uptane::Target>* installed_versions, size_t* current_version,
-                                    size_t* pending_version) {
-    return loadInstalledVersions("", installed_versions, current_version, pending_version);
+  bool loadPrimaryInstalledVersions(boost::optional<Uptane::Target>* current_version,
+                                    boost::optional<Uptane::Target>* pending_version) {
+    return loadInstalledVersions("", current_version, pending_version);
   }
   void savePrimaryInstalledVersion(const Uptane::Target& target, InstalledVersionUpdateMode update_mode) {
     return saveInstalledVersion("", target, update_mode);
+  }
+  bool loadPrimaryInstallationLog(std::vector<Uptane::Target>* log, bool only_installed) {
+    return loadInstallationLog("", log, only_installed);
   }
 
  private:

--- a/src/libaktualizr/storage/sqlstorage.h
+++ b/src/libaktualizr/storage/sqlstorage.h
@@ -66,8 +66,10 @@ class SQLStorage : public SQLStorageBase, public INvStorage {
   void clearNeedReboot() override;
   void saveInstalledVersion(const std::string& ecu_serial, const Uptane::Target& target,
                             InstalledVersionUpdateMode update_mode) override;
-  bool loadInstalledVersions(const std::string& ecu_serial, std::vector<Uptane::Target>* installed_versions,
-                             size_t* current_version, size_t* pending_version) override;
+  bool loadInstalledVersions(const std::string& ecu_serial, boost::optional<Uptane::Target>* current_version,
+                             boost::optional<Uptane::Target>* pending_version) override;
+  bool loadInstallationLog(const std::string& ecu_serial, std::vector<Uptane::Target>* log,
+                           bool only_installed) override;
   bool hasPendingInstall() override;
   void clearInstalledVersions() override;
 

--- a/src/libaktualizr/storage/sqlstorage_test.cc
+++ b/src/libaktualizr/storage/sqlstorage_test.cc
@@ -496,9 +496,9 @@ TEST(sqlstorage, migrate_from_fs) {
 
     EXPECT_TRUE(storage->loadEcuRegistered());
 
-    std::vector<Uptane::Target> installed;
-    storage->loadPrimaryInstalledVersions(&installed, nullptr, nullptr);
-    EXPECT_NE(installed.size(), 0);
+    boost::optional<Uptane::Target> installed;
+    storage->loadPrimaryInstalledVersions(&installed, nullptr);
+    EXPECT_TRUE(!!installed);
   }
 
   // note: installation result is not migrated anymore

--- a/src/uptane_generator/repo.cc
+++ b/src/uptane_generator/repo.cc
@@ -228,6 +228,9 @@ Json::Value Repo::getTarget(const std::string &target_name) {
   if (image_targets["targets"].isMember(target_name)) {
     return image_targets["targets"][target_name];
   } else if (repo_type_ == Uptane::RepositoryType::Image()) {
+    if (!boost::filesystem::is_directory(repo_dir_ / "delegations")) {
+      return {};
+    }
     for (auto &p : boost::filesystem::directory_iterator(repo_dir_ / "delegations")) {
       if (Uptane::Role::IsReserved(p.path().stem().string())) {
         continue;
@@ -237,7 +240,6 @@ Json::Value Repo::getTarget(const std::string &target_name) {
         return targets["targets"][target_name];
       }
     }
-    throw std::runtime_error(std::string("No target with name: ") + target_name);
   }
   return {};
 }


### PR DESCRIPTION
This adds a mechanism to remove old downloaded targets.

Here, "old" is what was before the current and the previous installed version and the cleaning is done at the end of the installation.

It's only enabled when using aktualizr's executable but can be added through the API as well.

~~This first version is simple. I was planning to add a more complex logic based on the previous log of installed versions (spinned off here: https://github.com/advancedtelematic/aktualizr/tree/feat/install-log) but now I'm not sure it's worth the trouble.~~

~~Main problem with this version is that it will probably make problems with rollbacks.~~

Also, we'd probably want to have something similar for ostree. (already here?)