### PR TITLE
Bump default Yocto branch in docs to thud.

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/pages/aktualizr-config-options.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/aktualizr-config-options.adoc
@@ -30,7 +30,7 @@ For examples of configuration files, see the following resources:
 
 * link:{aktualizr-github-url}/config/[Config files used by unit tests]
 * link:{aktualizr-github-url}/tests/config/[Config files used by continuous integration tests]
-* link:https://github.com/advancedtelematic/meta-updater/tree/rocko/recipes-sota/config/files[Configuration fragments used in meta-updater recipes].
+* link:https://github.com/advancedtelematic/meta-updater/tree/thud/recipes-sota/config/files[Configuration fragments used in meta-updater recipes].
 
 All fields are optional, and most have reasonable defaults that should be used unless you have a particular need to do otherwise.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/build-raspberry.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-raspberry.adoc
@@ -53,7 +53,7 @@ First, clone a manifest file for the quickstart project:
 ----
 mkdir myproject
 cd myproject
-repo init -u https://github.com/advancedtelematic/updater-repo.git
+repo init -u https://github.com/advancedtelematic/updater-repo.git -m thud.xml
 repo sync
 ----
 


### PR DESCRIPTION
Specify it explicitly instead of relying on the default, since going forward we don't want to surprise users by changing their release branch. That should only be done with careful consideration.

@merltron / @tkfu does it make sense to have a note or a page describing the risks of changing branches? (Things like kernel/bootloader compatibility and the size of the update from one branch to another?)