### PR TITLE
Fixed doxygen rendering for Initialize()

### DIFF
--- a/src/libaktualizr/primary/aktualizr.h
+++ b/src/libaktualizr/primary/aktualizr.h
@@ -26,7 +26,7 @@ class Aktualizr {
   Aktualizr(const Aktualizr&) = delete;
   Aktualizr& operator=(const Aktualizr&) = delete;
 
-  /*
+  /**
    * Initialize aktualizr. Any secondaries should be added before making this
    * call. This will provision with the server if required. This must be called
    * before using any other aktualizr functions except AddSecondary.


### PR DESCRIPTION
This is just a really dumb little PR for the docs--there was an asterisk missing, so doxygen wasn't picking up the documentation for `Initialize`.