### PR TITLE
OTA-3682: using tabbed approach for config variants (.conf vs .toml)

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/nav.adoc
+++ b/docs/ota-client-guide/modules/ROOT/nav.adoc
@@ -84,6 +84,7 @@ ifndef::env-github[:pageroot:]
 * xref:{pageroot}provisioning-methods-and-credentialszip.adoc[Contents of the credentials file]
 * xref:{pageroot}useful-bitbake-commands.adoc[Bitbake commands]
 * xref:{pageroot}ostree-usage.adoc[OSTree commands]
+* xref:{pageroot}ecu_events.adoc[ECU events]
 
 .Test and simulate OTA functions
 * xref:{pageroot}simulate-device-cred-provtest.adoc[Simulate device credentials]

--- a/docs/ota-client-guide/modules/ROOT/pages/_partials/config-descriptions.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/_partials/config-descriptions.adoc
@@ -1,0 +1,62 @@
+//  tag::buildconfig-hint[]
+If you are building a disk image that contains aktualizr, your configuration will be the **local.conf** file.
+
+* You'll find this file in the `conf` subdirectory of the of your build project.
+
+For more information, see the xref:build-configuration.adoc[build configuration reference] and the xref:build-images.adoc[sample build procedures]
+
+//  end::buildconfig-hint[]
+
+//  tag::clientconfig-hint[]
+If you are running standalone aktualizr, your configuration file will be a *.toml* file.
+
+You configure aktualizr by creating and updating a `*.toml` file in one of the following directories:
+
+* `/usr/lib/sota/conf.d`
+* `/etc/sota/conf.d/`
+
+For more information and links to sample configuration files, see the xref:aktualizr-config-options.adoc[client configuration reference].
+
+//  end::clientconfig-hint[]
+
+//  tag::pollconfig-dev[]
+Interval between polls (in seconds).
+
+The default polling internal designed to make it convenient for you test and develop OTA update functions.
+
+//  end::pollconfig-dev[]
+
+//  tag::autorebootconfig-dev[]
+Forces installation completion. Causes a system reboot in case of an ostree package manager. Emulates a reboot in case of a fake package manager.
+
+You'll want to enable this option when developing because it's more convenient.
+
+//  end::autorebootconfig-dev[]
+
+//  tag::pollconfig-prod[]
+When moving to production you'll want to have a much longer interval. 
+In fact, for production, we don't support intervals less the 1 hour (3,600 seconds). Longer internals help you to reduce the internet bandwidth and power consumption for your devices.
+
+We recommend an internal between 1 and 7 days (86,400 to 604,800 seconds)
+
+//  end::pollconfig-prod[]
+
+//  tag::autorebootconfig-prod[]
+If you followed our recommendation to enable automatic rebooting for development, you should disable again for production.
+
+//  end::autorebootconfig-prod[]
+
+
+//  tag::metadata-expires[]
+Use this option to have the metadata expire after a fixed date and time.
+
+Specify the time as a UTC instant like in the following example:
+
+//  end::metadata-expires[]
+
+//  tag::metadata-expireafter[]
+Use this option to have the metadata expire after an elapsed period of time.
+
+Specify the number of years, months and days like in the following example:
+
+//  end::metadata-expireafter[]

--- a/docs/ota-client-guide/modules/ROOT/pages/aktualizr-config-options.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/aktualizr-config-options.adoc
@@ -30,7 +30,7 @@ For examples of configuration files, see the following resources:
 
 * link:{aktualizr-github-url}/config/[Config files used by unit tests]
 * link:{aktualizr-github-url}/tests/config/[Config files used by continuous integration tests]
-* link:https://github.com/advancedtelematic/meta-updater/tree/rocko/recipes-sota/config/files[Configuration fragments used in meta-updater recipes].
+* link:https://github.com/advancedtelematic/meta-updater/tree/thud/recipes-sota/config/files[Configuration fragments used in meta-updater recipes].
 
 All fields are optional, and most have reasonable defaults that should be used unless you have a particular need to do otherwise.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/build-quemu.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-quemu.adoc
@@ -8,6 +8,7 @@
 :toc: macro
 :device: QEMU VM
 :machine: qemux86-64
+:meta-env: qemux86-64
 :image: core-image-minimal
 
 {product-name} lets you easily manage OTA updates to embedded devices running custom-built Yocto images. This is a guide for building a simple Yocto image that you can run in Virtualbox or QEMU. This is a good way to get started if you don't know yet what hardware your project will use, or if you just want to try out the features of {product-name} without worrying about physical devices.

--- a/docs/ota-client-guide/modules/ROOT/pages/build-raspberry.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-raspberry.adoc
@@ -7,6 +7,7 @@
 :icons: font
 :device: Raspberry Pi Model 3
 :machine: raspberrypi3
+:meta-env: raspberrypi
 :image: rpi-basic-image
 
 {product-name} lets you easily manage OTA updates to embedded devices running custom-built Yocto images. This is a guide for building a simple Yocto image for the {device}. You can use it as a base image for another project, or as a template for how to get started. The whole process only takes about 3 minutes of your time.
@@ -53,7 +54,7 @@ First, clone a manifest file for the quickstart project:
 ----
 mkdir myproject
 cd myproject
-repo init -u https://github.com/advancedtelematic/updater-repo.git
+repo init -u https://github.com/advancedtelematic/updater-repo.git -m thud.xml
 repo sync
 ----
 
@@ -61,7 +62,7 @@ This downloads the basic Yocto layers you need.
 
 .What is this actually doing?
 ****
-Yocto is a set of tools, templates and methods for building Linux systems from scratch. Most Yocto-built systems use a common set of base layers. The Yocto project maintains a *reference distribution* called Poky; we include that as a base layer, then add layers containing hardware support for specific boards (in this case the {device}). Finally, we include the *meta-updater* layer, which contains the platform-independent software the device and build system need to work with {product-name-short}, and *meta-updater-{machine}* for the device-specific code--mostly the specialized bootloader code.
+Yocto is a set of tools, templates and methods for building Linux systems from scratch. Most Yocto-built systems use a common set of base layers. The Yocto project maintains a *reference distribution* called Poky; we include that as a base layer, then add layers containing hardware support for specific boards (in this case the {device}). Finally, we include the *meta-updater* layer, which contains the platform-independent software the device and build system need to work with {product-name-short}, and *meta-updater-{meta-env}* for the device-specific code--mostly the specialized bootloader code.
 
 All of these layers are assembled into a built Linux system by Bitbake, the build tool of the Yocto Project, based on the instructions in the recipes inside the layers.
 ****

--- a/docs/ota-client-guide/modules/ROOT/pages/deploy-checklist.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/deploy-checklist.adoc
@@ -23,14 +23,15 @@ However, regardless of the type of certficate that you use, you'll need to regis
 You can then automate the process of installing device certificates on your devices.
 
 * We can’t tell you exactly how to automate this process, but you can use the commands from our documentation as a guideline.
-|  xref:generate-devicecert.adoc[Generate a device certificate]
-
+| 
+* xref:generate-devicecert.adoc[Generate a device certificate]
+* xref:enable-device-cred-provisioning.adoc[Enable device-credential provisioning and install device certificates]
 |**Rotate production keys**  | 
 * In line with our security concept, We recommend that you sign disk images with secure, offline keys. 
 
 * Even if you've done this already for with a test account, you need to do it again with a `credentials.zip` from your production account.
 
-* You should keep these keys on a secure storage medium such as a link:https://www.yubico.com/[YubiKey]. You would only plugin your YubiKey when you need to sign metadata on your local computer.|  xref:rotating-signing-keys.adoc[Manage keys for software metadata]
+* You should keep these keys on a secure storage medium such as a link:https://www.yubico.com/[YubiKey]. You would only plug in your YubiKey when you need to sign metadata on your local computer.|  xref:rotating-signing-keys.adoc[Manage keys for software metadata]
 
 |**Transfer disk images to your production repository**  | 
 * When you're ready to deploy your software to production, you'll need to move all approved disk images from the software repository in your testing account to the one in your production account.  |  xref:cross-deploy-images.adoc[Transfer software to another repository]

--- a/docs/ota-client-guide/modules/ROOT/pages/metadata-expiry.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/metadata-expiry.adoc
@@ -7,57 +7,73 @@ The default expiry dates are as follows:
 * For `targets.json`, the expiry date is **31 days** from when the metadata was last updated.
 * For `root.json`, the expiry date is **365 days** from when the metadata was last updated.
 
-You can specify the expiry date with the following methods:
+== Define your own expiry dates
 
-* Specify it as an option in the `sign` command when running the standalone `garage-sign` tool.
-* Specify it in your `local.conf` file before you run the `bitbake` command to build and update software in your software repository.
+How you define the expiry dates depends on how you use OTA Connect:
 
-For examples of each method, see the following reference table:
+* If you're building disk images, you need to update your *build configuration*.
+* If you're using the standalone command-line tools such as xref:install-garage-sign-deploy.adoc[`garage-deploy`], you need to add extra *command-line arguments*.
 
+
+[{tabs}]
+====
+Build configuration::
++
+--
+include::partial$config-descriptions.adoc[tags=buildconfig-hint]
+
+.Build configuration parameters for metadata expiry
 [cols="2a,3a",options="header"]
 |====================
 |Configuration  | Description
 |
-* **garage-sign option:** 
-+
-`--expires` 
-* **local.conf file:**
-+
 `GARAGE_TARGET_EXPIRES` 
 | 
-Use this option to have the metadata expire after a fixed date and time.
-
-Specify the time as a UTC instant like in the following examples.
-
-.garage sign
-----
-garage-sign targets sign --expires 2018-01-01T00:01:00Z  --repo myimagerepo --key-name mytargets
-----
-
-.local.conf
+include::partial$config-descriptions.adoc[tags=metadata-expires]
 ----
 GARAGE_TARGET_EXPIRES = "2018-01-01T00:01:00Z"
 ----
 
 |
-* **garage-sign option:**  
-+
-`--expire-after`
-* **local.conf file:** 
-+
 `GARAGE_TARGET_EXPIRE_AFTER`
 | 
-Use this option to have the metadata expire after an elapsed period of time.
-
-Specify the number of years, months and days like in the following examples.
-
-.garage sign
-----
-garage-sign targets sign ----expire-after 1Y3M5D  --repo myimagerepo --key-name mytargets
-----
-
-.local.conf
+include::partial$config-descriptions.adoc[tags=metadata-expireafter]
 ----
 GARAGE_TARGET_EXPIRE_AFTER = "1Y3M5D"
 ----
+
 |====================
+
+
+
+--
+
+Command-line arguments::
++
+--
+When you're using the `garage-sign` command to take your keys offline, you can also sign your metadata with one of the following expiry arguments.
+
+.Command-line arguments for metadata expiry
+[cols="2a,4a",options="header"]
+|====================
+|Configuration  | Description
+|
+`--expires`
+| 
+include::partial$config-descriptions.adoc[tags=metadata-expires]
+
+----
+garage-sign targets sign --expires 2018-01-01T00:01:00Z  --repo myimagerepo --key-name mytargets
+----
+
+|
+`--expire-after`
+| 
+include::partial$config-descriptions.adoc[tags=metadata-expireafter]
+----
+garage-sign targets sign ----expire-after 1Y3M5D  --repo myimagerepo --key-name mytargets
+----
+|====================
+
+--
+====

--- a/docs/ota-client-guide/modules/ROOT/pages/recommended-clientconfig.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/recommended-clientconfig.adoc
@@ -1,79 +1,89 @@
 = Recommended client configurations
 
-Before you start developing or deploying to production, you should check that your configuration file has appropriate settings for your use case. 
+Before you start developing or deploying to production, you should check that your configuration file has appropriate settings for your use case.
 
-* If you are running standalone aktualizr, your configuration file will be a **.toml** file.
+The configuration file and exact parameters depend on how you use OTA Connect:
+
+* If you're building disk images that contain aktualizr or libaktualizr, you need to update your *build configuration*.
+* If you're using a standalone version of aktualizr that you've installed locally, you need to update the *client configuration*.
+ 
+[{tabs}]
+====
+Build configuration::
 +
-You configure aktualizr by creating and updating a `*.toml` file in one of the following directories:
+--
+include::partial$config-descriptions.adoc[tags=buildconfig-hint]
 
-** `/usr/lib/sota/conf.d`
-** `/etc/sota/conf.d/`
-+
-For more information and links to sample configuration files, see the xref:aktualizr-config-options.adoc[client configuration reference].
-
-* If you are building a disk image that contains aktualizr, your configuration will be the **local.conf** file.
-
-** You'll find this file in the `conf` subdirectory of the your project directory.
-+
-For more information, see the xref:build-configuration.adoc[build configuration reference] and the xref:build-images.adoc[sample build procedures]. 
-
-== Recommended settings for development
-
-[cols="2a,3a",options="header"]
+.Recommended build configuration for development
+[cols="2a,2a",options="header"]
 |====================
 |Configuration  | Description
 |
-* **.toml file:** 
-+
-`polling_sec = "10"`  
-* **local.conf file:**
-+
-`SOTA_POLLING_SEC = "10"` 
-| 
-Interval between polls (in seconds).
+`SOTA_POLLING_SEC = "10"`
 
-The default polling internal designed to make it convenient for you test and develop OTA update functions.
+`IMAGE_INSTALL_append = " aktualizr-polling-interval "`
+| 
+include::partial$config-descriptions.adoc[tags=pollconfig-dev]
 |
-* **.toml file:** 
-+
-`force_install_completion=true`
-* **local.conf file:** 
-+
 `IMAGE_INSTALL_append = " aktualizr-auto-reboot "`
 | 
-Forces installation completion. Causes a system reboot in case of an ostree package manager. Emulates a reboot in case of a fake package manager.
-
-You'll want to enable this option when developing because it's more convenient.
+include::partial$config-descriptions.adoc[tags=autorebootconfig-dev]
 
 |====================
 
-== Recommended settings for production
-
-[cols="2a,3a",options="header,footer"]
+.Recommended build configuration for production
+[cols="2a,2a",options="header"]
 |====================
-|Configuration   | Description
-|   
-* **.toml file:** 
-+
-`polling_sec = "84600"`  
-* **local.conf file:**
-+
-`SOTA_POLLING_SEC = "84600"`
-
-| When moving to production you'll want to have a much longer interval. 
-In fact, for production, we don't support intervals less the 1 hour (3,600 seconds). Longer internals help you to reduce the internet bandwidth and power consumption for your devices.
-
-We recommend an internal between 1 and 7 days (86,400 to 604,800 seconds).
+|Configuration  | Description
 |
-* **.toml file:** 
-+
-`force_install_completion=false`
-* **local.conf file:** 
-+
-Remove `aktualizr-auto-reboot` from the `IMAGE_INSTALL_append` parameter.
+`SOTA_POLLING_SEC = "84600"` 
 
+`IMAGE_INSTALL_append = " aktualizr-polling-interval "`
 | 
-If you followed our recommendation to enable automatic rebooting for development, you should disable again for production.
+include::partial$config-descriptions.adoc[tags=pollconfig-prod]
+|
+Remove `aktualizr-auto-reboot` from the `IMAGE_INSTALL_append` parameter.
+| 
+include::partial$config-descriptions.adoc[tags=autorebootconfig-prod]
+
 |====================
 
+--
 
+Client configuration::
++
+--
+include::partial$config-descriptions.adoc[tags=clientconfig-hint]
+
+.Recommended client configuration for development
+[cols="2a,2a",options="header"]
+|====================
+|Configuration  | Description
+|
+`polling_sec = "10"`
+| 
+include::partial$config-descriptions.adoc[tags=pollconfig-dev]
+|
+`force_install_completion = "true"`
+| 
+include::partial$config-descriptions.adoc[tags=autorebootconfig-dev]
+
+|====================
+
+.Recommended client configuration for production
+[cols="2a,2a",options="header"]
+|====================
+|Configuration  | Description
+|
+`polling_sec = "84600"`
+| 
+include::partial$config-descriptions.adoc[tags=pollconfig-prod]
+|
+`force_install_completion = "false"`
+| 
+include::partial$config-descriptions.adoc[tags=autorebootconfig-prod]
+
+|====================
+
+--
+====


### PR DESCRIPTION
- Putting different ways of configuring into
tabs ie("local.conf" vs "sota_local.toml") and adding more content reuse.
- Minor fix to deploy checklist (added xref)
- Minor fix to env setup command
- restored missing ECU events from nav

Example of tabbed approach:
![image](https://user-images.githubusercontent.com/30755179/64185244-17595b80-ce6d-11e9-8bdb-6b989edc044f.png)


Signed-off-by: Merlin Carter <merlin.carter@here.com>