### PR TITLE
OTA-3682: renaming "dev" version id

### DIFF
--- a/docs/ota-client-guide/antora.yml
+++ b/docs/ota-client-guide/antora.yml
@@ -1,5 +1,5 @@
 name: ota-client
 title: OTA Connect Developer Guide
-version: dev
+version: latest
 nav:
 - modules/ROOT/nav.adoc


### PR DESCRIPTION
Just a lil' change to prepare for our versioning setup

renaming the version id from "dev" to "latest" (currently 2019.06) so it's more obvious in the URL what version of the docs you're looking at.

eg: 
"https://docs.ota.here.com/ota-client/latest/developer-tools.html"

instead of

"https://docs.ota.here.com/ota-client/dev/developer-tools.html"

Signed-off-by: Merlin Carter <merlin.carter@here.com>