### PR TITLE
Only trigger github release on tags

### DIFF
--- a/ci/gitlab/.gitlab-ci.yml
+++ b/ci/gitlab/.gitlab-ci.yml
@@ -250,7 +250,7 @@ github-release:
       aktualizr_src-$CI_COMMIT_TAG.tar.gz
   only:
     variables:
-      - $CI_COMMIT_REF_NAME =~ /^\d\d\d\d\.\d+(-\w+)?$/
+      - $CI_COMMIT_TAG =~ /^\d\d\d\d\.\d+(-\w+)?$/
 
 # -- publish coverage results on gitlab pages
 


### PR DESCRIPTION
I forgot why I opted for `CI_COMMIT_REF_NAME` but I don't see why it would be useful outside of tags.