### PR TITLE
OTA-3746: Adding github-only note

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/pages/account-setup.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/account-setup.adoc
@@ -1,4 +1,12 @@
 = Set up multiple accounts
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 In OTA Connect, all devices and software belong to one *user* login. However, you don't want to mix up test software and production software by creating them all under the same user.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/add-ota-functonality-existing-yocto-project.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/add-ota-functonality-existing-yocto-project.adoc
@@ -1,4 +1,12 @@
 = Add OTA functionality to an existing Yocto project
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :page-layout: page
 :page-categories: [quickstarts]
 :page-date: 2017-05-23 16:27:58

--- a/docs/ota-client-guide/modules/ROOT/pages/adoc-test.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/adoc-test.adoc
@@ -1,4 +1,12 @@
 = Client provisioning methods
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :page-layout: page
 :page-categories: [client-config]
 :page-date: 2018-07-05 13:31:58

--- a/docs/ota-client-guide/modules/ROOT/pages/aktualizr-config-options.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/aktualizr-config-options.adoc
@@ -1,4 +1,12 @@
 = Client configuration options
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :page-layout: page
 :page-categories: [client-config]
 :page-date: 2018-07-05 11:14:01

--- a/docs/ota-client-guide/modules/ROOT/pages/aktualizr-runningmodes-finegrained-commandline-control.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/aktualizr-runningmodes-finegrained-commandline-control.adoc
@@ -1,4 +1,12 @@
 = Selectively trigger aktualizr
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :page-layout: page
 :page-categories: [client-config]
 :page-date: 2018-08-22 11:01:14

--- a/docs/ota-client-guide/modules/ROOT/pages/build-agl.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-agl.adoc
@@ -1,4 +1,12 @@
 = Build an Automotive Grade Linux image
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :page-partial:
 :page-layout: page
 :page-categories: [quickstarts]

--- a/docs/ota-client-guide/modules/ROOT/pages/build-configuration.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-configuration.adoc
@@ -1,4 +1,12 @@
 = Build Configuration Options
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :page-partial:
 // MC: Included in aktualizr/docs/ota-client-guide/modules/ROOT/pages/build-configuration.adoc
 

--- a/docs/ota-client-guide/modules/ROOT/pages/build-images.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-images.adoc
@@ -1,4 +1,12 @@
 = Build OTA-enabled Disk images
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 As described in the xref:workflow-overview.adoc[workflow overview], you use the Yocto tools to build a disk image that you can flash to your devices. This disk image includes the OTA Connect client, which communicates with the OTA Connect server. You can learn more about the Yocto tools, in the xref:yocto.adoc[Yocto section].
 

--- a/docs/ota-client-guide/modules/ROOT/pages/build-only-ostree.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-only-ostree.adoc
@@ -1,4 +1,12 @@
 = I don't need to build the SD card images every time--how can I do a build that only does the OSTree part?
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :page-layout: page
 :page-categories: [faq]
 :page-date: 2017-06-29 13:30:33

--- a/docs/ota-client-guide/modules/ROOT/pages/build-ota-enabled-images.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-ota-enabled-images.adoc
@@ -1,3 +1,11 @@
 = Build OTA-enabled disk images
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 Aside from our demo recipes, you can also create your own Yocto project from scratch.

--- a/docs/ota-client-guide/modules/ROOT/pages/build-qemu.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-qemu.adoc
@@ -1,4 +1,12 @@
 = Build a QEMU/VirtualBox 
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :page-partial:
 :page-layout: page
 :page-categories: [quickstarts]

--- a/docs/ota-client-guide/modules/ROOT/pages/build-raspberry.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-raspberry.adoc
@@ -1,4 +1,12 @@
 = Build a Raspberry Pi image
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :page-partial:
 :page-layout: page
 :page-categories: [quickstarts]

--- a/docs/ota-client-guide/modules/ROOT/pages/client-provisioning-methods.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/client-provisioning-methods.adoc
@@ -1,4 +1,12 @@
 = Device Provisioning Methods
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :page-layout: page
 :page-categories: [client-config]
 :page-date: 2018-07-05 13:31:58

--- a/docs/ota-client-guide/modules/ROOT/pages/cross-deploy-images.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/cross-deploy-images.adoc
@@ -1,4 +1,12 @@
 = Transfer disk images to a software repository in another account
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :page-layout: page
 :page-categories: [prod]
 :page-date: 2018-03-15 13:52:05

--- a/docs/ota-client-guide/modules/ROOT/pages/deb-package-install.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/deb-package-install.adoc
@@ -1,4 +1,12 @@
 == Installing aktualizr via debian package
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 Aktualizr makes .deb packages available via the https://github.com/advancedtelematic/aktualizr/releases[GitHub releases page]. Download and install the .deb package, for example:
 

--- a/docs/ota-client-guide/modules/ROOT/pages/debugging-tips.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/debugging-tips.adoc
@@ -1,4 +1,12 @@
 = Aktualizr Debugging Tips
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :aktualizr-github-url: https://github.com/advancedtelematic/aktualizr/tree/master
 
 == Running Aktualizr in development

--- a/docs/ota-client-guide/modules/ROOT/pages/deploy-checklist.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/deploy-checklist.adoc
@@ -1,4 +1,12 @@
 = Deployment Checklist
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 OTA Connect is designed to integrate easily into development workflows: you build your image, push it, set auto-updates for some of your test-bench devices, and so on. But once you're ready to move from testing into production, you will likely want to do a few things differently. 
 

--- a/docs/ota-client-guide/modules/ROOT/pages/developer-tools.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/developer-tools.adoc
@@ -1,4 +1,12 @@
 = Developer Tools
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 Before we walk you through the basic workflow of an OTA update, it would be helpful to understand the tools that are involved at each stage.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/device-cred-prov-steps.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/device-cred-prov-steps.adoc
@@ -1,4 +1,12 @@
 = Set Up Device Provisioning
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 In this section, you'll learn how provisioning in production is different from the provisioning method that you used to get started. You'll also understand the major steps involved in provisioning devices for production.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/device-cred-prov-teststeps.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/device-cred-prov-teststeps.adoc
@@ -1,4 +1,12 @@
 = Text Device-credential Provisioning
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 Although shared-credential provisioning is useful for evaluating OTA Connect, we don't recommend that you use it in production.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/ecu_events.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/ecu_events.adoc
@@ -1,4 +1,12 @@
 = Client events reporting
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :aktualizr-github-url: https://github.com/advancedtelematic/aktualizr/tree/master
 
 This is a technical document describing the format of the events reported to the back-end by aktualizr during an ongoing update installation.

--- a/docs/ota-client-guide/modules/ROOT/pages/enable-device-cred-provisioning.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/enable-device-cred-provisioning.adoc
@@ -1,4 +1,12 @@
 = Enable device-credential provisioning and install device certificates 
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 //MC: This is a copy of the topic "enable-device-cred-provtest.adoc" but intended for the "deploy/production" use case. Need to use more includes to reduce redundancy.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/enable-device-cred-provtest.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/enable-device-cred-provtest.adoc
@@ -1,4 +1,12 @@
 = Enable device-credential provisioning and install device certificates 
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 //MC: This is a copy of the topic "enable-device-cred-provisioning.adoc" but intended for the "test" use case. Need to use more includes to reduce redundancy.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/enable-shared-cred-provisioning.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/enable-shared-cred-provisioning.adoc
@@ -1,4 +1,12 @@
 = Enable shared-credential provisioning
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 If you build a disk image with the default configuration, shared-credential provisioning is enabled by default. You can also enable it explicitly in your build configuration.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/evaluation-to-prod.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/evaluation-to-prod.adoc
@@ -1,4 +1,12 @@
 = Moving from evaluation to production
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 The procedures to deploy OTA Connect in production are a little more complex than the basic xref:dev@getstarted::index.adoc[Get Started]  procedures.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/fault-injection.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/fault-injection.adoc
@@ -1,4 +1,12 @@
 = Running aktualizr with fault injection
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 ifdef::env-github[:simulatelink: link:https://docs.ota.here.com/ota-client/dev/simulate-device-basic.html[Simulate a device without building a disk image]]
 ifndef::env-github[:simulatelink: xref:dev@getstarted::simulate-device-basic.adoc[Simulate a device without building a disk image]]
 

--- a/docs/ota-client-guide/modules/ROOT/pages/generate-devicecert.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/generate-devicecert.adoc
@@ -1,6 +1,12 @@
 = Device Certificate Generation
 
-// MC: This is a slightly altered copy of "generatetest-devicecert.adoc" with wording that explains you should only use the examples as a reference, since we can't know the customers "real" certificate generation process.
+ifdef::env-github[]
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 Once you have your final fleet root certificate, you can use it to generate and sign device certificates. You can then automate the process of installing device certificates on your devices. 
 

--- a/docs/ota-client-guide/modules/ROOT/pages/generate-selfsigned-root.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/generate-selfsigned-root.adoc
@@ -1,4 +1,12 @@
 = Generate a self-signed root certificate
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 When you move to production, you'll need to register your fleet root certificate with OTA Connect server. This certificate needs to be signed by a trusted Certificate Authority (CA).
 

--- a/docs/ota-client-guide/modules/ROOT/pages/generatetest-devicecert.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/generatetest-devicecert.adoc
@@ -1,4 +1,12 @@
 = Generate a test device certificate
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 // MC: This is a slightly altered copy of "generate-devicecert.doc" with wording that explains the process from the perspective of testing with a self-signed root cert.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/generating-provisioning-credentials.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/generating-provisioning-credentials.adoc
@@ -1,3 +1,10 @@
+ifndef::env-github[]
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 include::dev@ota-web:ROOT:page$create-provisioning-key.adoc[]
 
 // MC: Images don't render from included files, added local copies of 's1-prov.png' and 'screenshot_provisioning_key_2.png' (from "ota-web") until I can find a better solution.

--- a/docs/ota-client-guide/modules/ROOT/pages/how-can-i-check-which-ostree-version-is-installed.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/how-can-i-check-which-ostree-version-is-installed.adoc
@@ -1,4 +1,12 @@
 = How can I check which OSTree commit is deployed?
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :page-layout: page
 :page-categories: [faq]
 :page-date: 2017-01-25 15:42:59

--- a/docs/ota-client-guide/modules/ROOT/pages/index.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/index.adoc
@@ -1,4 +1,12 @@
 = Introduction
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 include::dev@getstarted::partial$product-intro.adoc[tags=standard-intro]
 

--- a/docs/ota-client-guide/modules/ROOT/pages/install-garage-sign-deploy.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/install-garage-sign-deploy.adoc
@@ -1,4 +1,12 @@
 = Install the "garage deploy" tool
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :page-layout: page
 :page-categories: [prod]
 :page-date: 2018-09-13 11:50:24

--- a/docs/ota-client-guide/modules/ROOT/pages/intro-evaluate.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/intro-evaluate.adoc
@@ -1,4 +1,12 @@
 = Evaluate OTA Connect
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 Here are our recommendations for xref:intro-evaluate.adoc[evaluating OTA connect]:
 

--- a/docs/ota-client-guide/modules/ROOT/pages/intro-prep.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/intro-prep.adoc
@@ -1,4 +1,12 @@
 = Build your own OTA-enabled solution
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 Once you've evaluated the basic functions of OTA Connect, you're ready to build your own OTA-enabled solution. You probably have your client software that runs on your devices. In this phase, you'll start to integrate OTA update functionality into that client. 
 

--- a/docs/ota-client-guide/modules/ROOT/pages/intro-prod.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/intro-prod.adoc
@@ -1,5 +1,11 @@
+= Moving to Production
+ifdef::env-github[]
 
-== Moving to Production
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
 
 {product-name} is designed to integrate easily into development workflows: you build your image, push it, set auto-updates for some of your test-bench devices, and so on. But once you're ready to move from testing into production, you will likely want to do a few things differently. Here is a summary of our recommended workflow for moving from development to production.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/libaktualizr-getstarted.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/libaktualizr-getstarted.adoc
@@ -1,4 +1,12 @@
 = Get started
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :page-layout: page
 :page-categories: [using-libaktualizr]
 :page-date: 2018-11-28 14:08:55

--- a/docs/ota-client-guide/modules/ROOT/pages/libaktualizr-integrate.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/libaktualizr-integrate.adoc
@@ -1,4 +1,12 @@
 = Build disc images that contain your libaktualizr integration
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 Assuming you followed our recommendation to use libaktualizr, you'll need to build disc images that contain your final integration. The build recipes that we provide in the evaluation stage are configured to use standalone aktualizr.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/libaktualizr-update-secondary.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/libaktualizr-update-secondary.adoc
@@ -1,4 +1,12 @@
 = Update a secondary ECU
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :page-layout: page
 :page-categories: [using-libaktualizr]
 :page-date: 2018-11-28 14:06:25

--- a/docs/ota-client-guide/modules/ROOT/pages/libaktualizr-why-use.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/libaktualizr-why-use.adoc
@@ -1,4 +1,12 @@
 = Integrate libaktualizr into your solution
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 ////
 This topic is supposed to outline the main use cases the product aims to address. The body of the guide must show how to use the product to implement these use cases.
@@ -22,4 +30,4 @@ Typical scenarios for making your own client could be:
 * You want to constrain network traffic and software updates to specific vehicle states
 * You want to provide motorists or service staff with progress indicators for specific software updates.
 
-To get started, have a look at our https://github.com/advancedtelematic/libaktualizr-demo[demo app] in GitHub (documentation coming soon) or read through our guide to xref:libaktualizr-getstarted.adoc[getting started with libaktualizr].
+To get started, have a look at our https://github.com/advancedtelematic/libaktualizr-demo[demo app] in GitHub or read through our guide to xref:libaktualizr-getstarted.adoc[getting started with libaktualizr].

--- a/docs/ota-client-guide/modules/ROOT/pages/meta-updater-build.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/meta-updater-build.adoc
@@ -1,4 +1,12 @@
 = Build
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :meta-updater-github-url: https://github.com/advancedtelematic/meta-updater/tree/master
 
 == Quickstart

--- a/docs/ota-client-guide/modules/ROOT/pages/meta-updater-dev-config.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/meta-updater-dev-config.adoc
@@ -1,4 +1,12 @@
 = Development configuration
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :meta-updater-github-url: https://github.com/advancedtelematic/meta-updater/tree/master
 
 //MC: The dev guide already has a recommended config topic: https://github.com/advancedtelematic/aktualizr/blob/master/docs/ota-client-guide/modules/ROOT/pages/recommended-clientconfig.adoc

--- a/docs/ota-client-guide/modules/ROOT/pages/meta-updater-provisioning-methods.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/meta-updater-provisioning-methods.adoc
@@ -1,4 +1,12 @@
 = Manual provisioning
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 //MC: TOMERGE: Looks mostly like a duplicate of this topic: https://github.com/advancedtelematic/aktualizr/blob/master/docs/ota-client-guide/modules/ROOT/pages/simulate-device-cred-provtest.adoc
 

--- a/docs/ota-client-guide/modules/ROOT/pages/meta-updater-testing.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/meta-updater-testing.adoc
@@ -1,4 +1,12 @@
 = Testing
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 //MC: No overlap with any content currently in the developer guide, but probably useful content to clean up and include.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/meta-updater-usage.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/meta-updater-usage.adoc
@@ -1,4 +1,12 @@
 = Usage
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :meta-updater-github-url: https://github.com/advancedtelematic/meta-updater/tree/master
 :metadata-expiry-article: xref:dev@ota-client::metadata-expiry.adoc[OTA Connect documentation]
 ifdef::env-github[:metadata-expiry-article: link:https://docs.ota.here.com/ota-client/dev/metadata-expiry.html[OTA Connect documentation]]

--- a/docs/ota-client-guide/modules/ROOT/pages/metadata-expiry.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/metadata-expiry.adoc
@@ -1,4 +1,12 @@
 = Manage metadata expiry dates
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 Once you xref:rotating-signing-keys.adoc[take the keys for signing metadata offline], you need to be aware of when this metadata expires. You need to refresh the expiry date before it is reached, otherwise you won't be able to push updates. You can also define your own expiry dates when you take your keys offline.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/ostree-and-treehub.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/ostree-and-treehub.adoc
@@ -1,4 +1,12 @@
 == OSTree
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 link:http://ostree.readthedocs.io/en/latest/[OSTree] is an open-source tool that combines a "git-like" model for committing and downloading bootable filesystem trees, along with a layer for deploying them and managing the bootloader configuration. It is actively developed and support by Red Hat, and used in link:http://flatpak.org/[flatpak] and link:http://www.projectatomic.io/[Project Atomic].
 

--- a/docs/ota-client-guide/modules/ROOT/pages/ostree-usage.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/ostree-usage.adoc
@@ -1,4 +1,12 @@
 = OSTree usage
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :page-layout: page
 :page-categories: [tips]
 :page-date: 2017-06-06 15:23:36

--- a/docs/ota-client-guide/modules/ROOT/pages/pki.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/pki.adoc
@@ -1,4 +1,12 @@
 = Key Management
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 Once you move to production, we recommend that you manage these keys offline in your own PKI rather than having all keys managed on the OTA Connect server.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/posix-secondaries-bitbaking.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/posix-secondaries-bitbaking.adoc
@@ -1,4 +1,12 @@
 = Posix Secondaries: bitbaking and usage of Primary and Secondary images
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :build-qemu-link: xref:build-qemu.adoc[How to build 'core-image-minimal' image for QEMU]]
 
 The goal of this doc is to guide a reader on bitbaking of two type of images `primary` and `secondary` that are targeted for QEMU or RPi

--- a/docs/ota-client-guide/modules/ROOT/pages/posix-secondaries.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/posix-secondaries.adoc
@@ -1,4 +1,12 @@
 = Posix Secondaries aka IP Secondaries: configuration and emulation of Primary and Secondary on a local host
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :aktualizr-github-url: https://github.com/advancedtelematic/aktualizr/tree/master
 
 The goal of this doc is to guide a reader on configuring and running two executables that can be built out of the given repository source code and act as Primary and Secondary correspondingly.

--- a/docs/ota-client-guide/modules/ROOT/pages/provide-root-cert.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/provide-root-cert.adoc
@@ -1,4 +1,12 @@
 = Register the Root Certificate for your Fleet
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 //MC: This is a copy of the topic "provide-testroot-cert.adoc" but intended for the "prod" use case. Need to use more includes to reduce redundancy
 

--- a/docs/ota-client-guide/modules/ROOT/pages/provide-testroot-cert.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/provide-testroot-cert.adoc
@@ -1,4 +1,12 @@
 = Register your test root certificate
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 //MC: This is a copy of the topic "provide-root-cert.adoc" but intended for the "test" use case. Need to use more includes to reduce redundancy
 

--- a/docs/ota-client-guide/modules/ROOT/pages/provisioning-methods-and-credentialszip.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/provisioning-methods-and-credentialszip.adoc
@@ -1,4 +1,12 @@
 = Provisioning methods and credentials.zip
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :page-layout: page
 :page-categories: [concepts]
 :page-date: 2018-03-15 16:15:17

--- a/docs/ota-client-guide/modules/ROOT/pages/pushing-updates.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/pushing-updates.adoc
@@ -1,4 +1,12 @@
 = Upload a sample software version
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :page-partial:
 :page-layout: page
 :page-categories: [quickstarts]

--- a/docs/ota-client-guide/modules/ROOT/pages/recommended-clientconfig.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/recommended-clientconfig.adoc
@@ -1,4 +1,12 @@
 = Recommended client configurations
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 Before you start developing or deploying to production, you should check that your configuration file has appropriate settings for your use case.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/release-process.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/release-process.adoc
@@ -1,7 +1,15 @@
+= Release process
 :toc: macro
 :toc-title:
 
-= Release process
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 To create a new link:https://github.com/advancedtelematic/aktualizr/releases[release of aktualizr and garage-deploy], there are several discrete steps to follow:
 

--- a/docs/ota-client-guide/modules/ROOT/pages/rollback.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/rollback.adoc
@@ -1,4 +1,12 @@
 = Rollbacks
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 Since Aktualizr is a userspace application and relies on a lot of other software which can be
 affected by an unsuccessful update, rollback functionality should be implemented in the bootloader.

--- a/docs/ota-client-guide/modules/ROOT/pages/rotating-signing-keys.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/rotating-signing-keys.adoc
@@ -1,4 +1,12 @@
 = Manage keys for software metadata
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 OTA Connect has a security concept that includes signing metadata files with secure, offline keys. For more information about these files, see the xref:uptane.adoc#_uptane_metadata[Uptane metadata overview].
 

--- a/docs/ota-client-guide/modules/ROOT/pages/schema-migrations.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/schema-migrations.adoc
@@ -1,4 +1,12 @@
 = How to add a schema migration
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :aktualizr-github-url: https://github.com/advancedtelematic/aktualizr/tree/master
 ifdef::env-github[]
 :aktualizr-github-url: ..

--- a/docs/ota-client-guide/modules/ROOT/pages/secure-software-updates-test.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/secure-software-updates-test.adoc
@@ -1,4 +1,12 @@
 = Test software update security
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 //MC: This is a copy of the topic "secure-software-updates.adoc" but intended for the "test" use case. Need to use more includes to reduce redundancy.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/secure-software-updates.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/secure-software-updates.adoc
@@ -1,4 +1,12 @@
 = Secure your software updates
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 //MC: This is a copy of the topic "secure-software-updates-test.adoc" but intended for the "prod" use case. Need to use more includes to reduce redundancy.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/security.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/security.adoc
@@ -1,4 +1,12 @@
 = Security and Identity
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 OTA Connect provides you with two levels of security which have different tradeoffs. You can work with the *default* security measures which are much less work to manage but expose you to certain risks. Or, you can follow our recommended *production-level* security measures which are more work to set up but provide more robust security.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/simulate-device-basic.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/simulate-device-basic.adoc
@@ -1,4 +1,12 @@
 = Simulate a device without building a disk image
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :page-partial:
 :page-layout: page
 :page-categories: [quickstarts]

--- a/docs/ota-client-guide/modules/ROOT/pages/simulate-device-cred-provtest.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/simulate-device-cred-provtest.adoc
@@ -1,4 +1,12 @@
 = Simulate the provisioning process with device credentials
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 To provision with device credentials in production, you need to have a root CA. If you want to test this provisioning method without generating a root CA, you can simulate it with the `aktualizr-cert-provider` command.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/software-management.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/software-management.adoc
@@ -1,4 +1,12 @@
 = Software management
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :page-partial:
 
 When you develop software updates for OTA deployment, it's important to understand the two different ways in which you can get software into OTA Connect.

--- a/docs/ota-client-guide/modules/ROOT/pages/supported-boards.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/supported-boards.adoc
@@ -1,4 +1,12 @@
 = Supported boards
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 * https://github.com/advancedtelematic/meta-updater-raspberrypi[Raspberry Pi 2 and 3]
 * https://github.com/advancedtelematic/meta-updater-minnowboard[Intel Minnowboard]

--- a/docs/ota-client-guide/modules/ROOT/pages/supporting-technologies.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/supporting-technologies.adoc
@@ -1,4 +1,12 @@
 = Supporting Technologies
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 If you've started working on an embedded software project, you've probably reached the point where you looked around for an update system, and found out that there isn't a lot of great tooling out there. Our experience has been that people tend to implement software updates on a case-by-case basis, leading to solutions that are specific to the target platform, proprietary, brittle, or insecure--or sometimes all of the above. {product-name} provides an open source solution that you can plug-and-play into your build process.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/troubleshooting.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/troubleshooting.adoc
@@ -1,4 +1,12 @@
 = Troubleshooting
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :page-layout: page
 :page-categories: [tips]
 :page-date: 2017-06-13 10:51:53

--- a/docs/ota-client-guide/modules/ROOT/pages/update-single-device.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/update-single-device.adoc
@@ -1,4 +1,12 @@
 = Update a device with the sample software
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 Once you've uploaded a few different software versions, you can try to push that software to a device that doesn't yet have the version installed. 
 

--- a/docs/ota-client-guide/modules/ROOT/pages/update-your-client-configuration.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/update-your-client-configuration.adoc
@@ -1,4 +1,12 @@
 = Recommended client configurations
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 Before you start developing or deploying to production, you should check that your configuration file has appropriate settings for your use case. 
 

--- a/docs/ota-client-guide/modules/ROOT/pages/uptane-generator.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/uptane-generator.adoc
@@ -1,4 +1,12 @@
 = Simulate Uptane metadata transactions
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :aktualizr-github-url: https://github.com/advancedtelematic/aktualizr/tree/master
 
 The uptane-generator directory contains a basic tool that generates metadata according to the Uptane spec. It is comprised of three tools:

--- a/docs/ota-client-guide/modules/ROOT/pages/uptane.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/uptane.adoc
@@ -1,4 +1,12 @@
 = OTA Connect security: The Uptane framework
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :page-layout: page
 :page-categories: [concepts]
 :page-date: 2018-01-10 13:55:45

--- a/docs/ota-client-guide/modules/ROOT/pages/use-your-own-deviceid.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/use-your-own-deviceid.adoc
@@ -1,4 +1,12 @@
 = Configure your own device IDs
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 In OTA Connect, a device has two types of identifier: an internal device UUID, and a standard device ID.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/useful-bitbake-commands.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/useful-bitbake-commands.adoc
@@ -1,4 +1,12 @@
 = Useful Bitbake commands
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :page-layout: page
 :page-categories: [tips]
 :page-date: 2017-06-06 15:23:05

--- a/docs/ota-client-guide/modules/ROOT/pages/workflow-overview.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/workflow-overview.adoc
@@ -1,4 +1,12 @@
 = Basic Workflow
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :page-layout: page
 :page-categories: [concepts]
 :page-date: 2017-01-16 18:12:09

--- a/docs/ota-client-guide/modules/ROOT/pages/yocto-release-branches.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/yocto-release-branches.adoc
@@ -1,4 +1,12 @@
 = Yocto release branches
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 == Supported branches
 

--- a/docs/ota-client-guide/modules/ROOT/pages/yocto.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/yocto.adoc
@@ -1,4 +1,12 @@
 == Yocto
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 
 The link:https://www.yoctoproject.org/[Yocto Project] is an open source collaborative project that provides standardized high-quality infrastructure, tools, and methodology to help decrease the complexity and increase the portability of Linux implementations in the embedded industry. It enables its users to build custom operating systems using specific recipes for embedded devices. Most commercial embedded Linux distros already use and/or support Yocto, including link:https://www.windriver.com/products/linux/[Wind River] and link:http://www.enea.com/solutions/Enea-Linux/[Enea]. It's backed by major hardware vendors like Intel, AMD, Freescale, Mentor, Texas Instruments, and many others. If you need a highly performant customized Linux for your embedded device, whether it's IoT, automotive, or other kinds of mobility devices, the Yocto project is probably what you're using.
 


### PR DESCRIPTION
Adding note to all topics that directs people to the rendered version of the article in the docs portal.

We discussed this during our versioning meeting. For more details, see the meeting notes: https://confluence.in.here.com/display/OTA/MEETING+MINUTES%3A+Docs+versioning

Signed-off-by: Merlin Carter <merlin.carter@here.com>