### PR TITLE
Document that the garage tools need python3.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -54,6 +54,7 @@ The default versions packaged in recent Debian/Ubuntu releases are generally new
 
 Additional packages are used for non-essential components:
 
+* To build the garage tools, you will need `python3`.
 * To build the test suite, you will need `net-tools python3-dev python3-openssl python3-venv sqlite3 valgrind`.
 * To run the linting tools, you will need `clang clang-format-6.0 clang-tidy-6.0`.
 * To build additional documentation, you will need `doxygen graphviz`.


### PR DESCRIPTION
It's used for downloading garage-sign.