### PR TITLE
Fix/update secondary config example.

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/examples/sota-local.toml
+++ b/docs/ota-client-guide/modules/ROOT/examples/sota-local.toml
@@ -2,9 +2,6 @@
 provision_path = "credentials.zip"
 primary_ecu_hardware_id = "local-fake"
 
-[uptane]
-secondary_configs_dir = "secondary_configs"
-
 [logger]
 loglevel = 1
 
@@ -13,3 +10,6 @@ path = "storage"
 
 [pacman]
 type = "none"
+
+[uptane]
+secondary_config_file = "virtualsec.json"


### PR DESCRIPTION
It would be ideal if this file and and config/sota-local.toml were in fact the same file instead of duplicated. Can we get away with one being a softlink to the other?