### PR TITLE
Fix/update secondary config example (2019.05-docs)

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/examples/sota-local.toml
+++ b/docs/ota-client-guide/modules/ROOT/examples/sota-local.toml
@@ -2,9 +2,6 @@
 provision_path = "credentials.zip"
 primary_ecu_hardware_id = "local-fake"
 
-[uptane]
-secondary_configs_dir = "secondary_configs"
-
 [logger]
 loglevel = 1
 
@@ -13,3 +10,6 @@ path = "storage"
 
 [pacman]
 type = "none"
+
+[uptane]
+secondary_config_file = "virtualsec.json"


### PR DESCRIPTION
Backport of https://github.com/advancedtelematic/aktualizr/pull/1340 to the 2019.5 docs.

Does it matter that the release tag is 2019.5 but the docs branch is 2019.05-docs?