### PR TITLE
Update changelog and docs for 2019.7 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,30 @@ Our versioning scheme is `YEAR.N` where `N` is incremented whenever a new releas
 
 ## [??? (unreleased)]
 
+
+## [2019.7] - 2019-09-10
+
 ### Added
 
 - `GetInstallationLog` API method: [PR](https://github.com/advancedtelematic/aktualizr/pull/1318)
 - The aktualizr daemon will now automatically remove old downloaded targets to free up disk space: [PR](https://github.com/advancedtelematic/aktualizr/pull/1318)
+- CA path is now always supplied to curl and can be overwritten: [PR](https://github.com/advancedtelematic/aktualizr/pull/1294)
+
+### Changed
+
+- garage-push and garage-deploy can now stream OSTree objects to [S3 via Treehub](https://github.com/advancedtelematic/treehub/pull/70) (instead of getting copied): [PR](https://github.com/advancedtelematic/aktualizr/pull/1305)
+
+### Removed
+
+- hmi-stub (replaced by [libaktualizr-demo-app](https://github.com/advancedtelematic/libaktualizr-demo-app)): [PR](https://github.com/advancedtelematic/aktualizr/pull/1310)
+
+### Fixed
+
+- Uptane metadata is now rechecked (offline) before downloading and installing: [PR](https://github.com/advancedtelematic/aktualizr/pull/1296)
+- Downloaded target hashes are rechecked before installation: [PR](https://github.com/advancedtelematic/aktualizr/pull/1296)
+- Failed downloads are now reported to the backend in the installation report: [PR](https://github.com/advancedtelematic/aktualizr/pull/1301)
+- Binary targets for an OSTree-based primary are now rejected immediately: [PR](https://github.com/advancedtelematic/aktualizr/pull/1282)
+
 
 ## [2019.6] - 2019-08-21
 
@@ -34,6 +54,7 @@ Our versioning scheme is `YEAR.N` where `N` is incremented whenever a new releas
 - Target matching between the Director and Image repositories is now done as early as possible during the check for updates: [PR](https://github.com/advancedtelematic/aktualizr/pull/1271)
 - Target matching requires the hardware IDs to match: [PR](https://github.com/advancedtelematic/aktualizr/pull/1258)
 - Custom URL logic now prefers the Director and if it is empty, only then checks the Image repository value: [PR](https://github.com/advancedtelematic/aktualizr/pull/1267)
+
 
 ## [2019.5] - 2019-07-12
 

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -27,6 +27,7 @@ The link above is for the doxygen docs on master. Doxygen docs for the following
 * https://advancedtelematic.github.io/aktualizr/2019.4/index.html[2019.4]
 * https://advancedtelematic.github.io/aktualizr/2019.5/index.html[2019.5]
 * https://advancedtelematic.github.io/aktualizr/2019.6/index.html[2019.6]
+* https://advancedtelematic.github.io/aktualizr/2019.7/index.html[2019.7]
 ====
 
 == Release process

--- a/docs/ota-client-guide/modules/ROOT/pages/cross-deploy-images.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/cross-deploy-images.adoc
@@ -5,7 +5,6 @@
 :page-order: 3
 :icons: font
 :sectnums:
-:garage-deploy-version: 2019.6
 
 For our recommended production workflow, you will need to move disk images from one account to another from time to time. For example, you might want to send a development build that you're happy with to the QA team, or send that build to the deployment team once it's passed QA. You can do this with our `garage-deploy` tool.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/install-garage-sign-deploy.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/install-garage-sign-deploy.adoc
@@ -4,7 +4,7 @@
 :page-date: 2018-09-13 11:50:24
 :page-order: 2
 :icons: font
-:garage-deploy-version: 2019.6
+:garage-deploy-version: 2019.7
 
 For our recommended production workflow, we recommend some extra security procedures. Before you can follow these procedures, you need to install our `garage-deploy` tool first.
 


### PR DESCRIPTION
Removed garage-deploy-version from cross-deploy-images.adoc, since it wasn't actually being used.