### PR TITLE
OTA-3746: Fixing incorrect xrefs and inclues

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/pages/build-configuration.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-configuration.adoc
@@ -1,4 +1,12 @@
 = Build Configuration Options
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
 :page-partial:
 // MC: Included in aktualizr/docs/ota-client-guide/modules/ROOT/pages/build-configuration.adoc
 
@@ -20,7 +28,7 @@
 // We reuse the same descriptions in multiple places with includes - if rendered in Github (where includes aren't allowed), we fall back to the old descriptions.
 ifdef::env-github[Sets the `--expires` parameter of `garage-sign targets sign`. Format is a UTC instant such as '2018-01-01T00:01:00Z'.]
 ifndef::env-github[]
-include::dev@ota-client::partial$config-descriptions.adoc[tags=metadata-expires]
+include::partial$config-descriptions.adoc[tags=metadata-expires]
 ----
 GARAGE_TARGET_EXPIRES = "2018-01-01T00:01:00Z"
 ----
@@ -34,7 +42,7 @@ endif::[]
 // We reuse the same descriptions in multiple places with includes - if rendered in Github (where includes aren't allowed), we fall back to the old descriptions.
 ifdef::env-github[Sets the `--expire-after` parameter of `garage-sign targets sign`. Format is in years, months, and days (each optional, but in that order), such as '1Y3M5D'.]
 ifndef::env-github[]
-include::dev@ota-client::partial$config-descriptions.adoc[tags=metadata-expireafter]
+include::partial$config-descriptions.adoc[tags=metadata-expireafter]
 ----
 GARAGE_TARGET_EXPIRE_AFTER = "1Y3M5D"
 ----
@@ -44,15 +52,15 @@ Currently, this only works when using the master branch of meta-updater.
 ====
 endif::[]
 | `INITRAMFS_IMAGE`|The initramfs/initrd image that is used as a proxy while booting into OSTree deployment. Do not change this setting unless you are sure that your initramfs can serve as such a proxy.
-| `SOTA_PACKED_CREDENTIALS`|When set, your ostree commit will be pushed to a remote repo as a bitbake step. This should be the path to a zipped credentials file in xref:dev@ota-build::provisioning-methods-and-credentialszip.adoc[the format accepted by garage-push].
+| `SOTA_PACKED_CREDENTIALS`|When set, your ostree commit will be pushed to a remote repo as a bitbake step. This should be the path to a zipped credentials file in xref:provisioning-methods-and-credentialszip.adoc[the format accepted by garage-push].
 | `SOTA_DEPLOY_CREDENTIALS`|When set to '1' (default value), deploys credentials to the built image. Override it in `local.conf` to built a generic image that can be provisioned manually after the build.
-| `SOTA_CLIENT_PROV`|Which provisioning method to use. Valid options are `aktualizr-shared-prov`, `aktualizr-device-prov`, and `aktualizr-device-prov-hsm`. For more information on these provisioning methods, see the xref:dev@ota-client::client-provisioning-methods.adoc[OTA Connect documentation]. The default is `aktualizr-shared-prov`. This can also be set to an empty string to avoid using a provisioning recipe.
+| `SOTA_CLIENT_PROV`|Which provisioning method to use. Valid options are `aktualizr-shared-prov`, `aktualizr-device-prov`, and `aktualizr-device-prov-hsm`. For more information on these provisioning methods, see the xref:client-provisioning-methods.adoc[OTA Connect documentation]. The default is `aktualizr-shared-prov`. This can also be set to an empty string to avoid using a provisioning recipe.
 | `SOTA_CLIENT_FEATURES`|Extensions to aktualizr. The only valid options are `hsm` (to build with HSM support) and `secondary-network` (to set up a simulated 'in-vehicle' network with support for a primary node with a DHCP server and a secondary node with a DHCP client).
-| `SOTA_SECONDARY_CONFIG`|A file containing JSON configuration for secondaries. It will be installed into `/etc/sota/ecus` on the device and automatically provided to aktualizr. See xref:dev@ota-client::posix-secondaries-bitbaking.adoc[here] for more details.
+| `SOTA_SECONDARY_CONFIG`|A file containing JSON configuration for secondaries. It will be installed into `/etc/sota/ecus` on the device and automatically provided to aktualizr. See xref:posix-secondaries-bitbaking.adoc[here] for more details.
 | `SOTA_HARDWARE_ID`|A custom hardware ID that will be written to the aktualizr config. Defaults to MACHINE if not set.
 | `SOTA_MAIN_DTB`|The base device tree to use with the kernel. Used together with FIT images. You can change it, and the device tree will also be changed after the update.
 | `SOTA_DT_OVERLAYS`|A whitespace-separated list of used device tree overlays for FIT image. This list is OSTree-updateable as well.
 | `SOTA_EXTRA_CONF_FRAGS`|Extra https://lxr.missinglinkelectronics.com/uboot/doc/uImage.FIT/overlay-fdt-boot.txt[configuration fragments] for FIT image.
-| `RESOURCE_xxx_pn-aktualizr`|Controls maximum resource usage of the aktualizr service, when `aktualizr-resource-control` is installed on the image. See xref:dev@ota-build::meta-updater-usage.adoc#_aktualizr_service_resource_control[aktualizr service resource control] for details.
+| `RESOURCE_xxx_pn-aktualizr`|Controls maximum resource usage of the aktualizr service, when `aktualizr-resource-control` is installed on the image. See xref:meta-updater-usage.adoc#_aktualizr_service_resource_control[aktualizr service resource control] for details.
 | `SOTA_POLLING_SEC`|Sets polling interval for aktualizr to check for updates if aktualizr-polling-interval is included in the image.
 |====================


### PR DESCRIPTION
Fixing includes and xrefs that had necessary or obsolete component ids.

(@tkfu  - Since this is a general fix, I assume once this is merged to master, I can backport it to 2019.7,  2019.6,  2019.5 with having to do a PR each time?)

Signed-off-by: Merlin Carter <merlin.carter@here.com>