### PR TITLE
DOCS: Add docs on how to make the docs branch

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/pages/release-process.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/release-process.adoc
@@ -1,6 +1,7 @@
 = Release process
 :toc: macro
 :toc-title:
+:sectnums:
 
 ifdef::env-github[]
 
@@ -24,6 +25,10 @@ There are a few additional documents that should be updated to refer to the new 
 * The link:https://github.com/advancedtelematic/aktualizr/blob/master/docs/README.adoc#reference-documentation[docs README] contains a table with links to the doxygen docs for each release.
 * The xref:install-garage-sign-deploy.adoc[garage-deploy] installation guide contains a reference to the latest release of the garage-deploy Debian package.
 
+== Pull in any new changes from the current docs branch
+
+The docs published as https://docs.ota.here.com/ota-client/latest/index.html[latest] in the OTA Connect Developer Guide are built from the most recent release's docs branch (`\{version}-docs`). There will very likely be changes from there that have not been pulled into master yet. Open up a PR to merge the previous release's docs into master, resolving any merge conflicts as needed. Once that PR is merged, you can move on to the next step.
+
 == Create a new tag
 
 Releases are built automatically by gitlab from annotated tags of the form `major.minor`, where `major` and `minor` are numbers. We normally set `major` to the current year and `minor` to an incrementing number beginning at 1.
@@ -36,6 +41,15 @@ git push github <tag>
 ----
 
 Gitlab will build this tag and automatically create a release for it on github.
+
+=== Create a new docs branch
+
+Create (and push to github) a new branch with the commit you just tagged as the parent:
+
+----
+git checkout -b <tag>-docs # e.g. git checkout -b 2019.63-docs
+git push github <tag>-docs
+----
 
 == Update doxygen on github
 


### PR DESCRIPTION
Forward-port from 2019.7 docs branch, merged right after 2019.8 release was created, that seems worth bringing forward and not letting get lost in the shuffle.