### PR TITLE
Refactor/constructors

### DIFF
--- a/src/aktualizr_info/aktualizr_info_config.h
+++ b/src/aktualizr_info/aktualizr_info_config.h
@@ -5,6 +5,7 @@
 #include <boost/program_options.hpp>
 #include <boost/property_tree/ini_parser.hpp>
 
+#include "bootloader/bootloader_config.h"
 #include "logging/logging_config.h"
 #include "package_manager/packagemanagerconfig.h"
 #include "storage/storage_config.h"
@@ -24,6 +25,7 @@ class AktualizrInfoConfig : public BaseConfig {
   void writeToStream(std::ostream& sink) const;
 
   // from primary config
+  BootloaderConfig bootloader;
   LoggerConfig logger;
   PackageConfig pacman;
   StorageConfig storage;

--- a/src/aktualizr_info/main.cc
+++ b/src/aktualizr_info/main.cc
@@ -330,7 +330,7 @@ int main(int argc, char **argv) {
     std::cout << "Provisioned on server: " << (registered ? "yes" : "no") << std::endl;
     std::cout << "Fetched metadata: " << (has_metadata ? "yes" : "no") << std::endl;
 
-    auto pacman = PackageManagerFactory::makePackageManager(config.pacman, storage, nullptr, nullptr);
+    auto pacman = PackageManagerFactory::makePackageManager(config.pacman, config.bootloader, storage, nullptr);
 
     Uptane::Target current_target = pacman->getCurrent();
 

--- a/src/aktualizr_lite/helpers.cc
+++ b/src/aktualizr_lite/helpers.cc
@@ -47,11 +47,10 @@ LiteClient::LiteClient(Config &config_in) : config(std::move(config_in)) {
   }
 
   auto http_client = std::make_shared<HttpClient>();
-  auto report_queue = std::make_shared<ReportQueue>(config, http_client);
 
   KeyManager keys(storage, config.keymanagerConfig());
   keys.copyCertsToCurl(*http_client);
 
-  primary = std::make_shared<SotaUptaneClient>(config, storage, http_client, report_queue);
+  primary = std::make_shared<SotaUptaneClient>(config, storage, http_client);
   finalizeIfNeeded(*storage, config.pacman);
 }

--- a/src/aktualizr_lite/helpers.cc
+++ b/src/aktualizr_lite/helpers.cc
@@ -47,12 +47,11 @@ LiteClient::LiteClient(Config &config_in) : config(std::move(config_in)) {
   }
 
   auto http_client = std::make_shared<HttpClient>();
-  auto bootloader = std::make_shared<Bootloader>(config.bootloader, *storage);
   auto report_queue = std::make_shared<ReportQueue>(config, http_client);
 
   KeyManager keys(storage, config.keymanagerConfig());
   keys.copyCertsToCurl(*http_client);
 
-  primary = std::make_shared<SotaUptaneClient>(config, storage, http_client, bootloader, report_queue);
+  primary = std::make_shared<SotaUptaneClient>(config, storage, http_client, report_queue);
   finalizeIfNeeded(*storage, config.pacman);
 }

--- a/src/aktualizr_secondary/aktualizr_secondary_common.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_common.cc
@@ -9,7 +9,7 @@ AktualizrSecondaryCommon::AktualizrSecondaryCommon(const AktualizrSecondaryConfi
       keys_(storage_, config.keymanagerConfig()),
       ecu_serial_(Uptane::EcuSerial::Unknown()),
       hardware_id_(Uptane::HardwareIdentifier::Unknown()) {
-  pacman = PackageManagerFactory::makePackageManager(config_.pacman, storage_, nullptr, nullptr);
+  pacman = PackageManagerFactory::makePackageManager(config_.pacman, config_.bootloader, storage_, nullptr);
 
   // Load Root keys from storage
   std::string root;

--- a/src/aktualizr_secondary/aktualizr_secondary_config.h
+++ b/src/aktualizr_secondary/aktualizr_secondary_config.h
@@ -5,6 +5,7 @@
 #include <boost/program_options.hpp>
 #include <boost/property_tree/ini_parser.hpp>
 
+#include "bootloader/bootloader_config.h"
 #include "crypto/keymanager_config.h"
 #include "crypto/p11_config.h"
 #include "logging/logging_config.h"
@@ -55,6 +56,7 @@ class AktualizrSecondaryConfig : public BaseConfig {
   // from primary config
   P11Config p11;
   PackageConfig pacman;
+  BootloaderConfig bootloader;
   StorageConfig storage;
 
  private:

--- a/src/aktualizr_secondary/uptane_test.cc
+++ b/src/aktualizr_secondary/uptane_test.cc
@@ -48,7 +48,7 @@ TEST(aktualizr_secondary_uptane, credentialsPassing) {
 
   auto storage = INvStorage::newStorage(config.storage);
 
-  auto sota_client = UptaneTestCommon::newTestClient(config, storage, http);
+  auto sota_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage, http);
   EXPECT_NO_THROW(sota_client->initialize());
 
   std::string arch = sota_client->secondaryTreehubCredentials();

--- a/src/libaktualizr/bootloader/bootloader.cc
+++ b/src/libaktualizr/bootloader/bootloader.cc
@@ -10,7 +10,7 @@
 #include "utilities/exceptions.h"
 #include "utilities/utils.h"
 
-Bootloader::Bootloader(const BootloaderConfig& config, INvStorage& storage) : config_(config), storage_(storage) {
+Bootloader::Bootloader(BootloaderConfig config, INvStorage& storage) : config_(std::move(config)), storage_(storage) {
   reboot_sentinel_ = config_.reboot_sentinel_dir / config_.reboot_sentinel_name;
   reboot_command_ = config_.reboot_command;
 

--- a/src/libaktualizr/bootloader/bootloader.h
+++ b/src/libaktualizr/bootloader/bootloader.h
@@ -7,7 +7,7 @@
 
 class Bootloader {
  public:
-  Bootloader(const BootloaderConfig& config, INvStorage& storage);
+  Bootloader(BootloaderConfig config, INvStorage& storage);
   void setBootOK() const;
   void updateNotify() const;
 
@@ -25,7 +25,7 @@ class Bootloader {
   void reboot(bool fake_reboot = false);
 
  private:
-  const BootloaderConfig& config_;
+  const BootloaderConfig config_;
 
   INvStorage& storage_;
   boost::filesystem::path reboot_sentinel_;

--- a/src/libaktualizr/package_manager/androidmanager.h
+++ b/src/libaktualizr/package_manager/androidmanager.h
@@ -7,15 +7,14 @@ class AndroidInstallationDispatcher;
 
 class AndroidManager : public PackageManagerInterface {
  public:
-  explicit AndroidManager(PackageConfig pconfig, std::shared_ptr<INvStorage> storage,
+  explicit AndroidManager(PackageConfig pconfig, BootloaderConfig bconfig, std::shared_ptr<INvStorage> storage,
                           std::shared_ptr<Bootloader> bootloader, std::shared_ptr<HttpInterface> http)
-      : PackageManagerInterface(std::move(pconfig), std::move(storage), std::move(bootloader), std::move(http)) {}
+      : PackageManagerInterface(std::move(pconfig), std::move(bconfig), std::move(storage), std::move(http)) {}
   ~AndroidManager() override = default;
   std::string name() const override { return "android"; }
   Json::Value getInstalledPackages() const override;
 
   Uptane::Target getCurrent() const override;
-  bool imageUpdated() override { return true; };
 
   data::InstallationResult install(const Uptane::Target& target) const override;
   data::InstallationResult finalizeInstall(const Uptane::Target& target) const override;

--- a/src/libaktualizr/package_manager/debianmanager.h
+++ b/src/libaktualizr/package_manager/debianmanager.h
@@ -9,9 +9,9 @@
 
 class DebianManager : public PackageManagerInterface {
  public:
-  DebianManager(PackageConfig pconfig, std::shared_ptr<INvStorage> storage, std::shared_ptr<Bootloader> bootloader,
+  DebianManager(PackageConfig pconfig, BootloaderConfig bconfig, std::shared_ptr<INvStorage> storage,
                 std::shared_ptr<HttpInterface> http)
-      : PackageManagerInterface(std::move(pconfig), std::move(storage), std::move(bootloader), std::move(http)) {}
+      : PackageManagerInterface(std::move(pconfig), std::move(bconfig), std::move(storage), std::move(http)) {}
   ~DebianManager() override = default;
   std::string name() const override { return "debian"; }
   Json::Value getInstalledPackages() const override;
@@ -21,7 +21,6 @@ class DebianManager : public PackageManagerInterface {
     (void)target;
     throw std::runtime_error("Unimplemented");
   }
-  bool imageUpdated() override { return true; }
 
  private:
   mutable std::mutex mutex_;

--- a/src/libaktualizr/package_manager/debianmanager_test.cc
+++ b/src/libaktualizr/package_manager/debianmanager_test.cc
@@ -17,7 +17,7 @@ TEST(PackageManagerFactory, Debian_Install_Good) {
 
   std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
   std::shared_ptr<PackageManagerInterface> pacman =
-      PackageManagerFactory::makePackageManager(config.pacman, storage, nullptr, nullptr);
+      PackageManagerFactory::makePackageManager(config.pacman, config.bootloader, storage, nullptr);
   EXPECT_TRUE(pacman);
   Json::Value target_json;
   target_json["hashes"]["sha256"] = "hash";
@@ -47,7 +47,7 @@ TEST(PackageManagerFactory, Debian_Install_Bad) {
   config.storage.path = dir.Path();
   std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
   std::shared_ptr<PackageManagerInterface> pacman =
-      PackageManagerFactory::makePackageManager(config.pacman, storage, nullptr, nullptr);
+      PackageManagerFactory::makePackageManager(config.pacman, config.bootloader, storage, nullptr);
   EXPECT_TRUE(pacman);
   Json::Value target_json;
   target_json["hashes"]["sha256"] = "hash";

--- a/src/libaktualizr/package_manager/dockerappmanager.h
+++ b/src/libaktualizr/package_manager/dockerappmanager.h
@@ -8,9 +8,9 @@ using DockerAppCb = std::function<bool(const std::string &app, const Uptane::Tar
 
 class DockerAppManager : public OstreeManager {
  public:
-  DockerAppManager(PackageConfig pconfig, std::shared_ptr<INvStorage> storage, std::shared_ptr<Bootloader> bootloader,
+  DockerAppManager(PackageConfig pconfig, BootloaderConfig bconfig, std::shared_ptr<INvStorage> storage,
                    std::shared_ptr<HttpInterface> http)
-      : OstreeManager(std::move(pconfig), std::move(storage), std::move(bootloader), std::move(http)) {
+      : OstreeManager(std::move(pconfig), std::move(bconfig), std::move(storage), std::move(http)) {
     fake_fetcher_ = std::make_shared<Uptane::Fetcher>(Config(), http_);
   }
   bool fetchTarget(const Uptane::Target &target, Uptane::Fetcher &fetcher, const KeyManager &keys,

--- a/src/libaktualizr/package_manager/dockerappmanager_test.cc
+++ b/src/libaktualizr/package_manager/dockerappmanager_test.cc
@@ -39,7 +39,7 @@ TEST(DockerAppManager, PackageManager_Factory_Good) {
   config.storage.path = dir.Path();
 
   std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
-  auto pacman = PackageManagerFactory::makePackageManager(config.pacman, storage, nullptr, nullptr);
+  auto pacman = PackageManagerFactory::makePackageManager(config.pacman, config.bootloader, storage, nullptr);
   EXPECT_TRUE(pacman);
 }
 

--- a/src/libaktualizr/package_manager/dockerappmanager_test.cc
+++ b/src/libaktualizr/package_manager/dockerappmanager_test.cc
@@ -73,8 +73,7 @@ TEST(DockerAppManager, DockerApp_Fetch) {
 
   std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
   KeyManager keys(storage, config.keymanagerConfig());
-  auto http = std::make_shared<HttpClient>();
-  auto client = std_::make_unique<SotaUptaneClient>(config, storage, http);
+  auto client = std_::make_unique<SotaUptaneClient>(config, storage);
   ASSERT_TRUE(client->updateImagesMeta());
 
   std::string targets = Utils::readFile(repo / "repo/repo/targets.json");

--- a/src/libaktualizr/package_manager/dockerappmanager_test.cc
+++ b/src/libaktualizr/package_manager/dockerappmanager_test.cc
@@ -17,16 +17,6 @@ static std::string treehub_server = "http://127.0.0.1:";
 static boost::filesystem::path test_sysroot;
 static boost::filesystem::path uptane_gen;
 
-static std::shared_ptr<SotaUptaneClient> newTestClient(Config& config_in, std::shared_ptr<INvStorage> storage_in,
-                                                       std::shared_ptr<HttpInterface> http_client_in,
-                                                       std::shared_ptr<event::Channel> events_channel_in = nullptr) {
-  std::shared_ptr<Bootloader> bootloader_in = std::make_shared<Bootloader>(config_in.bootloader, *storage_in);
-  std::shared_ptr<ReportQueue> report_queue_in = std::make_shared<ReportQueue>(config_in, http_client_in);
-
-  return std::make_shared<SotaUptaneClient>(config_in, storage_in, http_client_in, bootloader_in, report_queue_in,
-                                            events_channel_in);
-}
-
 static void progress_cb(const Uptane::Target& target, const std::string& description, unsigned int progress) {
   (void)description;
   LOG_INFO << "progress_cb " << target << " " << progress;
@@ -84,7 +74,7 @@ TEST(DockerAppManager, DockerApp_Fetch) {
   std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
   KeyManager keys(storage, config.keymanagerConfig());
   auto http = std::make_shared<HttpClient>();
-  auto client = newTestClient(config, storage, http, nullptr);
+  auto client = std_::make_unique<SotaUptaneClient>(config, storage, http);
   ASSERT_TRUE(client->updateImagesMeta());
 
   std::string targets = Utils::readFile(repo / "repo/repo/targets.json");

--- a/src/libaktualizr/package_manager/fetcher_death_test.cc
+++ b/src/libaktualizr/package_manager/fetcher_death_test.cc
@@ -45,7 +45,7 @@ static void progress_cb(const Uptane::Target& target, const std::string& descrip
 void resume(const Uptane::Target& target) {
   std::shared_ptr<INvStorage> storage(new SQLStorage(config.storage, false));
   auto http = std::make_shared<HttpClient>();
-  auto pacman = std::make_shared<PackageManagerFake>(config.pacman, storage, nullptr, http);
+  auto pacman = std::make_shared<PackageManagerFake>(config.pacman, config.bootloader, storage, http);
   api::FlowControlToken token;
   KeyManager keys(storage, config.keymanagerConfig());
   Uptane::Fetcher fetcher(config, http);
@@ -60,7 +60,7 @@ void pause_and_die(const Uptane::Target& target) {
   std::shared_ptr<INvStorage> storage(new SQLStorage(config.storage, false));
   auto http = std::make_shared<HttpClient>();
   api::FlowControlToken token;
-  auto pacman = std::make_shared<PackageManagerFake>(config.pacman, storage, nullptr, http);
+  auto pacman = std::make_shared<PackageManagerFake>(config.pacman, config.bootloader, storage, http);
   KeyManager keys(storage, config.keymanagerConfig());
   Uptane::Fetcher fetcher(config, http);
 

--- a/src/libaktualizr/package_manager/fetcher_test.cc
+++ b/src/libaktualizr/package_manager/fetcher_test.cc
@@ -64,7 +64,7 @@ void test_pause(const Uptane::Target& target, PackageManager type = PackageManag
   std::shared_ptr<INvStorage> storage(new SQLStorage(config.storage, false));
   auto http = std::make_shared<HttpClient>();
 
-  auto pacman = PackageManagerFactory::makePackageManager(config.pacman, storage, nullptr, http);
+  auto pacman = PackageManagerFactory::makePackageManager(config.pacman, config.bootloader, storage, http);
   KeyManager keys(storage, config.keymanagerConfig());
   Uptane::Fetcher fetcher(config, http);
 
@@ -153,7 +153,7 @@ TEST(Fetcher, DownloadCustomUri) {
   std::shared_ptr<INvStorage> storage(new SQLStorage(config.storage, false));
   auto http = std::make_shared<HttpCustomUri>(temp_dir.Path());
 
-  auto pacman = std::make_shared<PackageManagerFake>(config.pacman, storage, nullptr, http);
+  auto pacman = std::make_shared<PackageManagerFake>(config.pacman, config.bootloader, storage, http);
   KeyManager keys(storage, config.keymanagerConfig());
   Uptane::Fetcher fetcher(config, http);
 
@@ -189,7 +189,7 @@ TEST(Fetcher, DownloadDefaultUri) {
 
   std::shared_ptr<INvStorage> storage(new SQLStorage(config.storage, false));
   auto http = std::make_shared<HttpDefaultUri>(temp_dir.Path());
-  auto pacman = std::make_shared<PackageManagerFake>(config.pacman, storage, nullptr, http);
+  auto pacman = std::make_shared<PackageManagerFake>(config.pacman, config.bootloader, storage, http);
   KeyManager keys(storage, config.keymanagerConfig());
   Uptane::Fetcher fetcher(config, http);
 
@@ -250,7 +250,7 @@ TEST(Fetcher, DownloadLengthZero) {
 
   std::shared_ptr<INvStorage> storage(new SQLStorage(config.storage, false));
   auto http = std::make_shared<HttpZeroLength>(temp_dir.Path());
-  auto pacman = std::make_shared<PackageManagerFake>(config.pacman, storage, nullptr, http);
+  auto pacman = std::make_shared<PackageManagerFake>(config.pacman, config.bootloader, storage, http);
   KeyManager keys(storage, config.keymanagerConfig());
   Uptane::Fetcher fetcher(config, http);
 

--- a/src/libaktualizr/package_manager/ostreemanager.h
+++ b/src/libaktualizr/package_manager/ostreemanager.h
@@ -39,13 +39,13 @@ struct PullMetaStruct {
 
 class OstreeManager : public PackageManagerInterface {
  public:
-  OstreeManager(PackageConfig pconfig, std::shared_ptr<INvStorage> storage, std::shared_ptr<Bootloader> bootloader,
+  OstreeManager(PackageConfig pconfig, BootloaderConfig bconfig, std::shared_ptr<INvStorage> storage,
                 std::shared_ptr<HttpInterface> http);
   ~OstreeManager() override = default;
   std::string name() const override { return "ostree"; }
   Json::Value getInstalledPackages() const override;
   Uptane::Target getCurrent() const override;
-  bool imageUpdated() override;
+  bool imageUpdated();
   data::InstallationResult install(const Uptane::Target &target) const override;
   void completeInstall() const override;
   data::InstallationResult finalizeInstall(const Uptane::Target &target) const override;

--- a/src/libaktualizr/package_manager/ostreemanager_test.cc
+++ b/src/libaktualizr/package_manager/ostreemanager_test.cc
@@ -81,7 +81,7 @@ TEST(OstreeManager, InstallBadUri) {
   config.storage.path = temp_dir.Path();
 
   std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
-  OstreeManager ostree(config.pacman, storage, nullptr, nullptr);
+  OstreeManager ostree(config.pacman, config.bootloader, storage, nullptr);
   data::InstallationResult result = ostree.install(target);
   EXPECT_EQ(result.result_code.num_code, data::ResultCode::Numeric::kInstallFailed);
   EXPECT_EQ(result.description, "Refspec 'hash' not found");
@@ -95,7 +95,7 @@ TEST(OstreeManager, BadSysroot) {
   config.pacman.sysroot = "sysroot-that-is-missing";
   config.storage.path = temp_dir.Path();
   std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
-  EXPECT_THROW(OstreeManager ostree(config.pacman, storage, nullptr, nullptr), std::runtime_error);
+  EXPECT_THROW(OstreeManager ostree(config.pacman, config.bootloader, storage, nullptr), std::runtime_error);
 }
 
 /* Parse a provided list of installed packages. */
@@ -118,7 +118,7 @@ TEST(OstreeManager, ParseInstalledPackages) {
   config.storage.path = temp_dir.Path();
 
   std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
-  OstreeManager ostree(config.pacman, storage, nullptr, nullptr);
+  OstreeManager ostree(config.pacman, config.bootloader, storage, nullptr);
   Json::Value packages = ostree.getInstalledPackages();
   EXPECT_EQ(packages[0]["name"].asString(), "vim");
   EXPECT_EQ(packages[0]["version"].asString(), "1.0");

--- a/src/libaktualizr/package_manager/packagemanagerfactory.cc
+++ b/src/libaktualizr/package_manager/packagemanagerfactory.cc
@@ -19,36 +19,35 @@
 #include "logging/logging.h"
 
 std::shared_ptr<PackageManagerInterface> PackageManagerFactory::makePackageManager(
-    const PackageConfig& pconfig, const std::shared_ptr<INvStorage>& storage,
-    const std::shared_ptr<Bootloader>& bootloader, const std::shared_ptr<HttpInterface>& http) {
-  (void)bootloader;
+    const PackageConfig& pconfig, const BootloaderConfig& bconfig, const std::shared_ptr<INvStorage>& storage,
+    const std::shared_ptr<HttpInterface>& http) {
   switch (pconfig.type) {
     case PackageManager::kOstree:
 #ifdef BUILD_OSTREE
-      return std::make_shared<OstreeManager>(pconfig, storage, bootloader, http);
+      return std::make_shared<OstreeManager>(pconfig, bconfig, storage, http);
 #else
       throw std::runtime_error("aktualizr was compiled without OStree support!");
 #endif
     case PackageManager::kDebian:
 #ifdef BUILD_DEB
-      return std::make_shared<DebianManager>(pconfig, storage, bootloader, http);
+      return std::make_shared<DebianManager>(pconfig, bconfig, storage, http);
 #else
       throw std::runtime_error("aktualizr was compiled without debian packages support!");
 #endif
     case PackageManager::kAndroid:
 #if defined(ANDROID)
-      return std::make_shared<AndroidManager>(pconfig, storage, bootloader, http);
+      return std::make_shared<AndroidManager>(pconfig, bconfig, storage, http);
 #else
       throw std::runtime_error("aktualizr was compiled without android support!");
 #endif
     case PackageManager::kOstreeDockerApp:
 #if defined(BUILD_DOCKERAPP) && defined(BUILD_OSTREE)
-      return std::make_shared<DockerAppManager>(pconfig, storage, bootloader, http);
+      return std::make_shared<DockerAppManager>(pconfig, bconfig, storage, http);
 #else
       throw std::runtime_error("aktualizr was compiled without ostree+docker-app support!");
 #endif
     case PackageManager::kNone:
-      return std::make_shared<PackageManagerFake>(pconfig, storage, bootloader, http);
+      return std::make_shared<PackageManagerFake>(pconfig, bconfig, storage, http);
     default:
       LOG_ERROR << "Unrecognized package manager type: " << static_cast<int>(pconfig.type);
       return std::shared_ptr<PackageManagerInterface>();  // NULL-equivalent

--- a/src/libaktualizr/package_manager/packagemanagerfactory.h
+++ b/src/libaktualizr/package_manager/packagemanagerfactory.h
@@ -8,8 +8,8 @@
 class PackageManagerFactory {
  public:
   static std::shared_ptr<PackageManagerInterface> makePackageManager(const PackageConfig& pconfig,
+                                                                     const BootloaderConfig& bconfig,
                                                                      const std::shared_ptr<INvStorage>& storage,
-                                                                     const std::shared_ptr<Bootloader>& bootloader,
                                                                      const std::shared_ptr<HttpInterface>& http);
 };
 

--- a/src/libaktualizr/package_manager/packagemanagerfactory_test.cc
+++ b/src/libaktualizr/package_manager/packagemanagerfactory_test.cc
@@ -21,11 +21,11 @@ TEST(PackageManagerFactory, Ostree) {
   std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
 #ifdef BUILD_OSTREE
   std::shared_ptr<PackageManagerInterface> pacman =
-      PackageManagerFactory::makePackageManager(config.pacman, storage, nullptr, nullptr);
+      PackageManagerFactory::makePackageManager(config.pacman, config.bootloader, storage, nullptr);
   EXPECT_TRUE(pacman);
 #else
   EXPECT_THROW(std::shared_ptr<PackageManagerInterface> pacman =
-                   PackageManagerFactory::makePackageManager(config.pacman, storage, nullptr, nullptr),
+                   PackageManagerFactory::makePackageManager(config.pacman, config.bootloader, storage, nullptr),
                std::runtime_error);
 #endif
 }
@@ -38,11 +38,11 @@ TEST(PackageManagerFactory, Debian) {
   std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
 #ifdef BUILD_DEB
   std::shared_ptr<PackageManagerInterface> pacman =
-      PackageManagerFactory::makePackageManager(config.pacman, storage, nullptr, nullptr);
+      PackageManagerFactory::makePackageManager(config.pacman, config.bootloader, storage, nullptr);
   EXPECT_TRUE(pacman);
 #else
   EXPECT_THROW(std::shared_ptr<PackageManagerInterface> pacman =
-                   PackageManagerFactory::makePackageManager(config.pacman, storage, nullptr, nullptr),
+                   PackageManagerFactory::makePackageManager(config.pacman, config.bootloader, storage, nullptr),
                std::runtime_error);
 #endif
 }
@@ -54,7 +54,7 @@ TEST(PackageManagerFactory, None) {
   std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
   config.pacman.type = PackageManager::kNone;
   std::shared_ptr<PackageManagerInterface> pacman =
-      PackageManagerFactory::makePackageManager(config.pacman, storage, nullptr, nullptr);
+      PackageManagerFactory::makePackageManager(config.pacman, config.bootloader, storage, nullptr);
   EXPECT_TRUE(pacman);
 }
 
@@ -65,7 +65,7 @@ TEST(PackageManagerFactory, Bad) {
   config.pacman.type = (PackageManager)-1;
   std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
   std::shared_ptr<PackageManagerInterface> pacman =
-      PackageManagerFactory::makePackageManager(config.pacman, storage, nullptr, nullptr);
+      PackageManagerFactory::makePackageManager(config.pacman, config.bootloader, storage, nullptr);
   EXPECT_FALSE(pacman);
 }
 

--- a/src/libaktualizr/package_manager/packagemanagerfake.h
+++ b/src/libaktualizr/package_manager/packagemanagerfake.h
@@ -8,15 +8,14 @@
 
 class PackageManagerFake : public PackageManagerInterface {
  public:
-  PackageManagerFake(PackageConfig pconfig, std::shared_ptr<INvStorage> storage, std::shared_ptr<Bootloader> bootloader,
+  PackageManagerFake(PackageConfig pconfig, BootloaderConfig bconfig, std::shared_ptr<INvStorage> storage,
                      std::shared_ptr<HttpInterface> http)
-      : PackageManagerInterface(std::move(pconfig), std::move(storage), std::move(bootloader), std::move(http)) {}
+      : PackageManagerInterface(std::move(pconfig), std::move(bconfig), std::move(storage), std::move(http)) {}
   ~PackageManagerFake() override = default;
   std::string name() const override { return "fake"; }
   Json::Value getInstalledPackages() const override;
 
   Uptane::Target getCurrent() const override;
-  bool imageUpdated() override { return true; };
 
   data::InstallationResult install(const Uptane::Target &target) const override;
   void completeInstall() const override;

--- a/src/libaktualizr/package_manager/packagemanagerfake_test.cc
+++ b/src/libaktualizr/package_manager/packagemanagerfake_test.cc
@@ -38,7 +38,7 @@ TEST(PackageManagerFake, Verify) {
   const std::string hash = hasher.getHexDigest();
   Uptane::Target target("some-pkg", primary_ecu, {Uptane::Hash(Uptane::Hash::Type::kSha256, hash)}, length, "");
 
-  PackageManagerFake fakepm(config.pacman, storage, nullptr, nullptr);
+  PackageManagerFake fakepm(config.pacman, config.bootloader, storage, nullptr);
   // Target is not yet available.
   EXPECT_EQ(fakepm.verifyTarget(target), TargetStatus::kNotFound);
 
@@ -79,7 +79,7 @@ TEST(PackageManagerFake, FinalizeAfterReboot) {
   std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
   std::shared_ptr<Bootloader> bootloader = std::make_shared<Bootloader>(config.bootloader, *storage);
 
-  PackageManagerFake fakepm(config.pacman, storage, bootloader, nullptr);
+  PackageManagerFake fakepm(config.pacman, config.bootloader, storage, nullptr);
 
   Uptane::EcuMap primary_ecu;
   Uptane::Target target("pkg", primary_ecu, {Uptane::Hash(Uptane::Hash::Type::kSha256, "hash")}, 1, "");
@@ -105,7 +105,7 @@ TEST(PackageManagerFake, DownloadFailureInjection) {
   Uptane::Fetcher uptane_fetcher(config, http);
   KeyManager keys(storage, config.keymanagerConfig());
 
-  PackageManagerFake fakepm(config.pacman, storage, nullptr, http);
+  PackageManagerFake fakepm(config.pacman, config.bootloader, storage, http);
 
   fault_injection_init();
 
@@ -133,7 +133,7 @@ TEST(PackageManagerFake, InstallFailureInjection) {
   config.storage.path = temp_dir.Path();
   std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
 
-  PackageManagerFake fakepm(config.pacman, storage, nullptr, nullptr);
+  PackageManagerFake fakepm(config.pacman, config.bootloader, storage, nullptr);
 
   fault_injection_init();
 

--- a/src/libaktualizr/package_manager/packagemanagerinterface.h
+++ b/src/libaktualizr/package_manager/packagemanagerinterface.h
@@ -35,12 +35,12 @@ enum class TargetStatus {
 
 class PackageManagerInterface {
  public:
-  PackageManagerInterface(PackageConfig pconfig, std::shared_ptr<INvStorage> storage,
-                          std::shared_ptr<Bootloader> bootloader, std::shared_ptr<HttpInterface> http)
+  PackageManagerInterface(PackageConfig pconfig, BootloaderConfig bconfig, std::shared_ptr<INvStorage> storage,
+                          std::shared_ptr<HttpInterface> http)
       : config(std::move(pconfig)),
         storage_(std::move(storage)),
-        bootloader_(std::move(bootloader)),
-        http_(std::move(http)) {}
+        http_(std::move(http)),
+        bootloader_{new Bootloader(std::move(bconfig), *storage_)} {}
   virtual ~PackageManagerInterface() = default;
   virtual std::string name() const = 0;
   virtual Json::Value getInstalledPackages() const = 0;
@@ -48,7 +48,9 @@ class PackageManagerInterface {
   virtual data::InstallationResult install(const Uptane::Target& target) const = 0;
   virtual void completeInstall() const { throw std::runtime_error("Unimplemented"); };
   virtual data::InstallationResult finalizeInstall(const Uptane::Target& target) const = 0;
-  virtual bool imageUpdated() = 0;
+  virtual bool rebootDetected() { return bootloader_->rebootDetected(); };
+  virtual void rebootFlagClear() { bootloader_->rebootFlagClear(); };
+  virtual void updateNotify() { bootloader_->updateNotify(); };
   virtual bool fetchTarget(const Uptane::Target& target, Uptane::Fetcher& fetcher, const KeyManager& keys,
                            FetcherProgressCb progress_cb, const api::FlowControlToken* token);
   virtual TargetStatus verifyTarget(const Uptane::Target& target) const;
@@ -73,7 +75,7 @@ class PackageManagerInterface {
  protected:
   PackageConfig config;
   std::shared_ptr<INvStorage> storage_;
-  std::shared_ptr<Bootloader> bootloader_;
   std::shared_ptr<HttpInterface> http_;
+  std::unique_ptr<Bootloader> bootloader_;
 };
 #endif  // PACKAGEMANAGERINTERFACE_H_

--- a/src/libaktualizr/primary/aktualizr.cc
+++ b/src/libaktualizr/primary/aktualizr.cc
@@ -20,7 +20,7 @@ Aktualizr::Aktualizr(Config &config) : config_(config) {
   sig_ = make_shared<boost::signals2::signal<void(shared_ptr<event::BaseEvent>)>>();
   storage_ = INvStorage::newStorage(config_.storage);
   storage_->importData(config_.import);
-  uptane_client_ = std::make_shared<SotaUptaneClient>(config_, storage_, nullptr, nullptr, nullptr, sig_);
+  uptane_client_ = std::make_shared<SotaUptaneClient>(config_, storage_, nullptr, nullptr, sig_);
 }
 
 Aktualizr::Aktualizr(Config &config, std::shared_ptr<INvStorage> storage_in, std::shared_ptr<HttpInterface> http_in)
@@ -31,10 +31,9 @@ Aktualizr::Aktualizr(Config &config, std::shared_ptr<INvStorage> storage_in, std
 
   sig_ = make_shared<event::Channel>();
   storage_ = std::move(storage_in);
-  std::shared_ptr<Bootloader> bootloader_in = std::make_shared<Bootloader>(config_.bootloader, *storage_);
   std::shared_ptr<ReportQueue> report_queue_in = std::make_shared<ReportQueue>(config_, http_in);
 
-  uptane_client_ = std::make_shared<SotaUptaneClient>(config_, storage_, http_in, bootloader_in, report_queue_in, sig_);
+  uptane_client_ = std::make_shared<SotaUptaneClient>(config_, storage_, http_in, report_queue_in, sig_);
 }
 
 void Aktualizr::Initialize() {

--- a/src/libaktualizr/primary/aktualizr.cc
+++ b/src/libaktualizr/primary/aktualizr.cc
@@ -20,7 +20,7 @@ Aktualizr::Aktualizr(Config &config) : config_(config) {
   sig_ = make_shared<boost::signals2::signal<void(shared_ptr<event::BaseEvent>)>>();
   storage_ = INvStorage::newStorage(config_.storage);
   storage_->importData(config_.import);
-  uptane_client_ = SotaUptaneClient::newDefaultClient(config_, storage_, sig_);
+  uptane_client_ = std::make_shared<SotaUptaneClient>(config_, storage_, nullptr, nullptr, nullptr, sig_);
 }
 
 Aktualizr::Aktualizr(Config &config, std::shared_ptr<INvStorage> storage_in, std::shared_ptr<HttpInterface> http_in)
@@ -29,7 +29,7 @@ Aktualizr::Aktualizr(Config &config, std::shared_ptr<INvStorage> storage_in, std
     throw std::runtime_error("Unable to initialize libsodium");
   }
 
-  sig_ = make_shared<boost::signals2::signal<void(shared_ptr<event::BaseEvent>)>>();
+  sig_ = make_shared<event::Channel>();
   storage_ = std::move(storage_in);
   std::shared_ptr<Bootloader> bootloader_in = std::make_shared<Bootloader>(config_.bootloader, *storage_);
   std::shared_ptr<ReportQueue> report_queue_in = std::make_shared<ReportQueue>(config_, http_in);

--- a/src/libaktualizr/primary/aktualizr.cc
+++ b/src/libaktualizr/primary/aktualizr.cc
@@ -20,7 +20,7 @@ Aktualizr::Aktualizr(Config &config) : config_(config) {
   sig_ = make_shared<boost::signals2::signal<void(shared_ptr<event::BaseEvent>)>>();
   storage_ = INvStorage::newStorage(config_.storage);
   storage_->importData(config_.import);
-  uptane_client_ = std::make_shared<SotaUptaneClient>(config_, storage_, nullptr, nullptr, sig_);
+  uptane_client_ = std::make_shared<SotaUptaneClient>(config_, storage_, sig_);
 }
 
 Aktualizr::Aktualizr(Config &config, std::shared_ptr<INvStorage> storage_in, std::shared_ptr<HttpInterface> http_in)
@@ -31,9 +31,8 @@ Aktualizr::Aktualizr(Config &config, std::shared_ptr<INvStorage> storage_in, std
 
   sig_ = make_shared<event::Channel>();
   storage_ = std::move(storage_in);
-  std::shared_ptr<ReportQueue> report_queue_in = std::make_shared<ReportQueue>(config_, http_in);
 
-  uptane_client_ = std::make_shared<SotaUptaneClient>(config_, storage_, http_in, report_queue_in, sig_);
+  uptane_client_ = std::make_shared<SotaUptaneClient>(config_, storage_, http_in, sig_);
 }
 
 void Aktualizr::Initialize() {

--- a/src/libaktualizr/primary/aktualizr.h
+++ b/src/libaktualizr/primary/aktualizr.h
@@ -21,7 +21,7 @@ class Aktualizr {
  public:
   /** Aktualizr requires a configuration object. Examples can be found in the
    *  config directory. */
-  explicit Aktualizr(Config& config);
+  explicit Aktualizr(Config config);
   Aktualizr(const Aktualizr&) = delete;
   Aktualizr& operator=(const Aktualizr&) = delete;
 
@@ -196,7 +196,7 @@ class Aktualizr {
   Config config_;
 
  protected:
-  Aktualizr(Config& config, std::shared_ptr<INvStorage> storage_in, std::shared_ptr<HttpInterface> http_in);
+  Aktualizr(Config config, std::shared_ptr<INvStorage> storage_in, std::shared_ptr<HttpInterface> http_in);
 
   std::shared_ptr<SotaUptaneClient> uptane_client_;
 

--- a/src/libaktualizr/primary/aktualizr.h
+++ b/src/libaktualizr/primary/aktualizr.h
@@ -201,8 +201,6 @@ class Aktualizr {
   std::shared_ptr<SotaUptaneClient> uptane_client_;
 
  private:
-  static void systemSetup();
-
   struct {
     std::mutex m;
     std::condition_variable cv;

--- a/src/libaktualizr/primary/aktualizr_test.cc
+++ b/src/libaktualizr/primary/aktualizr_test.cc
@@ -636,7 +636,7 @@ TEST(Aktualizr, FinalizationFailure) {
     auto aktualizr_cycle_thread_status = aktualizr_cycle_thread.wait_for(std::chrono::seconds(20));
 
     ASSERT_EQ(aktualizr_cycle_thread_status, std::future_status::ready);
-    EXPECT_TRUE(aktualizr.uptane_client()->bootloader->rebootDetected());
+    EXPECT_TRUE(aktualizr.uptane_client()->package_manager_->rebootDetected());
     EXPECT_TRUE(event_hdlr.checkReceivedEvents(expected_event_order));
     EXPECT_TRUE(aktualizr.uptane_client()->hasPendingUpdates());
     EXPECT_TRUE(http_server_mock->checkReceivedReports(expected_report_order));
@@ -909,7 +909,7 @@ TEST(Aktualizr, AutoRebootAfterUpdate) {
     auto aktualizr_cycle_thread_status = aktualizr_cycle_thread.wait_for(std::chrono::seconds(20));
 
     EXPECT_EQ(aktualizr_cycle_thread_status, std::future_status::ready);
-    EXPECT_TRUE(aktualizr.uptane_client()->bootloader->rebootDetected());
+    EXPECT_TRUE(aktualizr.uptane_client()->package_manager_->rebootDetected());
   }
 
   {

--- a/src/libaktualizr/primary/download_nonostree_test.cc
+++ b/src/libaktualizr/primary/download_nonostree_test.cc
@@ -30,7 +30,7 @@ TEST(Aktualizr, DownloadNonOstreeBin) {
 
   {
     std::shared_ptr<INvStorage> storage = INvStorage::newStorage(conf.storage);
-    auto uptane_client = SotaUptaneClient::newDefaultClient(conf, storage);
+    auto uptane_client = std_::make_unique<SotaUptaneClient>(conf, storage);
     uptane_client->initialize();
     EXPECT_FALSE(uptane_client->uptaneIteration(nullptr, nullptr));
     EXPECT_STREQ(uptane_client->getLastException().what(),

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -26,21 +26,18 @@ static void report_progress_cb(event::Channel *channel, const Uptane::Target &ta
 }
 
 SotaUptaneClient::SotaUptaneClient(Config &config_in, const std::shared_ptr<INvStorage> &storage_in,
-                                   std::shared_ptr<HttpInterface> http_in, std::shared_ptr<ReportQueue> report_queue_in,
+                                   std::shared_ptr<HttpInterface> http_in,
                                    std::shared_ptr<event::Channel> events_channel_in)
     : config(config_in),
       uptane_manifest(config, storage_in),
       storage(storage_in),
       http(std::move(http_in)),
-      report_queue(std::move(report_queue_in)),
+      uptane_fetcher(new Uptane::Fetcher(config, http)),
+      report_queue(new ReportQueue(config, http)),
       events_channel(std::move(events_channel_in)) {
   if (!http) {
     http = std::make_shared<HttpClient>();
   }
-  if (!report_queue) {
-    report_queue = std::make_shared<ReportQueue>(config, http);
-  }
-  uptane_fetcher = std::make_shared<Uptane::Fetcher>(config, http);
 
   package_manager_ = PackageManagerFactory::makePackageManager(config.pacman, config.bootloader, storage, http);
 }

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -10,7 +10,6 @@
 #include "crypto/keymanager.h"
 #include "initializer.h"
 #include "logging/logging.h"
-#include "package_manager/packagemanagerfactory.h"
 #include "uptane/exceptions.h"
 
 #include "utilities/fault_injection.h"
@@ -24,25 +23,6 @@ static void report_progress_cb(event::Channel *channel, const Uptane::Target &ta
   auto event = std::make_shared<event::DownloadProgressReport>(target, description, progress);
   (*channel)(event);
 }
-
-SotaUptaneClient::SotaUptaneClient(Config &config_in, const std::shared_ptr<INvStorage> &storage_in,
-                                   std::shared_ptr<HttpInterface> http_in,
-                                   std::shared_ptr<event::Channel> events_channel_in)
-    : config(config_in),
-      uptane_manifest(config, storage_in),
-      storage(storage_in),
-      http(std::move(http_in)),
-      uptane_fetcher(new Uptane::Fetcher(config, http)),
-      report_queue(new ReportQueue(config, http)),
-      events_channel(std::move(events_channel_in)) {
-  if (!http) {
-    http = std::make_shared<HttpClient>();
-  }
-
-  package_manager_ = PackageManagerFactory::makePackageManager(config.pacman, config.bootloader, storage, http);
-}
-
-SotaUptaneClient::~SotaUptaneClient() { conn.disconnect(); }
 
 void SotaUptaneClient::addNewSecondary(const std::shared_ptr<Uptane::SecondaryInterface> &sec) {
   if (storage->loadEcuRegistered()) {

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -31,7 +31,6 @@ class SotaUptaneClient {
  public:
   SotaUptaneClient(Config &config_in, const std::shared_ptr<INvStorage> &storage_in,
                    std::shared_ptr<HttpInterface> http_in = nullptr,
-                   std::shared_ptr<ReportQueue> report_queue_in = nullptr,
                    std::shared_ptr<event::Channel> events_channel_in = nullptr);
   ~SotaUptaneClient();
 
@@ -144,7 +143,7 @@ class SotaUptaneClient {
   std::shared_ptr<PackageManagerInterface> package_manager_;
   std::shared_ptr<HttpInterface> http;
   std::shared_ptr<Uptane::Fetcher> uptane_fetcher;
-  std::shared_ptr<ReportQueue> report_queue;
+  std::unique_ptr<ReportQueue> report_queue;
   Json::Value last_network_info_reported;
   Json::Value last_hw_info_reported;
   Uptane::EcuMap hw_ids;

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -31,7 +31,6 @@ class SotaUptaneClient {
  public:
   SotaUptaneClient(Config &config_in, const std::shared_ptr<INvStorage> &storage_in,
                    std::shared_ptr<HttpInterface> http_in = nullptr,
-                   std::shared_ptr<Bootloader> bootloader_in = nullptr,
                    std::shared_ptr<ReportQueue> report_queue_in = nullptr,
                    std::shared_ptr<event::Channel> events_channel_in = nullptr);
   ~SotaUptaneClient();
@@ -145,7 +144,6 @@ class SotaUptaneClient {
   std::shared_ptr<PackageManagerInterface> package_manager_;
   std::shared_ptr<HttpInterface> http;
   std::shared_ptr<Uptane::Fetcher> uptane_fetcher;
-  std::shared_ptr<Bootloader> bootloader;
   std::shared_ptr<ReportQueue> report_queue;
   Json::Value last_network_info_reported;
   Json::Value last_hw_info_reported;

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -42,15 +42,11 @@ class SotaUptaneClient {
         events_channel(std::move(events_channel_in)) {}
 
   SotaUptaneClient(Config &config_in, const std::shared_ptr<INvStorage> &storage_in,
-                   std::shared_ptr<event::Channel> events_channel_in)
-      : SotaUptaneClient(config_in, storage_in, std::make_shared<HttpClient>(), std::move(events_channel_in)) {}
-
-  SotaUptaneClient(Config &config_in, const std::shared_ptr<INvStorage> &storage_in,
                    std::shared_ptr<HttpInterface> http_in)
       : SotaUptaneClient(config_in, storage_in, std::move(http_in), nullptr) {}
 
   SotaUptaneClient(Config &config_in, const std::shared_ptr<INvStorage> &storage_in)
-      : SotaUptaneClient(config_in, storage_in, std::make_shared<HttpClient>(), nullptr) {}
+      : SotaUptaneClient(config_in, storage_in, std::make_shared<HttpClient>()) {}
 
   void initialize();
   void addNewSecondary(const std::shared_ptr<Uptane::SecondaryInterface> &sec);

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -29,13 +29,10 @@
 
 class SotaUptaneClient {
  public:
-  static std::shared_ptr<SotaUptaneClient> newDefaultClient(
-      Config &config_in, std::shared_ptr<INvStorage> storage_in,
-      std::shared_ptr<event::Channel> events_channel_in = nullptr);
-
   SotaUptaneClient(Config &config_in, const std::shared_ptr<INvStorage> &storage_in,
-                   std::shared_ptr<HttpInterface> http_client, std::shared_ptr<Bootloader> bootloader_in,
-                   std::shared_ptr<ReportQueue> report_queue_in,
+                   std::shared_ptr<HttpInterface> http_in = nullptr,
+                   std::shared_ptr<Bootloader> bootloader_in = nullptr,
+                   std::shared_ptr<ReportQueue> report_queue_in = nullptr,
                    std::shared_ptr<event::Channel> events_channel_in = nullptr);
   ~SotaUptaneClient();
 

--- a/src/libaktualizr/uptane/uptane_ci_test.cc
+++ b/src/libaktualizr/uptane/uptane_ci_test.cc
@@ -34,10 +34,9 @@ TEST(UptaneCI, ProvisionAndPutManifest) {
   config.postUpdateValues();  // re-run copy of urls
 
   auto storage = INvStorage::newStorage(config.storage);
-  auto http = std::make_shared<HttpClient>();
   Uptane::Manifest uptane_manifest{config, storage};
 
-  auto sota_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage, http);
+  auto sota_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage);
   EXPECT_NO_THROW(sota_client->initialize());
   EXPECT_TRUE(sota_client->putManifestSimple());
 }
@@ -54,10 +53,9 @@ TEST(UptaneCI, CheckKeys) {
   boost::filesystem::remove_all(config.storage.path);
 
   auto storage = INvStorage::newStorage(config.storage);
-  auto http = std::make_shared<HttpClient>();
 
   UptaneTestCommon::addDefaultSecondary(config, temp_dir, "", "secondary_hardware");
-  auto sota_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage, http);
+  auto sota_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage);
   EXPECT_NO_THROW(sota_client->initialize());
 
   std::string ca;

--- a/src/libaktualizr/uptane/uptane_ci_test.cc
+++ b/src/libaktualizr/uptane/uptane_ci_test.cc
@@ -37,7 +37,7 @@ TEST(UptaneCI, ProvisionAndPutManifest) {
   auto http = std::make_shared<HttpClient>();
   Uptane::Manifest uptane_manifest{config, storage};
 
-  auto sota_client = UptaneTestCommon::newTestClient(config, storage, http);
+  auto sota_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage, http);
   EXPECT_NO_THROW(sota_client->initialize());
   EXPECT_TRUE(sota_client->putManifestSimple());
 }
@@ -57,7 +57,7 @@ TEST(UptaneCI, CheckKeys) {
   auto http = std::make_shared<HttpClient>();
 
   UptaneTestCommon::addDefaultSecondary(config, temp_dir, "", "secondary_hardware");
-  auto sota_client = UptaneTestCommon::newTestClient(config, storage, http);
+  auto sota_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage, http);
   EXPECT_NO_THROW(sota_client->initialize());
 
   std::string ca;

--- a/src/libaktualizr/uptane/uptane_network_test.cc
+++ b/src/libaktualizr/uptane/uptane_network_test.cc
@@ -125,7 +125,7 @@ TEST(UptaneNetwork, DownloadFailure) {
 
   auto storage = INvStorage::newStorage(conf.storage);
   auto http = std::make_shared<HttpClient>();
-  auto up = newTestClient(conf, storage, http);
+  auto up = std_::make_unique<SotaUptaneClient>(conf, storage, http);
   EXPECT_NO_THROW(up->initialize());
 
   Json::Value ot_json;

--- a/src/libaktualizr/uptane/uptane_network_test.cc
+++ b/src/libaktualizr/uptane/uptane_network_test.cc
@@ -124,8 +124,7 @@ TEST(UptaneNetwork, DownloadFailure) {
   conf.provision.primary_ecu_hardware_id = "hardware_id";
 
   auto storage = INvStorage::newStorage(conf.storage);
-  auto http = std::make_shared<HttpClient>();
-  auto up = std_::make_unique<SotaUptaneClient>(conf, storage, http);
+  auto up = std_::make_unique<SotaUptaneClient>(conf, storage);
   EXPECT_NO_THROW(up->initialize());
 
   Json::Value ot_json;

--- a/src/libaktualizr/uptane/uptane_serial_test.cc
+++ b/src/libaktualizr/uptane/uptane_serial_test.cc
@@ -49,18 +49,18 @@ TEST(Uptane, RandomSerial) {
   auto http2 = std::make_shared<HttpFake>(temp_dir2.Path());
 
   auto uptane_client1 = std_::make_unique<UptaneTestCommon::TestUptaneClient>(conf_1, storage_1, http1);
-  EXPECT_NO_THROW(uptane_client1->initialize());
+  ASSERT_NO_THROW(uptane_client1->initialize());
 
   auto uptane_client2 = std_::make_unique<UptaneTestCommon::TestUptaneClient>(conf_2, storage_2, http2);
-  EXPECT_NO_THROW(uptane_client2->initialize());
+  ASSERT_NO_THROW(uptane_client2->initialize());
 
   // Verify that none of the serials match.
   EcuSerials ecu_serials_1;
   EcuSerials ecu_serials_2;
-  EXPECT_TRUE(storage_1->loadEcuSerials(&ecu_serials_1));
-  EXPECT_TRUE(storage_2->loadEcuSerials(&ecu_serials_2));
-  EXPECT_EQ(ecu_serials_1.size(), 2);
-  EXPECT_EQ(ecu_serials_2.size(), 2);
+  ASSERT_TRUE(storage_1->loadEcuSerials(&ecu_serials_1));
+  ASSERT_TRUE(storage_2->loadEcuSerials(&ecu_serials_2));
+  ASSERT_EQ(ecu_serials_1.size(), 2);
+  ASSERT_EQ(ecu_serials_2.size(), 2);
   EXPECT_FALSE(ecu_serials_1[0].first.ToString().empty());
   EXPECT_FALSE(ecu_serials_1[1].first.ToString().empty());
   EXPECT_FALSE(ecu_serials_2[0].first.ToString().empty());
@@ -94,9 +94,9 @@ TEST(Uptane, ReloadSerial) {
     UptaneTestCommon::addDefaultSecondary(conf, temp_dir, "", "secondary_hardware", false);
     auto uptane_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(conf, storage, http);
 
-    EXPECT_NO_THROW(uptane_client->initialize());
-    EXPECT_TRUE(storage->loadEcuSerials(&ecu_serials_1));
-    EXPECT_EQ(ecu_serials_1.size(), 2);
+    ASSERT_NO_THROW(uptane_client->initialize());
+    ASSERT_TRUE(storage->loadEcuSerials(&ecu_serials_1));
+    ASSERT_EQ(ecu_serials_1.size(), 2);
     EXPECT_FALSE(ecu_serials_1[0].first.ToString().empty());
     EXPECT_FALSE(ecu_serials_1[1].first.ToString().empty());
   }
@@ -113,9 +113,9 @@ TEST(Uptane, ReloadSerial) {
     UptaneTestCommon::addDefaultSecondary(conf, temp_dir, "", "secondary_hardware", false);
     auto uptane_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(conf, storage, http);
 
-    EXPECT_NO_THROW(uptane_client->initialize());
-    EXPECT_TRUE(storage->loadEcuSerials(&ecu_serials_2));
-    EXPECT_EQ(ecu_serials_2.size(), 2);
+    ASSERT_NO_THROW(uptane_client->initialize());
+    ASSERT_TRUE(storage->loadEcuSerials(&ecu_serials_2));
+    ASSERT_EQ(ecu_serials_2.size(), 2);
     EXPECT_FALSE(ecu_serials_2[0].first.ToString().empty());
     EXPECT_FALSE(ecu_serials_2[1].first.ToString().empty());
   }

--- a/src/libaktualizr/uptane/uptane_serial_test.cc
+++ b/src/libaktualizr/uptane/uptane_serial_test.cc
@@ -48,10 +48,10 @@ TEST(Uptane, RandomSerial) {
   auto http1 = std::make_shared<HttpFake>(temp_dir1.Path());
   auto http2 = std::make_shared<HttpFake>(temp_dir2.Path());
 
-  auto uptane_client1 = UptaneTestCommon::newTestClient(conf_1, storage_1, http1);
+  auto uptane_client1 = std_::make_unique<UptaneTestCommon::TestUptaneClient>(conf_1, storage_1, http1);
   EXPECT_NO_THROW(uptane_client1->initialize());
 
-  auto uptane_client2 = UptaneTestCommon::newTestClient(conf_2, storage_2, http2);
+  auto uptane_client2 = std_::make_unique<UptaneTestCommon::TestUptaneClient>(conf_2, storage_2, http2);
   EXPECT_NO_THROW(uptane_client2->initialize());
 
   // Verify that none of the serials match.
@@ -92,7 +92,7 @@ TEST(Uptane, ReloadSerial) {
     auto http = std::make_shared<HttpFake>(temp_dir.Path());
 
     UptaneTestCommon::addDefaultSecondary(conf, temp_dir, "", "secondary_hardware", false);
-    auto uptane_client = UptaneTestCommon::newTestClient(conf, storage, http);
+    auto uptane_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(conf, storage, http);
 
     EXPECT_NO_THROW(uptane_client->initialize());
     EXPECT_TRUE(storage->loadEcuSerials(&ecu_serials_1));
@@ -111,7 +111,7 @@ TEST(Uptane, ReloadSerial) {
     auto storage = INvStorage::newStorage(conf.storage);
     auto http = std::make_shared<HttpFake>(temp_dir.Path());
     UptaneTestCommon::addDefaultSecondary(conf, temp_dir, "", "secondary_hardware", false);
-    auto uptane_client = UptaneTestCommon::newTestClient(conf, storage, http);
+    auto uptane_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(conf, storage, http);
 
     EXPECT_NO_THROW(uptane_client->initialize());
     EXPECT_TRUE(storage->loadEcuSerials(&ecu_serials_2));

--- a/src/libaktualizr/uptane/uptane_test.cc
+++ b/src/libaktualizr/uptane/uptane_test.cc
@@ -145,7 +145,7 @@ TEST(Uptane, AssembleManifestGood) {
   UptaneTestCommon::addDefaultSecondary(config, temp_dir, "secondary_ecu_serial", "secondary_hardware");
 
   auto storage = INvStorage::newStorage(config.storage);
-  auto sota_client = UptaneTestCommon::newTestClient(config, storage, http);
+  auto sota_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage, http);
   EXPECT_NO_THROW(sota_client->initialize());
 
   Json::Value manifest = sota_client->AssembleManifest()["ecu_version_manifests"];
@@ -183,7 +183,7 @@ TEST(Uptane, AssembleManifestBad) {
   Utils::writeFile(ecu_config.full_client_dir / ecu_config.ecu_public_key, public_key);
 
   auto storage = INvStorage::newStorage(config.storage);
-  auto sota_client = UptaneTestCommon::newTestClient(config, storage, http);
+  auto sota_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage, http);
   EXPECT_NO_THROW(sota_client->initialize());
 
   Json::Value manifest = sota_client->AssembleManifest()["ecu_version_manifests"];
@@ -215,7 +215,7 @@ TEST(Uptane, PutManifest) {
 
   auto storage = INvStorage::newStorage(config.storage);
 
-  auto sota_client = UptaneTestCommon::newTestClient(config, storage, http);
+  auto sota_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage, http);
   EXPECT_NO_THROW(sota_client->initialize());
   EXPECT_TRUE(sota_client->putManifestSimple());
 
@@ -268,7 +268,8 @@ TEST(Uptane, PutManifestError) {
   std::function<void(std::shared_ptr<event::BaseEvent> event)> f_cb = process_events_PutManifestError;
   events_channel->connect(f_cb);
   num_events_PutManifestError = 0;
-  auto sota_client = UptaneTestCommon::newTestClient(conf, storage, http, events_channel);
+  auto sota_client =
+      std_::make_unique<UptaneTestCommon::TestUptaneClient>(conf, storage, http, nullptr, nullptr, events_channel);
   EXPECT_NO_THROW(sota_client->initialize());
   auto result = sota_client->putManifest();
   EXPECT_FALSE(result);
@@ -293,7 +294,7 @@ TEST(Uptane, FetchMetaFail) {
   conf.tls.server = http->tls_server;
 
   auto storage = INvStorage::newStorage(conf.storage);
-  auto up = UptaneTestCommon::newTestClient(conf, storage, http);
+  auto up = std_::make_unique<UptaneTestCommon::TestUptaneClient>(conf, storage, http);
 
   EXPECT_NO_THROW(up->initialize());
   result::UpdateCheck result = up->fetchMeta();
@@ -352,7 +353,8 @@ TEST(Uptane, InstallFakeGood) {
   auto events_channel = std::make_shared<event::Channel>();
   std::function<void(std::shared_ptr<event::BaseEvent> event)> f_cb = process_events_Install;
   events_channel->connect(f_cb);
-  auto up = UptaneTestCommon::newTestClient(conf, storage, http, events_channel);
+  auto up =
+      std_::make_unique<UptaneTestCommon::TestUptaneClient>(conf, storage, http, nullptr, nullptr, events_channel);
   EXPECT_NO_THROW(up->initialize());
 
   result::UpdateCheck update_result = up->fetchMeta();
@@ -414,7 +416,7 @@ TEST(Uptane, InstallFakeBad) {
 
   auto storage = INvStorage::newStorage(conf.storage);
   std::function<void(std::shared_ptr<event::BaseEvent> event)> f_cb = process_events_Install;
-  auto up = UptaneTestCommon::newTestClient(conf, storage, http, nullptr);
+  auto up = std_::make_unique<UptaneTestCommon::TestUptaneClient>(conf, storage, http);
   EXPECT_NO_THROW(up->initialize());
 
   result::UpdateCheck update_result = up->fetchMeta();
@@ -575,7 +577,7 @@ TEST(Uptane, SendMetadataToSeconadry) {
 
   auto sec = std::make_shared<SecondaryInterfaceMock>(ecu_config);
   auto storage = INvStorage::newStorage(conf.storage);
-  auto up = UptaneTestCommon::newTestClient(conf, storage, http);
+  auto up = std_::make_unique<UptaneTestCommon::TestUptaneClient>(conf, storage, http);
   up->addNewSecondary(sec);
   EXPECT_NO_THROW(up->initialize());
   result::UpdateCheck update_result = up->fetchMeta();
@@ -615,7 +617,7 @@ TEST(Uptane, UptaneSecondaryAdd) {
   UptaneTestCommon::addDefaultSecondary(config, temp_dir, "secondary_ecu_serial", "secondary_hardware");
 
   auto storage = INvStorage::newStorage(config.storage);
-  auto sota_client = UptaneTestCommon::newTestClient(config, storage, http);
+  auto sota_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage, http);
   EXPECT_NO_THROW(sota_client->initialize());
 
   /* Verify the correctness of the metadata sent to the server about the
@@ -643,7 +645,7 @@ TEST(Uptane, UptaneSecondaryAddSameSerial) {
   UptaneTestCommon::addDefaultSecondary(config, temp_dir, "secondary_ecu_serial", "secondary_hardware");
 
   auto storage = INvStorage::newStorage(config.storage);
-  auto sota_client = UptaneTestCommon::newTestClient(config, storage, http);
+  auto sota_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage, http);
   UptaneTestCommon::addDefaultSecondary(config, temp_dir, "secondary_ecu_serial", "secondary_hardware_new");
   EXPECT_THROW(sota_client->addNewSecondary(std::make_shared<Primary::VirtualSecondary>(
                    Primary::VirtualSecondaryConfig::create_from_file(config.uptane.secondary_config_file)[0])),
@@ -667,7 +669,7 @@ TEST(Uptane, UptaneSecondaryMisconfigured) {
     UptaneTestCommon::addDefaultSecondary(config, temp_dir, "secondary_ecu_serial", "secondary_hardware");
 
     auto storage = INvStorage::newStorage(config.storage);
-    auto sota_client = UptaneTestCommon::newTestClient(config, storage, http);
+    auto sota_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage, http);
     EXPECT_NO_THROW(sota_client->initialize());
 
     std::vector<MisconfiguredEcu> ecus;
@@ -682,7 +684,7 @@ TEST(Uptane, UptaneSecondaryMisconfigured) {
     config.storage.path = temp_dir.Path();
     auto storage = INvStorage::newStorage(config.storage);
     UptaneTestCommon::addDefaultSecondary(config, temp_dir, "new_secondary_ecu_serial", "new_secondary_hardware");
-    auto sota_client = UptaneTestCommon::newTestClient(config, storage, http);
+    auto sota_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage, http);
     EXPECT_NO_THROW(sota_client->initialize());
 
     std::vector<MisconfiguredEcu> ecus;
@@ -708,7 +710,7 @@ TEST(Uptane, UptaneSecondaryMisconfigured) {
     config.storage.path = temp_dir.Path();
     auto storage = INvStorage::newStorage(config.storage);
     UptaneTestCommon::addDefaultSecondary(config, temp_dir, "secondary_ecu_serial", "secondary_hardware");
-    auto sota_client = UptaneTestCommon::newTestClient(config, storage, http);
+    auto sota_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage, http);
     EXPECT_NO_THROW(sota_client->initialize());
 
     std::vector<MisconfiguredEcu> ecus;
@@ -917,7 +919,8 @@ TEST(Uptane, ProvisionOnServer) {
 
   auto storage = INvStorage::newStorage(config.storage);
   auto events_channel = std::make_shared<event::Channel>();
-  auto up = UptaneTestCommon::newTestClient(config, storage, http, events_channel);
+  auto up =
+      std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage, http, nullptr, nullptr, events_channel);
 
   EXPECT_EQ(http->devices_count, 0);
   EXPECT_EQ(http->ecus_count, 0);
@@ -1207,7 +1210,7 @@ TEST(Uptane, restoreVerify) {
   config.postUpdateValues();
 
   auto storage = INvStorage::newStorage(config.storage);
-  auto sota_client = UptaneTestCommon::newTestClient(config, storage, http);
+  auto sota_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage, http);
 
   EXPECT_NO_THROW(sota_client->initialize());
   sota_client->AssembleManifest();
@@ -1265,7 +1268,7 @@ TEST(Uptane, offlineIteration) {
   config.postUpdateValues();
 
   auto storage = INvStorage::newStorage(config.storage);
-  auto sota_client = UptaneTestCommon::newTestClient(config, storage, http);
+  auto sota_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage, http);
   EXPECT_NO_THROW(sota_client->initialize());
 
   std::vector<Uptane::Target> targets_online;
@@ -1294,7 +1297,7 @@ TEST(Uptane, IgnoreUnknownUpdate) {
   config.postUpdateValues();
 
   auto storage = INvStorage::newStorage(config.storage);
-  auto sota_client = UptaneTestCommon::newTestClient(config, storage, http);
+  auto sota_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage, http);
 
   EXPECT_NO_THROW(sota_client->initialize());
   auto result = sota_client->fetchMeta();

--- a/src/libaktualizr/uptane/uptane_test.cc
+++ b/src/libaktualizr/uptane/uptane_test.cc
@@ -269,7 +269,7 @@ TEST(Uptane, PutManifestError) {
   events_channel->connect(f_cb);
   num_events_PutManifestError = 0;
   auto sota_client =
-      std_::make_unique<UptaneTestCommon::TestUptaneClient>(conf, storage, http, nullptr, nullptr, events_channel);
+      std_::make_unique<UptaneTestCommon::TestUptaneClient>(conf, storage, http, nullptr, events_channel);
   EXPECT_NO_THROW(sota_client->initialize());
   auto result = sota_client->putManifest();
   EXPECT_FALSE(result);
@@ -353,8 +353,7 @@ TEST(Uptane, InstallFakeGood) {
   auto events_channel = std::make_shared<event::Channel>();
   std::function<void(std::shared_ptr<event::BaseEvent> event)> f_cb = process_events_Install;
   events_channel->connect(f_cb);
-  auto up =
-      std_::make_unique<UptaneTestCommon::TestUptaneClient>(conf, storage, http, nullptr, nullptr, events_channel);
+  auto up = std_::make_unique<UptaneTestCommon::TestUptaneClient>(conf, storage, http, nullptr, events_channel);
   EXPECT_NO_THROW(up->initialize());
 
   result::UpdateCheck update_result = up->fetchMeta();
@@ -919,8 +918,7 @@ TEST(Uptane, ProvisionOnServer) {
 
   auto storage = INvStorage::newStorage(config.storage);
   auto events_channel = std::make_shared<event::Channel>();
-  auto up =
-      std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage, http, nullptr, nullptr, events_channel);
+  auto up = std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage, http, nullptr, events_channel);
 
   EXPECT_EQ(http->devices_count, 0);
   EXPECT_EQ(http->ecus_count, 0);

--- a/src/libaktualizr/uptane/uptane_test.cc
+++ b/src/libaktualizr/uptane/uptane_test.cc
@@ -268,8 +268,7 @@ TEST(Uptane, PutManifestError) {
   std::function<void(std::shared_ptr<event::BaseEvent> event)> f_cb = process_events_PutManifestError;
   events_channel->connect(f_cb);
   num_events_PutManifestError = 0;
-  auto sota_client =
-      std_::make_unique<UptaneTestCommon::TestUptaneClient>(conf, storage, http, events_channel);
+  auto sota_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(conf, storage, http, events_channel);
   EXPECT_NO_THROW(sota_client->initialize());
   auto result = sota_client->putManifest();
   EXPECT_FALSE(result);

--- a/src/libaktualizr/uptane/uptane_test.cc
+++ b/src/libaktualizr/uptane/uptane_test.cc
@@ -269,7 +269,7 @@ TEST(Uptane, PutManifestError) {
   events_channel->connect(f_cb);
   num_events_PutManifestError = 0;
   auto sota_client =
-      std_::make_unique<UptaneTestCommon::TestUptaneClient>(conf, storage, http, nullptr, events_channel);
+      std_::make_unique<UptaneTestCommon::TestUptaneClient>(conf, storage, http, events_channel);
   EXPECT_NO_THROW(sota_client->initialize());
   auto result = sota_client->putManifest();
   EXPECT_FALSE(result);
@@ -353,7 +353,7 @@ TEST(Uptane, InstallFakeGood) {
   auto events_channel = std::make_shared<event::Channel>();
   std::function<void(std::shared_ptr<event::BaseEvent> event)> f_cb = process_events_Install;
   events_channel->connect(f_cb);
-  auto up = std_::make_unique<UptaneTestCommon::TestUptaneClient>(conf, storage, http, nullptr, events_channel);
+  auto up = std_::make_unique<UptaneTestCommon::TestUptaneClient>(conf, storage, http, events_channel);
   EXPECT_NO_THROW(up->initialize());
 
   result::UpdateCheck update_result = up->fetchMeta();
@@ -918,7 +918,7 @@ TEST(Uptane, ProvisionOnServer) {
 
   auto storage = INvStorage::newStorage(config.storage);
   auto events_channel = std::make_shared<event::Channel>();
-  auto up = std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage, http, nullptr, events_channel);
+  auto up = std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage, http, events_channel);
 
   EXPECT_EQ(http->devices_count, 0);
   EXPECT_EQ(http->ecus_count, 0);

--- a/tests/uptane_test_common.h
+++ b/tests/uptane_test_common.h
@@ -43,9 +43,8 @@ struct UptaneTestCommon {
     TestUptaneClient(Config &config_in,
                      std::shared_ptr<INvStorage> storage_in,
                      std::shared_ptr<HttpInterface> http_client = nullptr,
-                     std::shared_ptr<ReportQueue> report_queue_in = nullptr,
                      std::shared_ptr<event::Channel> events_channel_in = nullptr):
-      SotaUptaneClient(config_in, storage_in, http_client, report_queue_in, events_channel_in) {
+      SotaUptaneClient(config_in, storage_in, http_client, events_channel_in) {
 
       if (boost::filesystem::exists(config_in.uptane.secondary_config_file)) {
           for (const auto& item : Primary::VirtualSecondaryConfig::create_from_file(config_in.uptane.secondary_config_file)) {

--- a/tests/uptane_test_common.h
+++ b/tests/uptane_test_common.h
@@ -42,8 +42,8 @@ struct UptaneTestCommon {
    public:
     TestUptaneClient(Config &config_in,
                      std::shared_ptr<INvStorage> storage_in,
-                     std::shared_ptr<HttpInterface> http_client = nullptr,
-                     std::shared_ptr<event::Channel> events_channel_in = nullptr):
+                     std::shared_ptr<HttpInterface> http_client,
+                     std::shared_ptr<event::Channel> events_channel_in):
       SotaUptaneClient(config_in, storage_in, http_client, events_channel_in) {
 
       if (boost::filesystem::exists(config_in.uptane.secondary_config_file)) {
@@ -52,6 +52,13 @@ struct UptaneTestCommon {
           }
       }
     }
+
+    TestUptaneClient(Config &config_in,
+                     std::shared_ptr<INvStorage> storage_in,
+                     std::shared_ptr<HttpInterface> http_client) : TestUptaneClient(config_in, storage_in, http_client, nullptr) {}
+
+    TestUptaneClient(Config &config_in,
+                     std::shared_ptr<INvStorage> storage_in) : TestUptaneClient(config_in, storage_in, std::make_shared<HttpClient>()) {}
   };
 
   static Primary::VirtualSecondaryConfig addDefaultSecondary(Config& config, const TemporaryDirectory& temp_dir,

--- a/tests/uptane_test_common.h
+++ b/tests/uptane_test_common.h
@@ -43,10 +43,9 @@ struct UptaneTestCommon {
     TestUptaneClient(Config &config_in,
                      std::shared_ptr<INvStorage> storage_in,
                      std::shared_ptr<HttpInterface> http_client = nullptr,
-                     std::shared_ptr<Bootloader> bootloader_in = nullptr,
                      std::shared_ptr<ReportQueue> report_queue_in = nullptr,
                      std::shared_ptr<event::Channel> events_channel_in = nullptr):
-      SotaUptaneClient(config_in, storage_in, http_client, bootloader_in, report_queue_in, events_channel_in) {
+      SotaUptaneClient(config_in, storage_in, http_client, report_queue_in, events_channel_in) {
 
       if (boost::filesystem::exists(config_in.uptane.secondary_config_file)) {
           for (const auto& item : Primary::VirtualSecondaryConfig::create_from_file(config_in.uptane.secondary_config_file)) {

--- a/tests/uptane_test_common.h
+++ b/tests/uptane_test_common.h
@@ -16,16 +16,6 @@
 static const char* sec_public_key = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyjUeAzozBEccaGFAJ2Q3\n9QBfItH5i5O7yLRjZlKcEnWnFsxAWHUn5W/msRgZN/pXUrlax0wvrvMvHHLwZA2J\nz+UQApzSqj53HPVAcCH6kB9x0r9PM/0vVTKtmcrdSHj7jJ2yAW2T4Vo/eKlpvz3w\n9kTPAj0j1f5LvUgX5VIjUnsQK1LGzMwnleHk2dkWeWnt3OqomnO7V5C0jkDi58tG\nJ6fnyCYWcMUbpMaldXVXqmQ+iBkWxBjZ99+XJSRjdsskC7x8u8t+sA146VDB977r\nN8D+i+P1tAe810crciUqpYNenDYx47aAm6gaDWr7oeDzp3HyCjx4dZi9Z85rVE36\n8wIDAQAB\n-----END PUBLIC KEY-----\n";
 static const char* sec_private_key = "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAyjUeAzozBEccaGFAJ2Q39QBfItH5i5O7yLRjZlKcEnWnFsxA\nWHUn5W/msRgZN/pXUrlax0wvrvMvHHLwZA2Jz+UQApzSqj53HPVAcCH6kB9x0r9P\nM/0vVTKtmcrdSHj7jJ2yAW2T4Vo/eKlpvz3w9kTPAj0j1f5LvUgX5VIjUnsQK1LG\nzMwnleHk2dkWeWnt3OqomnO7V5C0jkDi58tGJ6fnyCYWcMUbpMaldXVXqmQ+iBkW\nxBjZ99+XJSRjdsskC7x8u8t+sA146VDB977rN8D+i+P1tAe810crciUqpYNenDYx\n47aAm6gaDWr7oeDzp3HyCjx4dZi9Z85rVE368wIDAQABAoIBAA0WlxS6Zab3O11+\nPfrOv9h5566HTNG+BD+ffXeYDUYcm24cVmXjX2u4bIQ1/RvkdlaCbN/NjKCUWQ5M\nWkb/oVX1i62/nNssI+WZ8kvPxzog7usnOucwkim/mAEGYoBYZF/brTPudc32W3lh\n7dhVGA24snWAo5ssVJax3eoYAPVLqFK5Pb8VUxpHtjERMDDUxM3w6WGXLxuBdA5s\n5vIdv+XrdiQhdPn1HMYEBBInkkYK8w4UytOCAS1/3xfVi2QwX5H9bHkduFpjLSQt\n2StWR9Kh4I80xXp7FwGpfkdUn+3qj5WwneuGY/JnD7AzjDlAThj0AE9iaYjkzXKJ\nVD4ULmECgYEA+UGQ1aglftFuTO427Xmi7tHhooo9U1pKMrg5CkCLkA+MudFzMEgj\npRtDdj8lTTWHEIYQXo5hhZfhk63j89RAKRz1MDFOvgknE8yJa9rSyCAEcwzRzXcY\n3WtWozEZ+5u4KYFHhGjJCSqVFdwyXmjP9ldb35Uxh06OuTbdNkSbiUsCgYEAz62t\nJ1EftTkd/YA/9Poq1deil5g0btPXnMJMj7C99dexNAXuVhS10Rz1Hi74wCFEbkcV\nGL/8U80pER9YYYeFUmqs1pYu7zwcYBT+iNrvFaPifid8FqlJEJ727swnWdpzXpwv\n/6q0h3JXU2odrEMNaGqiPycHQ/45EWMbCtpSs/kCgYEAwjMgWicA17bqvkuXRhzQ\nIkwqBU65ixi82JmJ73/sfNhwp1IV8hcylnAQdq+qK2a6Ddi2JkW+m6yDF2GTSiUj\nvCSQr/SqygsthBKHOx4pvbycWtsxF2lkWRdJUCpweQWRTd0o0HQntdmUgIyoPcBh\nzyevMBr4lNhTAOFLJv37RNMCgYAQq+ODjXqbJKuopvv7YX3Azt+phbln0C+10M8u\nlcSaEKeUAongdScnU0jGFIU5fzIsHB6wbvEFlSmfy0FgCu4D8LZRP5si71Njzyuj\ntteMiCxtbiQC+bH42JoAD3l1OBkc1jLwNjbpzJ7//jvFkVhpMm413Z8ysRzJrYgF\nNgN/mQKBgQDNT2nFoqanlQPkZekqNQNcVMHPyOWP40z4HC5JD1Z5F18Kg3El4EdS\nNfwaFGRT5qiFJBmmzl+6EFmUrrBNtV01zQ6rO+xgy2Y7qUQMNAUMjh1cCpWwUlN0\ng4aT/RawS5WpWN3+lEs4Ouxpgg4ZStXNZRJkSDHwZpkXtFfKzsEXaA==\n-----END RSA PRIVATE KEY-----\n";
 
-std::shared_ptr<SotaUptaneClient> newTestClient(Config &config_in,
-                                                                  std::shared_ptr<INvStorage> storage_in,
-                                                                  std::shared_ptr<HttpInterface> http_client_in,
-                                                                  std::shared_ptr<event::Channel> events_channel_in = nullptr) {
-  std::shared_ptr<Bootloader> bootloader_in = std::make_shared<Bootloader>(config_in.bootloader, *storage_in);
-  std::shared_ptr<ReportQueue> report_queue_in = std::make_shared<ReportQueue>(config_in, http_client_in);
-  return std::make_shared<SotaUptaneClient>(config_in, storage_in, http_client_in, bootloader_in,
-                                                               report_queue_in, events_channel_in);
-}
-
 struct UptaneTestCommon {
 
   class TestAktualizr: public Aktualizr {
@@ -52,9 +42,9 @@ struct UptaneTestCommon {
    public:
     TestUptaneClient(Config &config_in,
                      std::shared_ptr<INvStorage> storage_in,
-                     std::shared_ptr<HttpInterface> http_client,
-                     std::shared_ptr<Bootloader> bootloader_in,
-                     std::shared_ptr<ReportQueue> report_queue_in,
+                     std::shared_ptr<HttpInterface> http_client = nullptr,
+                     std::shared_ptr<Bootloader> bootloader_in = nullptr,
+                     std::shared_ptr<ReportQueue> report_queue_in = nullptr,
                      std::shared_ptr<event::Channel> events_channel_in = nullptr):
       SotaUptaneClient(config_in, storage_in, http_client, bootloader_in, report_queue_in, events_channel_in) {
 
@@ -65,18 +55,6 @@ struct UptaneTestCommon {
       }
     }
   };
-
-  static std::shared_ptr<SotaUptaneClient> newTestClient(Config &config_in,
-                                                         std::shared_ptr<INvStorage> storage_in,
-                                                         std::shared_ptr<HttpInterface> http_client_in,
-                                                         std::shared_ptr<event::Channel> events_channel_in = nullptr) {
-
-    std::shared_ptr<Bootloader> bootloader_in = std::make_shared<Bootloader>(config_in.bootloader, *storage_in);
-    std::shared_ptr<ReportQueue> report_queue_in = std::make_shared<ReportQueue>(config_in, http_client_in);
-
-    return std::make_shared<TestUptaneClient>(config_in, storage_in, http_client_in, bootloader_in,
-                                              report_queue_in, events_channel_in);
-  }
 
   static Primary::VirtualSecondaryConfig addDefaultSecondary(Config& config, const TemporaryDirectory& temp_dir,
                                                              const std::string& serial, const std::string& hw_id,

--- a/tests/uptane_vector_tests.cc
+++ b/tests/uptane_vector_tests.cc
@@ -97,7 +97,7 @@ TEST_P(UptaneVector, Test) {
 
   auto storage = INvStorage::newStorage(config.storage);
   Uptane::Manifest uptane_manifest{config, storage};
-  auto uptane_client = SotaUptaneClient::newDefaultClient(config, storage);
+  auto uptane_client = std_::make_unique<SotaUptaneClient>(config, storage);
   Uptane::EcuSerial ecu_serial(config.provision.primary_ecu_serial);
   Uptane::HardwareIdentifier hw_id(config.provision.primary_ecu_hardware_id);
   uptane_client->hw_ids.insert(std::make_pair(ecu_serial, hw_id));


### PR DESCRIPTION
While looking into the exception handling in ctors and dtors, I did some refactorings in hope that they will simplify the task.
Main ideas are to bring object initialization and ownership closer to the place they are being used, specifically `Bootloader` to `PackageManager` and `ReportQueue` to `SotaUptaneClient`, as well as to make object creation more transparent and to reduce code duplication.