### PR TITLE
OTA-2743: Aktualizr test in case of ostree update with failures

### DIFF
--- a/src/libaktualizr/primary/CMakeLists.txt
+++ b/src/libaktualizr/primary/CMakeLists.txt
@@ -23,10 +23,7 @@ target_link_libraries(t_aktualizr virtual_secondary)
 if (BUILD_OSTREE)
     add_aktualizr_test(NAME aktualizr_fullostree SOURCES aktualizr_fullostree_test.cc PROJECT_WORKING_DIRECTORY ARGS $<TARGET_FILE:uptane-generator> ${PROJECT_BINARY_DIR}/ostree_repo)
     set_target_properties(t_aktualizr_fullostree PROPERTIES LINK_FLAGS -Wl,--export-dynamic)
-    add_dependencies(t_aktualizr_fullostree ostree_mock uptane-generator make_ostree_sysroot)
-    set_tests_properties(test_aktualizr_fullostree PROPERTIES
-        ENVIRONMENT LD_PRELOAD=$<TARGET_FILE:ostree_mock>
-        LABELS "noptest")
+    add_dependencies(t_aktualizr_fullostree uptane-generator make_ostree_sysroot)
     target_link_libraries(t_aktualizr_fullostree virtual_secondary)
     add_aktualizr_test(NAME download_nonostree SOURCES  download_nonostree_test.cc PROJECT_WORKING_DIRECTORY ARGS $<TARGET_FILE:uptane-generator> ${PROJECT_BINARY_DIR}/ostree_repo)
     add_dependencies(t_download_nonostree uptane-generator make_ostree_sysroot)

--- a/src/libaktualizr/primary/aktualizr_fullostree_test.cc
+++ b/src/libaktualizr/primary/aktualizr_fullostree_test.cc
@@ -28,7 +28,7 @@ static struct {
 static std::string new_rev;
 
 #include <ostree.h>
-extern "C" OstreeDeployment *ostree_sysroot_get_booted_deployment_mock(OstreeSysroot *self) {
+extern "C" OstreeDeployment *ostree_sysroot_get_booted_deployment(OstreeSysroot *self) {
   (void)self;
   static GObjectUniquePtr<OstreeDeployment> dep;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,10 +56,10 @@ add_library(testutilities test_utils.cc)
 list(APPEND TEST_LIBS testutilities)
 
 if(BUILD_OSTREE)
-add_library(ostree_mock SHARED ostree_mock.c)
-aktualizr_source_file_checks(ostree_mock.c)
-target_include_directories(ostree_mock PUBLIC ${LIBOSTREE_INCLUDE_DIRS})
-add_dependencies(build_tests ostree_mock)
+    add_library(ostree_mock SHARED ostree_mock.c)
+    aktualizr_source_file_checks(ostree_mock.c)
+    target_include_directories(ostree_mock PUBLIC ${LIBOSTREE_INCLUDE_DIRS})
+    add_dependencies(build_tests ostree_mock)
 endif(BUILD_OSTREE)
 
 # Setup coverage
@@ -194,7 +194,7 @@ add_test(NAME test_ip_secondary
 
 add_test(NAME test_backend_failure
          COMMAND ${PROJECT_SOURCE_DIR}/tests/test_backend_failure.py
-         --build-dir ${PROJECT_BINARY_DIR} --src-dir ${PROJECT_SOURCE_DIR})
+         --build-dir ${PROJECT_BINARY_DIR} --src-dir ${PROJECT_SOURCE_DIR} --ostree ${BUILD_OSTREE})
 
 add_executable(aktualizr-cycle-simple aktualizr_cycle_simple.cc)
 target_link_libraries(aktualizr-cycle-simple aktualizr_static_lib ${AKTUALIZR_EXTERNAL_LIBS})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,8 +55,12 @@ include(CMakeParseArguments)
 add_library(testutilities test_utils.cc)
 list(APPEND TEST_LIBS testutilities)
 
+if(BUILD_OSTREE)
 add_library(ostree_mock SHARED ostree_mock.c)
 aktualizr_source_file_checks(ostree_mock.c)
+target_include_directories(ostree_mock PUBLIC ${LIBOSTREE_INCLUDE_DIRS})
+add_dependencies(build_tests ostree_mock)
+endif(BUILD_OSTREE)
 
 # Setup coverage
 if(BUILD_WITH_CODE_COVERAGE)

--- a/tests/ostree_mock.c
+++ b/tests/ostree_mock.c
@@ -40,7 +40,6 @@ OstreeDeployment* ostree_sysroot_get_booted_deployment(OstreeSysroot* self) {
 
   if (deployment_version_file != NULL &&
       (deployment_from_file = ostree_sysroot_get_booted_deployment_from_file(deployment_version_file)) != NULL) {
-    printf("%s: Reading ostree deployment info from %s", __FILE__, deployment_version_file);
     return deployment_from_file;
   }
 
@@ -56,7 +55,7 @@ static int read_deployment_info(FILE* file, struct OstreeDeployment* deployment)
   struct OstreeDeployment deployment_res;
 
   // TODO: make it more robust and reliable as a file might contain a value exceeding 255
-  if (fscanf(file, "%s\n", deployment_res.rev) != 1) {
+  if (fscanf(file, "%254s\n", deployment_res.rev) != 1) {
     return -1;
   }
 
@@ -72,7 +71,6 @@ static int read_deployment_info(FILE* file, struct OstreeDeployment* deployment)
 
 static int get_ostree_deployment_info(const char* filename, struct OstreeDeployment* deployed,
                                       struct OstreeDeployment* booted) {
-  printf("\n>>>>>>>>>> Reading the file: %s\n\n", filename);
   FILE* file = fopen(filename, "r");
   if (file == NULL) {
     printf("\n>>>>>>>>>> Failed to open the file: %s\n\n", filename);
@@ -81,7 +79,7 @@ static int get_ostree_deployment_info(const char* filename, struct OstreeDeploym
 
   int return_code = -1;
 
-  while (1) {
+  do {
     struct OstreeDeployment deployed_res;
     if (read_deployment_info(file, &deployed_res) != 0) {
       break;
@@ -97,8 +95,7 @@ static int get_ostree_deployment_info(const char* filename, struct OstreeDeploym
 
     *deployed = deployed_res;
     return_code = 0;
-    break;
-  }
+  } while (0);
 
   fclose(file);
   if (return_code != 0) {

--- a/tests/ostree_mock.c
+++ b/tests/ostree_mock.c
@@ -3,26 +3,137 @@
 #include <ostree.h>
 #include <stdio.h>
 
-OstreeDeployment* ostree_sysroot_get_booted_deployment(OstreeSysroot* self) {
-  OstreeDeployment* (*orig)(OstreeSysroot*) = dlsym(RTLD_NEXT, __func__);
-  char mocked_name[100];
-  snprintf(mocked_name, sizeof(mocked_name), "%s_mock", __func__);
-  OstreeDeployment* (*mocked)(OstreeSysroot*) = dlsym(RTLD_DEFAULT, mocked_name);
+/**
+ * @brief This mock allows the ostree package manager usage on non-ostree booted environment, e.g. local host
+ *
+ * in order to use it the following has to be pre-defined
+ * 1) OSTREE_DEPLOYMENT_VERSION_FILE environment variable that points to the test file containing a revision
+ * hash/checksum and its serial number 2) LD_PRELOAD environment variable that refers to the libostree_mock.so 3)
+ * [pacman].os == OSTREE_DEPLOYMENT_OS_NAME (aktualizr configuration, pacman section, os field must be equal to
+ * OSTREE_DEPLOYMENT_OS_NAME defined here)
+ *
+ * OSTREE_DEPLOYMENT_VERSION_FILE must follow this schema/format
+ *
+ * <deployed-revision-hash>\n
+ * <deployed-revision-serial>\n
+ * <booted-revision-hash>\n
+ * <booted-revision-serial>
+ *
+ * For example
+ *
+ *  d0ef921904bc573616a42e862de2421b265a76d06a334cfe5ad9f811107bbee0
+ *  0
+ *  d0ef921904bc573616a42e862de2421b265a76d06a334cfe5ad9f811107bbee0
+ *  0
+ */
 
-  if (mocked) {
-    return mocked(self);
+static const char OSTREE_DEPLOYMENT_OS_NAME[] = "dummy-os";
+static const char OSTREE_DEPLOYMENT_VERSION_FILE[] = "OSTREE_DEPLOYMENT_VERSION_FILE";
+
+static OstreeDeployment* ostree_sysroot_get_booted_deployment_from_file(const char* filename);
+
+OstreeDeployment* ostree_sysroot_get_booted_deployment(OstreeSysroot* self) {
+  OstreeDeployment* (*orig)(OstreeSysroot*) = (OstreeDeployment * (*)(OstreeSysroot*))(dlsym(RTLD_NEXT, __func__));
+
+  const char* deployment_version_file = getenv(OSTREE_DEPLOYMENT_VERSION_FILE);
+  OstreeDeployment* deployment_from_file = NULL;
+
+  if (deployment_version_file != NULL &&
+      (deployment_from_file = ostree_sysroot_get_booted_deployment_from_file(deployment_version_file)) != NULL) {
+    printf("%s: Reading ostree deployment info from %s", __FILE__, deployment_version_file);
+    return deployment_from_file;
   }
+
   return orig(self);
 }
 
-const char* ostree_deployment_get_bootcsum(OstreeDeployment* self) {
-  char* (*orig)(OstreeDeployment*) = dlsym(RTLD_NEXT, __func__);
-  char mocked_name[100];
-  snprintf(mocked_name, sizeof(mocked_name), "%s_mock", __func__);
-  char* (*mocked)(OstreeDeployment*) = dlsym(RTLD_DEFAULT, mocked_name);
+struct OstreeDeployment {
+  int serial;
+  char rev[255];
+};
 
-  if (mocked) {
-    return mocked(self);
+static int read_deployment_info(FILE* file, struct OstreeDeployment* deployment) {
+  struct OstreeDeployment deployment_res;
+
+  // TODO: make it more robust and reliable as a file might contain a value exceeding 255
+  if (fscanf(file, "%s\n", deployment_res.rev) != 1) {
+    return -1;
   }
+
+  // TODO: make it more robust and reliable as a file might contain a value exceeding 255 and/or char(s) instead of a
+  // number for the serial value
+  if (fscanf(file, "%d\n", &deployment_res.serial) != 1) {
+    return -1;
+  }
+
+  *deployment = deployment_res;
+  return 0;
+}
+
+static int get_ostree_deployment_info(const char* filename, struct OstreeDeployment* deployed,
+                                      struct OstreeDeployment* booted) {
+  printf("\n>>>>>>>>>> Reading the file: %s\n\n", filename);
+  FILE* file = fopen(filename, "r");
+  if (file == NULL) {
+    printf("\n>>>>>>>>>> Failed to open the file: %s\n\n", filename);
+    return -1;
+  }
+
+  int return_code = -1;
+
+  while (1) {
+    struct OstreeDeployment deployed_res;
+    if (read_deployment_info(file, &deployed_res) != 0) {
+      break;
+    }
+
+    if (booted != NULL) {
+      struct OstreeDeployment booted_res;
+      if (read_deployment_info(file, &booted_res) != 0) {
+        break;
+      }
+      *booted = booted_res;
+    }
+
+    *deployed = deployed_res;
+    return_code = 0;
+    break;
+  }
+
+  fclose(file);
+  if (return_code != 0) {
+    printf("%s: Failed to read the deployment info from: %s\n", __FILE__, filename);
+  }
+  return return_code;
+}
+
+static struct OstreeDeployment g_deployed;
+
+const char* ostree_deployment_get_csum(OstreeDeployment* self) {
+  const char* (*orig)(OstreeDeployment*) = (const char* (*)(OstreeDeployment*))(dlsym(RTLD_NEXT, __func__));
+
+  const char* deployment_version_file = NULL;
+
+  if ((deployment_version_file = getenv(OSTREE_DEPLOYMENT_VERSION_FILE)) != NULL) {
+    if (get_ostree_deployment_info(deployment_version_file, &g_deployed, NULL) != 0) {
+      return NULL;
+    }
+
+    return g_deployed.rev;
+  }
+
   return orig(self);
+}
+
+OstreeDeployment* ostree_sysroot_get_booted_deployment_from_file(const char* filename) {
+  struct OstreeDeployment deployed;
+  struct OstreeDeployment booted;
+
+  if (get_ostree_deployment_info(filename, &deployed, &booted) != 0) {
+    return NULL;
+  }
+
+  OstreeDeployment* new_depl =
+      ostree_deployment_new(0, OSTREE_DEPLOYMENT_OS_NAME, deployed.rev, deployed.serial, booted.rev, booted.serial);
+  return new_depl;
 }

--- a/tests/test_backend_failure.py
+++ b/tests/test_backend_failure.py
@@ -8,7 +8,7 @@ from os import getcwd, chdir
 from test_fixtures import with_aktualizr, with_uptane_backend, KeyStore, with_secondary, with_path,\
     DownloadInterruptionHandler, MalformedJsonHandler, with_director, with_imagerepo, InstallManager,\
     with_install_manager, with_images, MalformedImageHandler, with_customrepo, SlowRetrievalHandler, \
-    RedirectHandler
+    RedirectHandler, with_sysroot, with_treehub
 
 
 logger = logging.getLogger(__file__)
@@ -139,6 +139,55 @@ def test_backend_failure_sanity_customrepo_update_after_image_download_failure(i
 
 
 """
+    Verifies whether aktualizr is updatable after failure of object(s) download from Treehub/ostree repo
+    with follow-up successful download.
+
+    Currently, it's tested against two types of object download failure:
+    - download interruption - object download is interrupted once, after that it's successful
+    - malformed object - object download is successful but it's malformed. It happens once after that it's successful
+"""
+@with_uptane_backend(start_generic_server=True, port=8888)
+@with_director()
+@with_treehub(handlers=[
+                        DownloadInterruptionHandler(url='/objects/41/5ce9717fc7a5f4d743a4f911e11bd3ed83930e46756303fd13a3eb7ed35892.filez'),
+                        MalformedImageHandler(url='/objects/41/5ce9717fc7a5f4d743a4f911e11bd3ed83930e46756303fd13a3eb7ed35892.filez'),
+
+                        # TODO: ostree objects download is not resilient to `Slow Retrieval Attack`
+                        # https://saeljira.it.here.com/browse/OTA-3737
+                        #SlowRetrievalHandler(url='/objects/6b/1604b586fcbe052bbc0bd9e1c8040f62e085ca2e228f37df957ac939dff361.filez'),
+
+                        # TODO: Limit a number of HTTP redirects within a single request processing
+                        # https://saeljira.it.here.com/browse/OTA-3729
+                        #RedirectHandler(number_of_redirects=1000, url='/objects/41/5ce9717fc7a5f4d743a4f911e11bd3ed83930e46756303fd13a3eb7ed35892.filez')
+])
+@with_sysroot()
+@with_aktualizr(start=False, run_mode='once')
+def test_backend_failure_sanity_treehub_update_after_image_download_failure(uptane_repo,
+                                                                            aktualizr,
+                                                                            director,
+                                                                            uptane_server,
+                                                                            sysroot, treehub):
+    target_rev = treehub.revision
+    uptane_repo.add_ostree_target(aktualizr.id, target_rev)
+    with aktualizr:
+        aktualizr.wait_for_completion()
+
+    pending_rev = aktualizr.get_primary_pending_version()
+    if pending_rev != target_rev:
+        logger.error("Pending version {} != the target one {}".format(pending_rev, target_rev))
+        return False
+
+    sysroot.update_revision(pending_rev)
+    aktualizr.emulate_reboot()
+
+    with aktualizr:
+        aktualizr.wait_for_completion()
+
+    result = director.get_install_result() and (target_rev == aktualizr.get_current_primary_image_info())
+    return result
+
+
+"""
     Verifies if aktualizr supports redirects - update is successful after redirect
     Note: should aktualizr support unlimited number of redirects
 """
@@ -214,6 +263,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Test backend failure')
     parser.add_argument('-b', '--build-dir', help='build directory', default='build')
     parser.add_argument('-s', '--src-dir', help='source directory', default='.')
+    parser.add_argument('-o', '--ostree', help='ostree support', default='OFF')
     input_params = parser.parse_args()
 
     KeyStore.base_dir = input_params.src_dir
@@ -221,6 +271,7 @@ if __name__ == "__main__":
     chdir(input_params.build_dir)
 
     test_suite = [
+                    test_backend_failure_sanity_treehub_update_after_image_download_failure,
                     test_backend_failure_sanity_director_update_after_metadata_download_failure,
                     test_backend_failure_sanity_imagerepo_update_after_metadata_download_failure,
                     test_backend_failure_sanity_imagerepo_update_after_image_download_failure,
@@ -229,6 +280,9 @@ if __name__ == "__main__":
                     test_backend_failure_sanity_imagerepo_unsuccessful_download,
                     test_backend_failure_sanity_customrepo_update_redirect,
     ]
+
+    if input_params.ostree == 'ON':
+        test_suite.append(test_backend_failure_sanity_treehub_update_after_image_download_failure)
 
     test_suite_run_result = True
     for test in test_suite:


### PR DESCRIPTION
- free aktualizr_fullostree_test from the ostree_mock library and its preload
- make the ostree_mock universal so it can be used by any test, not just C/C++ written, e.g. by python-based integration tests like test_backend_failure.
- test aktualizr if failures happens during ostree objects download from Treehub in case of ostree updates.



Signed-off-by: Mykhaylo Sul <ext-mykhaylo.sul@here.com>