### PR TITLE
Fix asciidoc syntax issues to clean up warnings (2019.7)

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/pages/build-configuration.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-configuration.adoc
@@ -14,16 +14,16 @@ endif::[]
 [cols="1,2a",options="header"]
 |====================
 | Option | Description
-| `OSTREE_BRANCHNAME`|OSTree branch name. Defaults to `${SOTA_HARDWARE_ID}`. Particularly useful for grouping similar images.
+| `OSTREE_BRANCHNAME`|OSTree branch name. Defaults to `$\{SOTA_HARDWARE_ID}`. Particularly useful for grouping similar images.
 | `OSTREE_REPO`|Path to your OSTree repository. Defaults to `$\{DEPLOY_DIR_IMAGE}/ostree_repo`
 | `OSTREE_OSNAME`|OS deployment name on your target device. For more information about deployments and osnames see the https://ostree.readthedocs.io/en/latest/manual/deployment/[OSTree documentation]. Defaults to "poky".
 | `OSTREE_COMMIT_BODY`|Message attached to OSTree commit. Empty by default.
-| `OSTREE_COMMIT_SUBJECT`|Commit subject used by OSTree. Defaults to `Commit-id: ${IMAGE_NAME}`
+| `OSTREE_COMMIT_SUBJECT`|Commit subject used by OSTree. Defaults to `Commit-id: $\{IMAGE_NAME}`
 | `OSTREE_UPDATE_SUMMARY`|Set this to '1' to update summary of OSTree repository on each commit. '0' by default.
 | `OSTREE_DEPLOY_DEVICETREE`|Set this to '1' to include devicetree(s) to boot
 | `GARAGE_SIGN_AUTOVERSION`|Set this to '1' to automatically fetch the last version of the garage tools installed by the aktualizr-native. Otherwise use the fixed version specified in the recipe.
 | `GARAGE_TARGET_URL` | Sets the `--url` parameter of `garage-sign targets add`, which sets a custom URL for the Image repository targets.
-| `GARAGE_TARGET_EXPIRES` | 
+| `GARAGE_TARGET_EXPIRES` |
 // MC: This block shows reusable content snippets when the content is rendered in the docs portal.
 // We reuse the same descriptions in multiple places with includes - if rendered in Github (where includes aren't allowed), we fall back to the old descriptions.
 ifdef::env-github[Sets the `--expires` parameter of `garage-sign targets sign`. Format is a UTC instant such as '2018-01-01T00:01:00Z'.]

--- a/docs/ota-client-guide/modules/ROOT/pages/enable-device-cred-provisioning.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/enable-device-cred-provisioning.adoc
@@ -1,4 +1,4 @@
-= Enable device-credential provisioning and install device certificates 
+= Enable device-credential provisioning and install device certificates
 ifdef::env-github[]
 
 [NOTE]
@@ -12,7 +12,7 @@ endif::[]
 
 Once you're ready to provision devices in production, you need to build disk images that are configured to use device-credential provisioning.
 
-After you have flashed those images to devices, you boot the image and install the device certicate for each device. 
+After you have flashed those images to devices, you boot the image and install the device certicate for each device.
 
 How you get the certificate on the device is up to you:
 
@@ -21,7 +21,7 @@ How you get the certificate on the device is up to you:
 You woud then sign the certificate with your fleet root key.
 +
 ** We don't have documentation on how to do this, since the method is different for each HSM model.
-* You can also generate the device certificates and private keys on your development computer and copy them over to the device. 
+* You can also generate the device certificates and private keys on your development computer and copy them over to the device.
 ** For these instructions, we'll assume you are using this latter method.
 
 == HSM considerations
@@ -55,9 +55,9 @@ IMAGE_INSTALL_append = " softhsm-testtoken dropbear "
 +
 [NOTE]
 ====
-The line `IMAGE_INSTALL_append` installs optional software to your device. 
+The line `IMAGE_INSTALL_append` installs optional software to your device.
 
-* The option `dropbear` installs the link:https://matt.ucc.asn.au/dropbear/dropbear.html[Dropbear] ssh server. 
+* The option `dropbear` installs the link:https://matt.ucc.asn.au/dropbear/dropbear.html[Dropbear] ssh server.
 +
 You'll need to ssh into the device to copy the certificates to the device's filesystem.
 * The option `softhsm-testtoken` installs SoftHSM to so that you can easily test HSM interactions.
@@ -78,9 +78,9 @@ scp -P 2222 autoprov.url root@localhost:/var/sota/import/gateway.url
 ====
 You might remember that `credentials.zip` contains a provisioning key shared-credential provisioning. In this case we just need the `autoprov.url` file inside `credentials.zip`. This file contains the URL of your device gateway which is specific to your account.
 ====
-. Copy the device credentials and device gateway root CA certificate to the device. 
+. Copy the device credentials and device gateway root CA certificate to the device.
 +
-[source,sh,subs="attributes"]
+[source,sh]
 ----
 export device_dir=path/to/device-creds/dir
 scp -P 2222 -pr ${device_dir} root@localhost:/var/sota/import

--- a/docs/ota-client-guide/modules/ROOT/pages/enable-device-cred-provtest.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/enable-device-cred-provtest.adoc
@@ -1,4 +1,4 @@
-= Enable device-credential provisioning and install device certificates 
+= Enable device-credential provisioning and install device certificates
 ifdef::env-github[]
 
 [NOTE]
@@ -47,9 +47,9 @@ scp -P 2222 autoprov.url root@localhost:/var/sota/import/gateway.url
 ====
 You might remember that `credentials.zip` contains a provisioning key shared-credential provisioning. In this case we just need the `autoprov.url` file inside `credentials.zip`. This file contains the URL of your device gateway which is specific to your account.
 ====
-. Copy the device credentials and device gateway root CA certificate to the device. 
+. Copy the device credentials and device gateway root CA certificate to the device.
 +
-[source,sh,subs="attributes"]
+[source,sh]
 ----
 export device_dir=path/to/device/dir
 scp -P 2222 -pr ${device_dir} root@localhost:/var/sota/import
@@ -75,7 +75,7 @@ Once the certificates have copied, the following chain of events should occur:
 
 As described in the xref:index.adoc[introduction], it's a good idea to use a Hardware Security Model (HSM) to hold potentially sensitive device credentials.
 
-The following procedure describes how to use QEMU and link:https://www.opendnssec.org/softhsm/[SoftHSM] to simulate a device with an HSM. 
+The following procedure describes how to use QEMU and link:https://www.opendnssec.org/softhsm/[SoftHSM] to simulate a device with an HSM.
 
 However, the procedure for your HSM will probably be different. We've provided these instructions as a basic guide to how this provisioning method works but you'll need to make further changes on your own. For example, you'll probably need to adapt your BSP so that aktualizr can access the keys from your HSM.
 
@@ -92,7 +92,7 @@ IMAGE_INSTALL_append = " softhsm-testtoken dropbear "
 +
 [NOTE]
 ====
-The line `IMAGE_INSTALL_append = " softhsm-testtoken dropbear "` ensures that softhsm and an ssh server are installed on the image. You'll need to ssh into the device to copy the certificates to the hsm. 
+The line `IMAGE_INSTALL_append = " softhsm-testtoken dropbear "` ensures that softhsm and an ssh server are installed on the image. You'll need to ssh into the device to copy the certificates to the hsm.
 ====
 . Build a standard image using bitbake.
 . Boot the image.
@@ -108,9 +108,9 @@ scp -P 2222 autoprov.url root@localhost:/var/sota/import/gateway.url
 ====
 You might remember that `credentials.zip` contains a provisioning key shared-credential provisioning. In this case we just need the `autoprov.url` file inside `credentials.zip`. This file contains the URL of your device gateway which is specific to your account.
 ====
-. Copy the device credentials and device gateway root CA certificate to the device's HSM. 
+. Copy the device credentials and device gateway root CA certificate to the device's HSM.
 +
-[source,sh,subs="attributes"]
+[source,sh]
 ----
 export device_dir=path/to/device/dir
 scp -P 2222 -pr ${device_dir} root@localhost:/var/sota/import

--- a/docs/ota-client-guide/modules/ROOT/pages/generate-devicecert.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/generate-devicecert.adoc
@@ -8,7 +8,7 @@ We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}
 endif::[]
 
 
-Once you have your final fleet root certificate, you can use it to generate and sign device certificates. You can then automate the process of installing device certificates on your devices. 
+Once you have your final fleet root certificate, you can use it to generate and sign device certificates. You can then automate the process of installing device certificates on your devices.
 
 We can't tell you exactly how to automate this process, but heres a recap of the steps involved.
 
@@ -56,16 +56,16 @@ You should see a URL that resembles the following example:
 . Get the device gateway's root certificate with the following openssl command:
 +
 ----
-export device_gateway=<your-gateway-url> 
+export device_gateway=<your-gateway-url>
 openssl s_client -connect ${device_gateway}:8000 -servername $device_gateway -showcerts | \
   sed -n '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > ${device_dir}/root.crt
 ----
 +
 Replace, the placeholder `<your-gateway-url>` with URL that you noted in the previous step.
 +
-. Make a note where the actual `$(device_dir)` is on your computer.
+. Make a note where the actual `$\{device_dir}` is on your computer.
 +
-You can quickly get it with the command `echo $(device_dir)`. Your device directory should resemble the following example:
+You can quickly get it with the command `echo $\{device_dir}`. Your device directory should resemble the following example:
 +
 `myservername/devices/4e7cdc4f-b7dc-4fb0-900f-a237ba3e804c/`
 . Once have noted your device directory, you can xref:enable-device-cred-provisioning.adoc[install the device certificate on the device].

--- a/docs/ota-client-guide/modules/ROOT/pages/generate-selfsigned-root.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/generate-selfsigned-root.adoc
@@ -34,5 +34,5 @@ Then, generate the key and cert using openssl on the command line:
 include::example$start.sh[tags="genserverkeys"]
 ----
 +
-This will create a `./${SERVER_DIR}/devices/` directory with the `ca.crt` certificate and a `ca.key` private key. Keep the private key safe and secure.
-. Next, xref:provide-testroot-cert.adoc[register the test root certificate with your OTA Connect account]. 
+This will create a `./$\{SERVER_DIR}/devices/` directory with the `ca.crt` certificate and a `ca.key` private key. Keep the private key safe and secure.
+. Next, xref:provide-testroot-cert.adoc[register the test root certificate with your OTA Connect account].

--- a/docs/ota-client-guide/modules/ROOT/pages/libaktualizr-getstarted.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/libaktualizr-getstarted.adoc
@@ -48,7 +48,7 @@ make
 
 NOTE: The `--recursive` flag in the `git clone` command is needed to recursively clone all the *git submodules*.
 
-After the build is finished, you'll find the client library at the following location: `${PROJECT_ROOT}/build/src/libaktualizr/libaktualizr_static_lib.a`.
+After the build is finished, you'll find the client library at the following location: `$\{PROJECT_ROOT}/build/src/libaktualizr/libaktualizr_static_lib.a`.
 
 == Integrating libaktualizr into your application
 

--- a/docs/ota-client-guide/modules/ROOT/pages/libaktualizr-why-use.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/libaktualizr-why-use.adoc
@@ -14,12 +14,12 @@ This topic is supposed to outline the main use cases the product aims to address
 For libaktualizr We already have this topic: https://docs.atsgarage.com/client-config/advanced-update-control-with-libaktualizr.html
 The following text was taken from the linked topic and is a proposal for the introcdution to the integration guide.
 
-Feel free to adapt it or leave as-is. 
+Feel free to adapt it or leave as-is.
 ////
 
 The OTA Connect client (aktualizr) is designed to be run as a standalone component on an embedded system and can manage the entire software update process. However, most automotive production use cases will have requirements that go beyond what the standalone client can provide. For example, some in-vehicle interfaces are proprietary and under NDA, so their implementation must be kept separate from aktualizr.
 
-= Why use libaktualizr?
+== Why use libaktualizr?
 
 You can integrate the OTA update functionality yourself and minimize the involvement of external consultants. For this purpose, you can use libaktualizr to build your own OTA update solution.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/meta-updater-dev-config.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/meta-updater-dev-config.adoc
@@ -49,6 +49,6 @@ You can override the version of aktualizr included in your image. This requires 
 Every time you build an image with `SOTA_PACKED_CREDENTIALS` set, a new entry in your Uptane metadata is created and you can see it in the OTA Garage UI if you're using one. Normally this version will be equal to OSTree hash of your root file system. If you want it to be different though you can override is using one of two methods:
 
 1. Set `GARAGE_TARGET_VERSION` variable in your `local.conf`.
-2. Write a recipe or a bbclass to write the desired version to `${STAGING_DATADIR_NATIVE}/target_version`. An example of such bbclass can be found in `classes/target_version_example.bbclass`.
+2. Write a recipe or a bbclass to write the desired version to `$\{STAGING_DATADIR_NATIVE}/target_version`. An example of such bbclass can be found in `classes/target_version_example.bbclass`.
 
 Please note that [target name, target version] pairs are expected to be unique in the system. If you build a new target with the same target version as a previously built one, the old package will be overwritten on the update server. It can have unpredictable effect on devices that have this version installed, and it is not guaranteed that information will be reported correctly for such devices or that you will be able to update them (we're doing our best though). The easiest way to avoid problems is to make sure that your overriding version is as unique as an OSTree commit hash.

--- a/docs/ota-client-guide/modules/ROOT/pages/ostree-usage.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/ostree-usage.adoc
@@ -18,25 +18,25 @@ Sometimes, while troubleshooting, it might be helpful to see and manipulate your
     export OSTREE=$(pwd)/tmp/sysroots/x86_64-linux/usr/bin/ostree
     export REPO=$(pwd)/tmp/deploy/images/raspberrypi3/ostree_repo/
 
-=== Get a list of all branches in the repo
+== Get a list of all branches in the repo
 
 You'll need a branch name for most other commands, so it's often useful to check your list of branches:
 
     $OSTREE refs --repo $REPO
 
-The branch name defaults to {MACHINE}-ota, so if you were building for raspberrypi3, your branch name would be raspberrypi3-ota by default. However, you can set the branch name for your build in local.conf using the *OSTREE_BRANCHNAME* configuration option, letting you keep your different builds, projects, or branches under different names.
+The branch name defaults to \{MACHINE}-ota, so if you were building for raspberrypi3, your branch name would be raspberrypi3-ota by default. However, you can set the branch name for your build in local.conf using the *OSTREE_BRANCHNAME* configuration option, letting you keep your different builds, projects, or branches under different names.
 
-=== Show the log for a particular branch
+== Show the log for a particular branch
 
     $OSTREE log --repo $REPO [branchname]
 
-=== List files in a particular commit
+== List files in a particular commit
 
     $OSTREE ls --repo $REPO [commit] [path]
 
 The -R option is supported, for recursive file listing.
 
-=== See a diff between two commits or references
+== See a diff between two commits or references
 
     $OSTREE diff --repo $REPO [ref1] [ref2]
 

--- a/docs/ota-client-guide/modules/ROOT/pages/release-process.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/release-process.adoc
@@ -55,19 +55,19 @@ git push github <tag>-docs
 
 To update the doxygen documentation for master on github, you will need to do something like the following:
 
-1. In an aktualizr repo, run `make doxygen` (or `make docs`) in the build directory.
-1. Clone a second aktualizr repo and run `git checkout gh-pages`.
-1. In the second repo, run `git rm search/* *.css *.html *.js *.png *.map *.md5 *.png *.svg`.
-1. Copy the contents of `<build_dir>/docs/doxygen/html` into the root of the second repo. (Something like `cp -a <build_dir>/docs/doxygen/html/* <second_repo>`.)
-1. In the second repo, run `git add .`, `git commit -as`, and `git push`.
-1. Wait a minute or two for github to refresh and render the files.
+. In an aktualizr repo, run `make doxygen` (or `make docs`) in the build directory.
+. Clone a second aktualizr repo and run `git checkout gh-pages`.
+. In the second repo, run `git rm search/* *.css *.html *.js *.png *.map *.md5 *.png *.svg`.
+. Copy the contents of `<build_dir>/docs/doxygen/html` into the root of the second repo. (Something like `cp -a <build_dir>/docs/doxygen/html/* <second_repo>`.)
+. In the second repo, run `git add .`, `git commit -as`, and `git push`.
+. Wait a minute or two for github to refresh and render the files.
 
 == Add doxygen pages for the new release on github
 
 To add doxygen docs for a new tag, you will need to do something like the following:
 
-1. Check out the tag or commit you wish to add (`git checkout 2018.63`, for example).
-1. Clean out the build directory (to remove stale objects), then run CMake and doxygen again:
+. Check out the tag or commit you wish to add (`git checkout 2018.63`, for example).
+. Clean out the build directory (to remove stale objects), then run CMake and doxygen again:
 +
 ----
 rm -rf build/*
@@ -76,11 +76,11 @@ cmake ..
 make doxygen
 ----
 +
-1. Clone a second aktualizr repo and run `git checkout gh-pages`.
-1. In the second repo, make a directory for the tag or commit you wish to add, i.e. `mkdir 2018.63`.
-1. Copy the contents of `<build_dir>/docs/doxygen/html` into the directory you just created. (Something like `cp -a <build_dir>/docs/doxygen/html/* <second_repo>/2018.63`.)
-1. In the second repo, run `git add 2018.63`, `git commit -as`, and `git push`.
-1. Wait a minute or two for github to refresh and render the files.
+. Clone a second aktualizr repo and run `git checkout gh-pages`.
+. In the second repo, make a directory for the tag or commit you wish to add, i.e. `mkdir 2018.63`.
+. Copy the contents of `<build_dir>/docs/doxygen/html` into the directory you just created. (Something like `cp -a <build_dir>/docs/doxygen/html/* <second_repo>/2018.63`.)
+. In the second repo, run `git add 2018.63`, `git commit -as`, and `git push`.
+. Wait a minute or two for github to refresh and render the files.
 
 == Update the description of the github release
 

--- a/docs/ota-client-guide/modules/ROOT/pages/schema-migrations.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/schema-migrations.adoc
@@ -14,14 +14,13 @@ endif::[]
 
 1. Modify link:{aktualizr-github-url}/config/sql/schema.sql[] as you see fit
 2. Write a config/sql/migration/migrate.n+1.sql that will convert an existing data to format in schema.sql. Note that old migrations must not be modified.
-
++
 Make sure that the migrate.n+1.sql file updates the 'version' table:
-
++
     DELETE FROM version;
     INSERT INTO version VALUES(...);
-
++
 3. Write a config/sql/rollback/rollback.n+1.sql that will revert the new data format to the previous one. It should contain the opposite steps of migrate.n+1.sql if possible. If the reverse operation is lossy, it should at the minimum bring the device to a state where it can be updated.
-
++
 The 'version' table has to be updated as well, to contain n.
-
 4. If the migration manipulates existing data in a non-trivial way (anything that's not simply a new table creation, deletion, renaming), it is strongly advised to write an explicit migration test with realistic data in link:{aktualizr-github-url}/src/libaktualizr/storage/sqlstorage_test.cc[], similar to `DbMigration18to19`.

--- a/docs/ota-client-guide/modules/ROOT/pages/security.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/security.adoc
@@ -10,11 +10,11 @@ endif::[]
 
 OTA Connect provides you with two levels of security which have different tradeoffs. You can work with the *default* security measures which are much less work to manage but expose you to certain risks. Or, you can follow our recommended *production-level* security measures which are more work to set up but provide more robust security.
 
-In both cases, communication between the devices and the OTA Connect is always secured via mutual TLS (X.509 certificates) for authorization, authentication, and encryption. 
+In both cases, communication between the devices and the OTA Connect is always secured via mutual TLS (X.509 certificates) for authorization, authentication, and encryption.
 
 The following sections describe the different security levels for device provisioning and software updates:
 
-= Device provisioning
+== Device provisioning
 
 When provisioning devices, you need to consider how to prevent unauthorized devices from provisioning. You also need to prevent your devices from being redirected to a malicious server.
 
@@ -24,14 +24,14 @@ This is usually done with a PKI (Public Key Infrastructure). Devices are automat
 +
 By default, **the OTA Connect server acts as its own PKI** and manages device keys and certificates for you.
 +
-All you have to do is download an initial provisioning key and bake it into the disk image that you'll flash to your devices. OTA Connect then takes care of issuing and validating device certificates. We call this type of provisioning xref:client-provisioning-methods.adoc[*shared-credential provisioning*] because you're using one provisioning key for your whole device fleet. 
+All you have to do is download an initial provisioning key and bake it into the disk image that you'll flash to your devices. OTA Connect then takes care of issuing and validating device certificates. We call this type of provisioning xref:client-provisioning-methods.adoc[*shared-credential provisioning*] because you're using one provisioning key for your whole device fleet.
 +
 {zwsp}
 * **Production-level security measure**
 +
 In short, you need to use your own PKI to allocate device certificates. You shouldn't leave this responsibility to the OTA Connect server. What makes things easy also makes things risky. If a malicious actor compromised your OTA Connect account, you would be in trouble because they could get your **private key** for signing device certificates. They could then provision whatever devices they wanted.
 
-= Software updates
+== Software updates
 
 Software updates are protected according to the xref:uptane.adoc[Uptane Framework] specifications. Uptane is one of the first comprehensive automotive OTA updating security frameworks available. This framework requires several metadata files to be signed by two separate keys. This metadata is also validated on the server.
 
@@ -42,6 +42,6 @@ By default, the OTA Connect server acts as a PKI for these keys too. When you cr
 {zwsp}
 * **Production-level security measure**
 +
-As with device provisioning, you should use your own PKI to sign metadata for your software files and updates. Take the two xref:pki.adoc[signing keys] offline and sign the metadata locally. 
+As with device provisioning, you should use your own PKI to sign metadata for your software files and updates. Take the two xref:pki.adoc[signing keys] offline and sign the metadata locally.
 +
 Again, if a malicious actor compromised your OTA Connect account, they could get your **private keys** for signing software metadata. They could then upload infected software and push them out to your devices. This type of attack is infinitely more difficult if you keep your keys offline in a safe place.

--- a/docs/ota-client-guide/modules/ROOT/pages/simulate-device-cred-provtest.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/simulate-device-cred-provtest.adoc
@@ -15,26 +15,25 @@ To use the `aktualizr-cert-provider` command, you must still generate a xref:get
 In production, you would use the root CA to sign the device certificate, but this method is useful for testing.
 
 To simulate provisioning with a device certificate, follow these steps: ::
-1. Add the following lines to your local.conf:
+. Add the following lines to your local.conf:
 +
 ----
 SOTA_CLIENT_PROV = "aktualizr-ca-device-prov"
 SOTA_DEPLOY_CREDENTIALS = "0"
 ----
-
-1. Build a standard image using the bitbake command.
-1. Boot the image.
+. Build a standard image using the bitbake command.
+. Boot the image.
 +
 The device should not be able to provision with a provisioning key. To verify this, log in to the {product-name} server and make sure that the device does not appear in the list of devices.
-1. Load the device credentials on to the device with `aktualizr-cert-provider` command:
+. Load the device credentials on to the device with `aktualizr-cert-provider` command:
 +
 ----
 aktualizr-cert-provider -c credentials.zip -t <device> -d /var/sota/import -r -u
 ----
 +
-You can find the link:https://github.com/advancedtelematic/aktualizr/tree/master/src/cert_provider[`aktualizr-cert-provider` source] in the aktualizr repo. You can also find a compiled binary in the host work directory of bitbake. 
+You can find the link:https://github.com/advancedtelematic/aktualizr/tree/master/src/cert_provider[`aktualizr-cert-provider` source] in the aktualizr repo. You can also find a compiled binary in the host work directory of bitbake.
 +
 The path should resemble the following example:
 +
-`tmp/work/x86_64-linux/aktualizr-native/1.0+gitAUTOINC+<version>/build/src/cert_provider/aktualizr-cert-provider`. 
+`tmp/work/x86_64-linux/aktualizr-native/1.0+gitAUTOINC+<version>/build/src/cert_provider/aktualizr-cert-provider`.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/use-your-own-deviceid.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/use-your-own-deviceid.adoc
@@ -23,7 +23,7 @@ However you can try our test procedures to specify your own Device IDs. Earlier 
 
 ** Replace the existing sample command:
 +
-`export device_id=${DEVICE_ID:-${DEVICE_UUID}}`
+`export device_id=${DEVICE_ID:-$\{DEVICE_UUID}}`
 +
 Update the command with your device ID instead:
 +

--- a/docs/ota-client-guide/modules/ROOT/pages/useful-bitbake-commands.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/useful-bitbake-commands.adoc
@@ -15,7 +15,7 @@ endif::[]
 
 You're going to run into Yocto build problems eventually--that's a given. We provide here a guide to a few bitbake commands we find particularly useful.
 
-=== Clean the build environment
+== Clean the build environment
 
 Yocto does a lot of caching and tries to be as smart about it as possible. But if you're running into build problems for a particular package, a good first start is
 
@@ -23,42 +23,42 @@ Yocto does a lot of caching and tries to be as smart about it as possible. But i
 
 This will remove everything in the work directory, everything in the state cache, and all previously downloaded source files.
 
-=== View the actual build environment bitbake will execute
+== View the actual build environment bitbake will execute
 
     bitbake -e [package] > env.log
 
 This is the bazooka of bitbake troubleshooting. It will output the entire build environment that bitbake uses for that package or image. This output will be tens of thousands of lines long, but can be grepped for what you need.
 
-=== Launch the bitbake devshell for a package
+== Launch the bitbake devshell for a package
 
     bitbake -c devshell [package]
 
 The devshell is the scalpel of bitbake troubleshooting. This command will open a new terminal in the package's build directory with bitbake's environment set up, after the source files have been fetched and all compile-time dependencies have been built, but before any configure/compile steps for the package have been taken. From here, you can troubleshoot specific problems with your build.
 
-=== Launch the dependency explorer for a package
+== Launch the dependency explorer for a package
 
     bitbake [package] -g -u depexp
 
 A GUI tool for exploring package dependencies.
 
-=== Show the layers currently in your build
+== Show the layers currently in your build
 
    bitbake-layers show-layers
 
 Outputs a list of the layers currently in use, and their priorities. If a package exists in two or more layers, it will be build from the layer with higher priority.
 
-=== Show all available recipes
+== Show all available recipes
 
     bitbake-layers show-recipes
 
-=== List all packages that will be built in an image/package
+== List all packages that will be built in an image/package
 
     bitbake -g [package] && cat pn-depends.dot | grep -v -e '-native' | \
     grep -v digraph | grep -v -e '-image' | awk '{print $1}' | sort | uniq
 
 A concise text dump of all of the dependencies of a package. Includes both runtime and compile-time dependencies.
 
-=== Save verbose build log
+== Save verbose build log
 
     bitbake -v [package] 2>&1 | tee build.log
 


### PR DESCRIPTION
This PR is to clean up some asciidoc syntax issues that were making antora barf up a bunch of warnings (and in some cases errors). That looks ugly on CI, and it also means that it's easy to miss a warning or error that we actually care about. Because I want to get rid of all the errors, I had to backport this to all the branches we build (that's why there are multiple PRs).

Mainly there were 3 issues:

### 1. Wrong numbers in ordered lists.
This comes from something that's a good practice in Markdown, but a bad habit in asciidoc. In asciidoc, you should either make an ordered list like this:
```
. some item
. something else
. item 3
```
or this:
```
1. some item
2. something else
3. item 3
```
The first option will automatically number the list for you, and you don't have to worry about it. The second option will also auto-number, but if the number you put is different that what got assigned with auto-numbering, it will throw a warning. This is actually good, because it catches errors like this, which would lead to both items being numbered 1, and asciidoctor throwing up a warning that you numbered item two wrong.
```
1. some item

There's an interesting detail about this item

2. something else
```
### 2. Unescaped attribute substitution

Asciidoc has a syntax for defining variables and then using them in the document, except that they're called attributes. You use an attribute by putting the attribute name in curly braces: `{some-attribute}`. If you put something in curly braces that isn't an attribute, you get a warning. You can fix this by escaping the first brace: `\{some-attribute}`

### 3. Heading levels in the wrong sequence

Markdown is lax about heading levels: you can start the page with a `###` section if you want, or put a `####` right after a `##` with no `###` in between. Asciidoc is pickier; your heading levels have to be strictly in order.