### PR TITLE
Add build pipeline triggers for docs branches

### DIFF
--- a/ci/gitlab/.gitlab-ci.yml
+++ b/ci/gitlab/.gitlab-ci.yml
@@ -41,6 +41,8 @@ include:
 Docker Setup:
   image: docker:18
   stage: docker
+  except:
+    - /^20\d\d\.\d\d?-docs$/
   services:
     - docker:18-dind
   before_script:
@@ -97,6 +99,8 @@ nop11:
     TEST_WITH_TESTSUITE: '0'
   image: "$UBUNTU_BIONIC_PR_IMAGE"
   stage: test
+  except:
+    - /^20\d\d\.\d\d?-docs$/
   cache:
     key: "$CI_JOB_NAME"
     paths:
@@ -117,6 +121,8 @@ debian-build+static:
     TEST_WITH_DOCS: '1'
   image: "$DEBIAN_TESTING_PR_IMAGE"
   stage: test
+  except:
+    - /^20\d\d\.\d\d?-docs$/
   cache:
     key: "$CI_JOB_NAME"
     paths:
@@ -132,6 +138,8 @@ bionic-pkg:
 
   image: "$UBUNTU_BIONIC_PR_IMAGE"
   stage: test
+  except:
+    - /^20\d\d\.\d\d?-docs$/
   cache:
     key: "$CI_JOB_NAME"
     paths:
@@ -151,6 +159,8 @@ xenial-pkg:
 
   image: "$UBUNTU_XENIAL_PR_IMAGE"
   stage: test
+  except:
+    - /^20\d\d\.\d\d?-docs$/
   cache:
     key: "$CI_JOB_NAME"
     paths:
@@ -170,6 +180,8 @@ bionic-pkg-test:
   dependencies:
     - bionic-pkg
   stage: pkg-test
+  except:
+    - /^20\d\d\.\d\d?-docs$/
   script:
     - ./scripts/test_install_garage_deploy.sh
 
@@ -181,6 +193,8 @@ xenial-pkg-test:
   dependencies:
     - xenial-pkg
   stage: pkg-test
+  except:
+    - /^20\d\d\.\d\d?-docs$/
   script:
     - ./scripts/test_install_garage_deploy.sh
     - ./scripts/test_install_aktualizr_and_update.sh

--- a/ci/gitlab/.gitlab-ci.yml
+++ b/ci/gitlab/.gitlab-ci.yml
@@ -348,3 +348,11 @@ trigger-otf-pipeline:
     variables:
       - $CI_COMMIT_REF_NAME =~ /^\d\d\d\d\.\d+(-\w+)?$/
   allow_failure: true
+
+trigger-docsite-build:
+  stage: trigger
+  only:
+    - /^20\d\d\.\d\d?-docs$/
+  trigger:
+    project: olp/edge/ota/documentation/ota-connect-docs
+    branch: master


### PR DESCRIPTION
There are two commits here: one to add the trigger, and one to exclude docs branches from unnecessary test jobs that suck up a lot of time. Obviously, this will need to be backported to all the current docs branches for it to actually work, but I wanted to open up the PR here first for review, and then cherry-pick it to the other branches once it's approved.