### PR TITLE
Adding "last updated" info, plus misc improvements

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/nav.adoc
+++ b/docs/ota-client-guide/modules/ROOT/nav.adoc
@@ -50,9 +50,10 @@ ifndef::env-github[:pageroot:]
 
 * xref:{pageroot}build-ota-enabled-images.adoc[Build and deploy OTA-enabled disk images]
 ** xref:{pageroot}supported-boards.adoc[Supported boards]
+** xref:{pageroot}yocto-release-branches.adoc[Yocto release branches]
 ** xref:{pageroot}add-ota-functonality-existing-yocto-project.adoc[Add OTA functionality to a Yocto project]
 ** xref:{pageroot}libaktualizr-integrate.adoc[Add libaktualizr integration to a Yocto project]
-** xref:{pageroot}yocto-release-branches.adoc[Yocto release branches]
+
 
 * xref:{pageroot}device-cred-prov-steps.adoc[Provision devices]
 ** xref:{pageroot}generate-selfsigned-root.adoc[Generate a self-signed root certificate]

--- a/docs/ota-client-guide/modules/ROOT/pages/_partials/recommended-steps.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/_partials/recommended-steps.adoc
@@ -2,16 +2,28 @@
 * *Use shared credential provisioning for your devices*
 +
 With shared-credential provisioning, you don't have to worry about installing certificates on your devices.
-The OTA Connect server automatically does this for you. All you need to do is download a provisioning key, unique to your account, and all your devices can share it.
+The OTA Connect server automatically does this for you. All you need to do is download a provisioning key that is unique to your account, and all your devices can share it.
 
-* *Build disk images using our demo recipes*
+** xref:generating-provisioning-credentials.adoc[Get a provisioning key]
 +
-We support a couple of demo boards "out of the box". You don't need to worry about complex build configurations at this stage. Just follow one of our xref:getstarted::index.adoc[Get Started guides] to learn how to build an OTA-enabled disk image.
+{nbsp}
+
 * *Use the standalone aktualizr client to test the OTA functionality*
 +
 You don't need to do anything extra to use the standalone aktualizr client. It's actually part of our demo build configurations, so the aktualizr client is included in the disk image that you'll build.
 +
 If you prefer to simulate an OTA-enabled device without building a disk image, you can install the aktualizr client on your development computer. In this case, however, you won't be able to try out OSTree functionality--the client will simply download and verify binaries, dropping them into a configurable location on your filesystem.
+
+** xref:simulate-device-basic.adoc[Simulate a device without building a disk image]
++
+{nbsp}
+
+* *Build disk images using our demo recipes*
++
+We support a couple of demo boards "out of the box". You don't need to worry about complex build configurations at this stage. Just follow one of our quick start guides to learn how to build an OTA-enabled disk image.
+
+** xref:build-raspberry.adoc[Build a Raspberry Pi image]
+** xref:build-qemu.adoc[Build a QEMU/VirtualBox image]
 
 //  end::evaluate-steps[]
 

--- a/docs/ota-client-guide/modules/ROOT/pages/account-setup.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/account-setup.adoc
@@ -1,4 +1,5 @@
 = Set up multiple accounts
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/add-ota-functonality-existing-yocto-project.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/add-ota-functonality-existing-yocto-project.adoc
@@ -1,4 +1,5 @@
 = Add OTA functionality to an existing Yocto project
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/adoc-test.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/adoc-test.adoc
@@ -1,4 +1,5 @@
 = Client provisioning methods
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/aktualizr-config-options.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/aktualizr-config-options.adoc
@@ -1,4 +1,5 @@
 = Client configuration options
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/aktualizr-runningmodes-finegrained-commandline-control.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/aktualizr-runningmodes-finegrained-commandline-control.adoc
@@ -1,4 +1,5 @@
 = Selectively trigger aktualizr
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/build-agl.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-agl.adoc
@@ -1,4 +1,6 @@
 = Build an Automotive Grade Linux image
+:page-partial:
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]
@@ -7,7 +9,7 @@ We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}
 ====
 endif::[]
 
-:page-partial:
+
 :page-layout: page
 :page-categories: [quickstarts]
 :page-date: 2017-05-16 15:54:29

--- a/docs/ota-client-guide/modules/ROOT/pages/build-configuration.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-configuration.adoc
@@ -1,4 +1,5 @@
 = Build Configuration Options
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/build-images.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-images.adoc
@@ -1,4 +1,5 @@
 = Build OTA-enabled Disk images
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/build-only-ostree.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-only-ostree.adoc
@@ -1,4 +1,5 @@
 = I don't need to build the SD card images every time--how can I do a build that only does the OSTree part?
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/build-ota-enabled-images.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-ota-enabled-images.adoc
@@ -1,4 +1,5 @@
 = Build OTA-enabled disk images
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/build-qemu.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-qemu.adoc
@@ -1,4 +1,4 @@
-= Build a QEMU/VirtualBox 
+= Build a QEMU/VirtualBox image
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/build-qemu.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-qemu.adoc
@@ -1,4 +1,6 @@
 = Build a QEMU/VirtualBox image
+:page-partial:
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]
@@ -7,7 +9,7 @@ We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}
 ====
 endif::[]
 
-:page-partial:
+
 :page-layout: page
 :page-categories: [quickstarts]
 :page-date: 2017-05-16 15:49:22

--- a/docs/ota-client-guide/modules/ROOT/pages/build-raspberry.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-raspberry.adoc
@@ -1,4 +1,6 @@
 = Build a Raspberry Pi image
+:page-partial:
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]
@@ -7,7 +9,7 @@ We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}
 ====
 endif::[]
 
-:page-partial:
+
 :page-layout: page
 :page-categories: [quickstarts]
 :page-date: 2017-05-16 15:48:37

--- a/docs/ota-client-guide/modules/ROOT/pages/client-provisioning-methods.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/client-provisioning-methods.adoc
@@ -1,4 +1,5 @@
 = Device Provisioning Methods
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/cross-deploy-images.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/cross-deploy-images.adoc
@@ -1,4 +1,5 @@
 = Transfer disk images to a software repository in another account
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/deb-package-install.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/deb-package-install.adoc
@@ -1,4 +1,5 @@
 == Installing aktualizr via debian package
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/debugging-tips.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/debugging-tips.adoc
@@ -1,4 +1,5 @@
 = Aktualizr Debugging Tips
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/deploy-checklist.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/deploy-checklist.adoc
@@ -1,4 +1,5 @@
 = Deployment Checklist
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/developer-tools.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/developer-tools.adoc
@@ -1,4 +1,5 @@
 = Developer Tools
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/device-cred-prov-steps.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/device-cred-prov-steps.adoc
@@ -1,4 +1,5 @@
 = Set Up Device Provisioning
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/device-cred-prov-teststeps.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/device-cred-prov-teststeps.adoc
@@ -1,4 +1,5 @@
 = Text Device-credential Provisioning
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/ecu_events.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/ecu_events.adoc
@@ -1,4 +1,5 @@
 = Client events reporting
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/enable-device-cred-provisioning.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/enable-device-cred-provisioning.adoc
@@ -1,4 +1,5 @@
 = Enable device-credential provisioning and install device certificates 
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/enable-device-cred-provtest.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/enable-device-cred-provtest.adoc
@@ -1,4 +1,5 @@
 = Enable device-credential provisioning and install device certificates 
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/enable-shared-cred-provisioning.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/enable-shared-cred-provisioning.adoc
@@ -1,4 +1,5 @@
 = Enable shared-credential provisioning
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/evaluation-to-prod.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/evaluation-to-prod.adoc
@@ -1,4 +1,5 @@
 = Moving from evaluation to production
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/fault-injection.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/fault-injection.adoc
@@ -1,4 +1,5 @@
 = Running aktualizr with fault injection
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/generate-devicecert.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/generate-devicecert.adoc
@@ -1,4 +1,5 @@
 = Device Certificate Generation
+:page-lastupdated: {docdate}
 
 ifdef::env-github[]
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/generate-selfsigned-root.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/generate-selfsigned-root.adoc
@@ -1,4 +1,5 @@
 = Generate a self-signed root certificate
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/generatetest-devicecert.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/generatetest-devicecert.adoc
@@ -1,4 +1,5 @@
 = Generate a test device certificate
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/how-can-i-check-which-ostree-version-is-installed.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/how-can-i-check-which-ostree-version-is-installed.adoc
@@ -1,4 +1,5 @@
 = How can I check which OSTree commit is deployed?
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/index.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/index.adoc
@@ -1,4 +1,5 @@
 = Introduction
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/install-garage-sign-deploy.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/install-garage-sign-deploy.adoc
@@ -1,4 +1,5 @@
 = Install the "garage deploy" tool
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/intro-evaluate.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/intro-evaluate.adoc
@@ -1,4 +1,5 @@
 = Evaluate OTA Connect
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/intro-prep.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/intro-prep.adoc
@@ -1,4 +1,5 @@
 = Build your own OTA-enabled solution
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/intro-prod.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/intro-prod.adoc
@@ -1,4 +1,5 @@
 = Moving to Production
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/libaktualizr-getstarted.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/libaktualizr-getstarted.adoc
@@ -1,4 +1,5 @@
 = Get started
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/libaktualizr-integrate.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/libaktualizr-integrate.adoc
@@ -1,4 +1,5 @@
 = Build disc images that contain your libaktualizr integration
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/libaktualizr-update-secondary.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/libaktualizr-update-secondary.adoc
@@ -1,4 +1,5 @@
 = Update a secondary ECU
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/libaktualizr-why-use.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/libaktualizr-why-use.adoc
@@ -1,4 +1,5 @@
 = Integrate libaktualizr into your solution
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/meta-updater-build.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/meta-updater-build.adoc
@@ -1,4 +1,5 @@
 = Build
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/meta-updater-dev-config.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/meta-updater-dev-config.adoc
@@ -1,4 +1,5 @@
 = Development configuration
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/meta-updater-provisioning-methods.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/meta-updater-provisioning-methods.adoc
@@ -1,4 +1,5 @@
 = Manual provisioning
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/meta-updater-testing.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/meta-updater-testing.adoc
@@ -1,4 +1,5 @@
 = Testing
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/meta-updater-usage.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/meta-updater-usage.adoc
@@ -1,4 +1,5 @@
 = Usage
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/metadata-expiry.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/metadata-expiry.adoc
@@ -1,4 +1,5 @@
 = Manage metadata expiry dates
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/ostree-and-treehub.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/ostree-and-treehub.adoc
@@ -1,4 +1,5 @@
 == OSTree
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/ostree-usage.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/ostree-usage.adoc
@@ -1,4 +1,5 @@
 = OSTree usage
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/pki.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/pki.adoc
@@ -1,4 +1,5 @@
 = Key Management
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/posix-secondaries-bitbaking.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/posix-secondaries-bitbaking.adoc
@@ -1,4 +1,5 @@
 = Posix Secondaries: bitbaking and usage of Primary and Secondary images
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/posix-secondaries.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/posix-secondaries.adoc
@@ -1,4 +1,5 @@
 = Posix Secondaries aka IP Secondaries: configuration and emulation of Primary and Secondary on a local host
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/provide-root-cert.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/provide-root-cert.adoc
@@ -1,4 +1,5 @@
 = Register the Root Certificate for your Fleet
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/provide-testroot-cert.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/provide-testroot-cert.adoc
@@ -1,4 +1,5 @@
 = Register your test root certificate
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/provisioning-methods-and-credentialszip.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/provisioning-methods-and-credentialszip.adoc
@@ -1,4 +1,5 @@
 = Provisioning methods and credentials.zip
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/pushing-updates.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/pushing-updates.adoc
@@ -1,4 +1,6 @@
 = Upload a sample software version
+:page-partial:
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]
@@ -7,7 +9,7 @@ We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}
 ====
 endif::[]
 
-:page-partial:
+
 :page-layout: page
 :page-categories: [quickstarts]
 :page-date: 2017-05-23 16:31:35

--- a/docs/ota-client-guide/modules/ROOT/pages/recommended-clientconfig.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/recommended-clientconfig.adoc
@@ -1,4 +1,5 @@
 = Recommended client configurations
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/release-process.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/release-process.adoc
@@ -1,4 +1,5 @@
 = Release process
+:page-lastupdated: {docdate}
 :toc: macro
 :toc-title:
 :sectnums:

--- a/docs/ota-client-guide/modules/ROOT/pages/rollback.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/rollback.adoc
@@ -1,4 +1,5 @@
 = Rollbacks
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/rotating-signing-keys.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/rotating-signing-keys.adoc
@@ -1,4 +1,5 @@
 = Manage keys for software metadata
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/schema-migrations.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/schema-migrations.adoc
@@ -1,4 +1,5 @@
 = How to add a schema migration
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/secure-software-updates-test.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/secure-software-updates-test.adoc
@@ -1,4 +1,5 @@
 = Test software update security
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/secure-software-updates.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/secure-software-updates.adoc
@@ -1,4 +1,5 @@
 = Secure your software updates
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/security.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/security.adoc
@@ -1,4 +1,5 @@
 = Security and Identity
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/simulate-device-basic.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/simulate-device-basic.adoc
@@ -1,4 +1,6 @@
 = Simulate a device without building a disk image
+:page-partial:
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]
@@ -7,7 +9,7 @@ We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}
 ====
 endif::[]
 
-:page-partial:
+
 :page-layout: page
 :page-categories: [quickstarts]
 :page-date: 2018-11-19 11:28:47

--- a/docs/ota-client-guide/modules/ROOT/pages/simulate-device-cred-provtest.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/simulate-device-cred-provtest.adoc
@@ -1,4 +1,5 @@
 = Simulate the provisioning process with device credentials
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/software-management.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/software-management.adoc
@@ -1,4 +1,6 @@
 = Software management
+:page-partial:
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]
@@ -7,7 +9,7 @@ We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}
 ====
 endif::[]
 
-:page-partial:
+
 
 When you develop software updates for OTA deployment, it's important to understand the two different ways in which you can get software into OTA Connect.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/supported-boards.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/supported-boards.adoc
@@ -1,4 +1,5 @@
 = Supported boards
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/supporting-technologies.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/supporting-technologies.adoc
@@ -1,4 +1,5 @@
 = Supporting Technologies
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/troubleshooting.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/troubleshooting.adoc
@@ -1,4 +1,5 @@
 = Troubleshooting
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/update-single-device.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/update-single-device.adoc
@@ -1,4 +1,5 @@
 = Update a device with the sample software
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/update-your-client-configuration.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/update-your-client-configuration.adoc
@@ -1,4 +1,5 @@
 = Recommended client configurations
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/uptane-generator.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/uptane-generator.adoc
@@ -1,4 +1,5 @@
 = Simulate Uptane metadata transactions
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/uptane.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/uptane.adoc
@@ -1,4 +1,5 @@
 = OTA Connect security: The Uptane framework
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/use-your-own-deviceid.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/use-your-own-deviceid.adoc
@@ -1,4 +1,5 @@
 = Configure your own device IDs
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/useful-bitbake-commands.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/useful-bitbake-commands.adoc
@@ -1,4 +1,5 @@
 = Useful Bitbake commands
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/workflow-overview.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/workflow-overview.adoc
@@ -1,4 +1,5 @@
 = Basic Workflow
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/yocto-release-branches.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/yocto-release-branches.adoc
@@ -1,4 +1,5 @@
 = Yocto release branches
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]

--- a/docs/ota-client-guide/modules/ROOT/pages/yocto.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/yocto.adoc
@@ -1,4 +1,5 @@
 == Yocto
+:page-lastupdated: {docdate}
 ifdef::env-github[]
 
 [NOTE]


### PR DESCRIPTION
This PR is mainly to add the "last update" attribute to each asciidoc file. For now I'll only add this to the developer guide. There will be a related PR for the UI bundle.

Each doc file should now have the attribute `:page-lastupdated: {docdate}`

I tried to set this as a global in the Antora playbook, but it choked (value of "page-lastupdated" undefined)
I tried to set `page.docdate` and `page.attributes.docdate` in the handlebars template, but according to [this list](https://docs.antora.org/antora-ui-default/templates/#template-variables-table) the docdate is not one of the environment variables that Antora knows about (yet). So this seems to be the only viable solution for now..