### PR TITLE
Add github CI action to build and upload macOS package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,21 +7,10 @@ jobs:
     name: Build macOS homebrew bottle for aktualizr release page
     runs-on: macOS-10.14
     steps:
-    # This first step is here to work around the fact that aktualizr doesn't build on macOS
-    # with boost 1.71. It checks out a known good revision of the boost recipe and
-    # reinstalls it. However, right now the macOS base image GitHub's agents are using has
-    # an older version of boost that builds without modification, so the commit we're
-    # trying to check out doesn't exist (hence the `|| true`). So, this is more-or-less for
-    # future-proofing; we don't know when GitHub will update their agents to the latest
-    # versions.
-    - name: Check out known-working version of boost
-      run: |
-        BREW_GIT_DIR=$(brew --prefix)/Homebrew/Library/Taps/homebrew/homebrew-core
-        git -C "$BREW_GIT_DIR" checkout 5da5895add Formula/boost.rb && brew reinstall boost || true
     - name: Attempt to auto-update recipe and build bottle
       run: |
         curl -O https://raw.githubusercontent.com/advancedtelematic/homebrew-otaconnect/master/aktualizr.rb
-        VERSION=$(basename $GITHUB_REF)
+        VERSION=${GITHUB_REF#refs/tags/}
         RELEASE_URL="https://github.com/advancedtelematic/aktualizr/releases/download/${VERSION}/"
         sed -i '' -E "s/  version \"20[1-2][0-9].[0-9]+\"/  version \"${VERSION}\"/" aktualizr.rb
         brew install --build-bottle ./aktualizr.rb
@@ -39,12 +28,9 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        VERSION=$(basename $GITHUB_REF)
-        RELEASE_ID=$(jq --raw-output '.release.id' $GITHUB_EVENT_PATH)
-        AUTH_HEADER="Authorization: token ${GITHUB_TOKEN}"
-        FILENAME=aktualizr-${VERSION}.mojave.bottle.tar.gz
-        UPLOAD_URL="https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?name=${FILENAME}"
-        curl -sSL -H "${AUTH_HEADER}" -F "data=@${FILENAME}" "$UPLOAD_URL"
+        brew install ghr 
+        VERSION=${GITHUB_REF#refs/tags/}
+        ghr -u "${GITHUB_REPOSITORY%/*}" -r "${GITHUB_REPOSITORY#*/}" ${VERSION} aktualizr-${VERSION}.mojave.bottle.tar.gz
     - name: Save recipe as build artifact
       uses: actions/upload-artifact@master
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,52 @@
+name: Build macOS homebrew bottle for aktualizr release page
+on: 
+  release:
+    types: [created]
+jobs:
+  macOS:
+    name: Build macOS homebrew bottle for aktualizr release page
+    runs-on: macOS-10.14
+    steps:
+    # This first step is here to work around the fact that aktualizr doesn't build on macOS
+    # with boost 1.71. It checks out a known good revision of the boost recipe and
+    # reinstalls it. However, right now the macOS base image GitHub's agents are using has
+    # an older version of boost that builds without modification, so the commit we're
+    # trying to check out doesn't exist (hence the `|| true`). So, this is more-or-less for
+    # future-proofing; we don't know when GitHub will update their agents to the latest
+    # versions.
+    - name: Check out known-working version of boost
+      run: |
+        BREW_GIT_DIR=$(brew --prefix)/Homebrew/Library/Taps/homebrew/homebrew-core
+        git -C "$BREW_GIT_DIR" checkout 5da5895add Formula/boost.rb && brew reinstall boost || true
+    - name: Attempt to auto-update recipe and build bottle
+      run: |
+        curl -O https://raw.githubusercontent.com/advancedtelematic/homebrew-otaconnect/master/aktualizr.rb
+        VERSION=$(basename $GITHUB_REF)
+        RELEASE_URL="https://github.com/advancedtelematic/aktualizr/releases/download/${VERSION}/"
+        sed -i '' -E "s/  version \"20[1-2][0-9].[0-9]+\"/  version \"${VERSION}\"/" aktualizr.rb
+        brew install --build-bottle ./aktualizr.rb
+        brew bottle --json --no-rebuild --force-core-tap --root-url=${RELEASE_URL} aktualizr
+        brew bottle --merge --write --no-commit ./aktualizr--${VERSION}.mojave.bottle.json
+        rm aktualizr.rb
+        echo "Bottle and recipe creation succeeded!"
+        echo "You should now open a PR at https://github.com/advancedtelematic/homebrew/otaconnect"
+        echo "Here's the new recipe. It's also attached to this job as an artifact."
+        echo "------------------------------------------------------------------------------------"
+        brew cat aktualizr | tee aktualizr.rb
+        echo "------------------------------------------------------------------------------------"
+        mv aktualizr--${VERSION}.mojave.bottle.tar.gz aktualizr-${VERSION}.mojave.bottle.tar.gz
+    - name: Upload bottle to github release page
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        VERSION=$(basename $GITHUB_REF)
+        RELEASE_ID=$(jq --raw-output '.release.id' $GITHUB_EVENT_PATH)
+        AUTH_HEADER="Authorization: token ${GITHUB_TOKEN}"
+        FILENAME=aktualizr-${VERSION}.mojave.bottle.tar.gz
+        UPLOAD_URL="https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?name=${FILENAME}"
+        curl -sSL -H "${AUTH_HEADER}" -F "data=@${FILENAME}" "$UPLOAD_URL"
+    - name: Save recipe as build artifact
+      uses: actions/upload-artifact@master
+      with:
+        name: aktualizr.rb
+        path: aktualizr.rb

--- a/docs/ota-client-guide/modules/ROOT/pages/release-process.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/release-process.adoc
@@ -102,7 +102,15 @@ Uptane has a fork of aktualizr in link:https://github.com/uptane/aktualizr[their
 
 == Update the homebrew recipe for aktualizr
 
-The https://github.com/advancedtelematic/homebrew-otaconnect/blob/master/aktualizr.rb[homebrew aktualizr recipe] should be updated with the new release. You'll need a mac, with homebrew installed, to do this.
+The https://github.com/advancedtelematic/homebrew-otaconnect/blob/master/aktualizr.rb[homebrew aktualizr recipe] should be updated with the new release.
+
+There is a github CI job that will automatically update the recipe, build a bottle, and upload the bottle to the release page when a new release is created. The one thing it doesn't do is make the pull request to update the recipe in the tap.
+
+You'll find the new recipe attached to the CI run for the release--it should be the latest run on the https://github.com/advancedtelematic/aktualizr/actions[Actions tab]. You can download the file from there, and submit the changes as a pull request to the https://github.com/advancedtelematic/homebrew-otaconnect/[homebrew-otaconnect repo].
+
+=== Fallback: manually build a bottle and update the homebrew recipe
+
+If the CI job failed for some reason, you might need to manually create the new bottle and edit the recipe. Here are the steps to follow (you'll need a Mac with homebrew installed):
 
 . Edit the recipe on your local system with `brew edit aktualizr`, and replace the old version tag with the new one.
 . Build it, and then bottle it:


### PR DESCRIPTION
Github has CI now! And they have agents running macOS!

So, this PR automates almost all of [this process](https://docs.ota.here.com/ota-client/latest/release-process.html#_update_the_homebrew_recipe_for_aktualizr). Normally the only thing you need to change in the build part of the recipe is the version; we can do that with sed. Homebrew provides tooling for generating the bottle, and for modifying the recipe to include the bottle, so we use that to generate a complete recipe that's ready to submit as a PR against https://github.com/advancedtelematic/homebrew-otaconnect. (The recipe shows up in the build log, and is attached to the CI run as an artifact.) The last step automates adding the bottle to the newly-generated release, which makes the generated recipe with the `bottle do` block work.

I used a personal repo to test this out; you can see a successful run over [here](https://github.com/tkfu/homebrew-action-testing/runs/229686121), with the release with the bottle attached [here](https://github.com/tkfu/homebrew-action-testing/releases/tag/2019.8). (We can't do a trial run in the real aktualizr repo, because it only triggers when a new release is created.)