### PR TITLE
Dogfooding survey fixes

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/pages/build-qemu.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-qemu.adoc
@@ -25,7 +25,7 @@ include::ota-client::page$build-raspberry.adoc[tags=prereqs;env-setup;config;bit
 
 == Run the built image with QEMU
 
-The build process creates disk images as an artefact. You can then directly run them with QEMU. (If you don't already have it installed, install it with `apt-get install qemu` or similar.) The meta-updater layer contains a helper script to launch the images:
+The build process creates disk images as an artefact. You can then directly run them with QEMU. (If you don't already have it installed, install it with `apt install qemu` or similar.) The meta-updater layer contains a helper script to launch the images:
 
 ----
 ../meta-updater/scripts/run-qemu-ota [image name] [mac address]

--- a/docs/ota-client-guide/modules/ROOT/pages/build-qemu.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-qemu.adoc
@@ -1,4 +1,4 @@
-= Build a QEMU/VirtualBox image
+= Build a QEMU image
 :page-partial:
 ifdef::env-github[]
 
@@ -19,7 +19,7 @@ endif::[]
 :machine: qemux86-64
 :meta-env: qemux86-64
 
-{product-name} lets you easily manage OTA updates to embedded devices running custom-built Yocto images. This is a guide for building a simple Yocto image that you can run in Virtualbox or QEMU. This is a good way to get started if you don't know yet what hardware your project will use, or if you just want to try out the features of {product-name} without worrying about physical devices.
+{product-name} lets you easily manage OTA updates to embedded devices running custom-built Yocto images. This is a guide for building a simple Yocto image that you can run in QEMU. This is a good way to get started if you don't know yet what hardware your project will use, or if you just want to try out the features of {product-name} without worrying about physical devices.
 
 include::ota-client::page$build-raspberry.adoc[tags=prereqs;env-setup;config;bitbake]
 

--- a/docs/ota-client-guide/modules/ROOT/pages/build-raspberry.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-raspberry.adoc
@@ -34,19 +34,19 @@ You'll need a build machine with the following:
 ** On a Debian-based system, you should be able to install all the required packages with the following command:
 +
 ----
-sudo apt install gawk wget git-core diffstat unzip texinfo gcc-multilib build-essential chrpath socat cpio python python3 python3-pip python3-pexpect python-dev xz-utils debianutils iputils-ping cpu-checker default-jre parted
+sudo apt install gawk wget git diffstat unzip texinfo gcc-multilib build-essential chrpath socat cpio python python3 python3-pip python3-pexpect python-dev xz-utils debianutils iputils-ping cpu-checker default-jre parted
 ----
 ** Many/most distros that aren't on the officially supported list will still work just fine--feel free to give it a try with whatever you're running.
-** You *can* run this all inside a VM, but a Yocto build is a pretty resource-intensive process, so generally we don't recommend it. Make sure your VM meets the following requirements:
-*** At least 6GB of RAM
-*** At least 150GB of disk space.
-* 100GB of free disk space
+* 100GB+ of free disk space
+* 6GB+ of RAM
 ifeval::["{machine}" == "qemux86-64"]
 * QEMU--we recommend installing it from your distro's package manager, e.g. `sudo apt install qemu`
 endif::[]
 * link:https://android.googlesource.com/tools/repo/[repo]
 ** link:https://source.android.com/source/downloading#installing-repo[Download the latest version] directly from Google, or
 ** install it from your distro's packages if available (`sudo apt install repo`)
+
+TIP: It's possible use a virtual machine running Linux as your build machine. However, we don't recommend it. It will be slower, and you're more likely to run into difficult-to-troubleshoot issues. If you do want to use a VM despite this warning, though, make sure the VM has enough resources allocated to it. Along with the disk space and memory requirements above, we suggest allocating at least 4-6 CPU cores to the VM to speed up building.
 
 Also, make sure that you've generated your xref:generating-provisioning-credentials.adoc[provisioning credentials] first.
 // end::prereqs[]

--- a/docs/ota-client-guide/modules/ROOT/pages/build-raspberry.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-raspberry.adoc
@@ -37,7 +37,6 @@ You'll need a build machine with the following:
 sudo apt-get install gawk wget git-core diffstat unzip texinfo gcc-multilib build-essential chrpath socat cpio python python3 python3-pip python3-pexpect python-dev xz-utils debianutils iputils-ping cpu-checker default-jre parted
 ----
 ** Many/most distros that aren't on the officially supported list will still work just fine--feel free to give it a try with whatever you're running.
-** Although the Yocto project as a whole does support architectures other than x86-64 for the build machine, one of the layers we'll be using only supports x86-64.
 ** You *can* run this all inside a VM, but a Yocto build is a pretty resource-intensive process, so generally we don't recommend it. Make sure your VM meets the following requirements:
 *** At least 6GB of RAM
 *** At least 150GB of disk space.

--- a/docs/ota-client-guide/modules/ROOT/pages/build-raspberry.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-raspberry.adoc
@@ -34,7 +34,7 @@ You'll need a build machine with the following:
 ** On a Debian-based system, you should be able to install all the required packages with the following command:
 +
 ----
-sudo apt-get install gawk wget git-core diffstat unzip texinfo gcc-multilib build-essential chrpath socat cpio python python3 python3-pip python3-pexpect python-dev xz-utils debianutils iputils-ping cpu-checker default-jre parted
+sudo apt install gawk wget git-core diffstat unzip texinfo gcc-multilib build-essential chrpath socat cpio python python3 python3-pip python3-pexpect python-dev xz-utils debianutils iputils-ping cpu-checker default-jre parted
 ----
 ** Many/most distros that aren't on the officially supported list will still work just fine--feel free to give it a try with whatever you're running.
 ** You *can* run this all inside a VM, but a Yocto build is a pretty resource-intensive process, so generally we don't recommend it. Make sure your VM meets the following requirements:
@@ -42,11 +42,11 @@ sudo apt-get install gawk wget git-core diffstat unzip texinfo gcc-multilib buil
 *** At least 150GB of disk space.
 * 100GB of free disk space
 ifeval::["{machine}" == "qemux86-64"]
-* QEMU--we recommend installing it from your distro's package manager, e.g. `sudo apt-get install qemu`
+* QEMU--we recommend installing it from your distro's package manager, e.g. `sudo apt install qemu`
 endif::[]
 * link:https://android.googlesource.com/tools/repo/[repo]
 ** link:https://source.android.com/source/downloading#installing-repo[Download the latest version] directly from Google, or
-** install it from your distro's packages if available (`sudo apt-get install repo`)
+** install it from your distro's packages if available (`sudo apt install repo`)
 
 Also, make sure that you've generated your xref:generating-provisioning-credentials.adoc[provisioning credentials] first.
 // end::prereqs[]

--- a/docs/ota-client-guide/modules/ROOT/pages/pushing-updates.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/pushing-updates.adoc
@@ -76,8 +76,8 @@ If you are building for 32-bit ARM (i.e. Raspberry Pi), you'll need some support
 
 ----
 sudo dpkg --add-architecture i386
-sudo apt-get update
-sudo apt-get install g++-multilib libssl-dev:i386 libcrypto++-dev:i386 zlib1g-dev:i386
+sudo apt update
+sudo apt install g++-multilib libssl-dev:i386 libcrypto++-dev:i386 zlib1g-dev:i386
 ----
 
 For more details, see the https://github.com/imyller/meta-nodejs#cross-compiling-for-32-bit-target-on-64-bit-host[meta-nodejs README].


### PR DESCRIPTION
* Make it more clear we don't recommend using a VM as a build machine
* Update apt-get to apt
* Remove warning about the build machine needing to be x86-64