### PR TITLE
Aktualizr-lite: return only not-nulled target to avoid crash

### DIFF
--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -161,7 +161,7 @@ static std::unique_ptr<Uptane::Target> find_target(const std::shared_ptr<SotaUpt
       }
     }
   }
-  if (find_latest) {
+  if (find_latest && latest != nullptr) {
     return latest;
   }
   throw std::runtime_error("Unable to find update");


### PR DESCRIPTION
Signed-off-by: Mykhaylo Sul <myk.sul@gmail.com>