### PR TITLE
Remove references to old Jira.

### DIFF
--- a/src/libaktualizr/uptane/tuf_test.cc
+++ b/src/libaktualizr/uptane/tuf_test.cc
@@ -39,7 +39,6 @@ TEST(Root, RootJsonNoRoles) {
 
 /**
  * Check that a root.json that uses "method": "rsassa-pss-sha256" validates correctly
- * See PRO-2999
  */
 TEST(Root, RootJsonRsassaPssSha256) {
   Uptane::Root root1(Uptane::Root::Policy::kAcceptAll);

--- a/tests/sota_tools/test-server-500
+++ b/tests/sota_tools/test-server-500
@@ -1,9 +1,7 @@
 #! /usr/bin/env python3
 
 """
-Regression test for PRO-2902
-
-The bug was caused by the logic that cleanly shuts down the request pool when
+Regression test for a bug caused by the logic that shuts down the request pool when
 the server returns an error. This test causes 3 'query' requests to hang until
 an upload fails.  Once the upload has failed and the server is trying to
 shutdown, the queries are released. In the broken case this caused RequestPool


### PR DESCRIPTION
It's gone and therefore useful to nobody. No reason to keep around
distracting comments, especially when the context was already provided.