### PR TITLE
Use `git describe --long` for versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ find_package(ZLIB)
 
 if(NOT AKTUALIZR_VERSION)
     if(GIT_EXECUTABLE)
-        execute_process(COMMAND sh -c "${GIT_EXECUTABLE} -C ${PROJECT_SOURCE_DIR} describe | tr -d '\n'" OUTPUT_VARIABLE AKTUALIZR_VERSION)
+        execute_process(COMMAND sh -c "${GIT_EXECUTABLE} -C ${PROJECT_SOURCE_DIR} describe --long | tr -d '\n'" OUTPUT_VARIABLE AKTUALIZR_VERSION)
         message(STATUS "Setting version to ${AKTUALIZR_VERSION}")
     else(GIT_EXECUTABLE)
         message(WARNING "Version is not set and git is not available, set version to an arbitrary string")

--- a/scripts/build_ubuntu.sh
+++ b/scripts/build_ubuntu.sh
@@ -17,4 +17,4 @@ mkdir -p "$TEST_INSTALL_DESTDIR"
 LDFLAGS="-s" "$GITREPO_ROOT/scripts/test.sh"
 
 git -C "$GITREPO_ROOT" fetch --tags --unshallow || true
-git -C "$GITREPO_ROOT" describe > "$TEST_INSTALL_DESTDIR/aktualizr-version"
+git -C "$GITREPO_ROOT" describe --long > "$TEST_INSTALL_DESTDIR/aktualizr-version"


### PR DESCRIPTION
So we'll have 2019.8-0-g5443f810 instead of just 2019.8