### PR TITLE
Use latest endpoint for /system_info

### DIFF
--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -186,7 +186,7 @@ data::InstallationResult SotaUptaneClient::PackageInstallSetResult(const Uptane:
 void SotaUptaneClient::reportHwInfo() {
   Json::Value hw_info = Utils::getHardwareInfo();
   if (!hw_info.empty()) {
-    http->put(config.tls.server + "/core/system_info", hw_info);
+    http->put(config.tls.server + "/system_info", hw_info);
   } else {
     LOG_WARNING << "Unable to fetch hardware information from host system.";
   }

--- a/src/libaktualizr/uptane/uptane_test.cc
+++ b/src/libaktualizr/uptane/uptane_test.cc
@@ -826,14 +826,6 @@ class HttpFakeProv : public HttpFake {
       EXPECT_EQ(data.size(), 1);
       EXPECT_EQ(data[0]["name"].asString(), "fake-package");
       EXPECT_EQ(data[0]["version"].asString(), "1.0");
-    } else if (url.find("/core/system_info") != std::string::npos) {
-      /* Send hardware info to the server. */
-      system_info_count++;
-      Json::Value hwinfo = Utils::getHardwareInfo();
-      EXPECT_EQ(hwinfo["id"].asString(), data["id"].asString());
-      EXPECT_EQ(hwinfo["description"].asString(), data["description"].asString());
-      EXPECT_EQ(hwinfo["class"].asString(), data["class"].asString());
-      EXPECT_EQ(hwinfo["product"].asString(), data["product"].asString());
     } else if (url.find("/director/manifest") != std::string::npos) {
       /* Get manifest from primary.
        * Get primary installation result.
@@ -871,6 +863,14 @@ class HttpFakeProv : public HttpFake {
       EXPECT_EQ(nwinfo["local_ipv4"].asString(), data["local_ipv4"].asString());
       EXPECT_EQ(nwinfo["mac"].asString(), data["mac"].asString());
       EXPECT_EQ(nwinfo["hostname"].asString(), data["hostname"].asString());
+    } else if (url.find("/system_info") != std::string::npos) {
+      /* Send hardware info to the server. */
+      system_info_count++;
+      Json::Value hwinfo = Utils::getHardwareInfo();
+      EXPECT_EQ(hwinfo["id"].asString(), data["id"].asString());
+      EXPECT_EQ(hwinfo["description"].asString(), data["description"].asString());
+      EXPECT_EQ(hwinfo["class"].asString(), data["class"].asString());
+      EXPECT_EQ(hwinfo["product"].asString(), data["product"].asString());
     } else {
       EXPECT_EQ(0, 1) << "Unexpected put to URL: " << url;
     }


### PR DESCRIPTION
Fixes https://saeljira.it.here.com/browse/OTA-3379 

Only works in production, not sit, due to https://saeljira.it.here.com/browse/OTA-3936

Will change device-gateway so that legacy devices can still use `/core/system_info`