### PR TITLE
Add noptest to test_lite-helpers

### DIFF
--- a/src/aktualizr_lite/CMakeLists.txt
+++ b/src/aktualizr_lite/CMakeLists.txt
@@ -22,7 +22,7 @@ add_library(t_lite-mock SHARED ostree_mock.cc)
 add_aktualizr_test(NAME lite-helpers SOURCES helpers.cc helpers_test.cc
                    ARGS ${PROJECT_BINARY_DIR}/ostree_repo)
 set_tests_properties(test_lite-helpers PROPERTIES
-        ENVIRONMENT LD_PRELOAD=$<TARGET_FILE:t_lite-mock>)
+        ENVIRONMENT LD_PRELOAD=$<TARGET_FILE:t_lite-mock> LABELS "noptest")
 
 endif(BUILD_OSTREE)
 


### PR DESCRIPTION
Tests with preloaded dynamic libraries don't play out well with ptest yet.