### PR TITLE
PackageConfig: using fake package manager for non-ostree build

### DIFF
--- a/src/libaktualizr/package_manager/packagemanagerconfig.h
+++ b/src/libaktualizr/package_manager/packagemanagerconfig.h
@@ -11,7 +11,11 @@ enum class PackageManager { kNone = 0, kOstree, kDebian, kAndroid, kOstreeDocker
 std::ostream& operator<<(std::ostream& os, PackageManager pm);
 
 struct PackageConfig {
+#ifdef BUILD_OSTREE
   PackageManager type{PackageManager::kOstree};
+#else
+  PackageManager type{PackageManager::kNone};
+#endif
   std::string os;
   boost::filesystem::path sysroot;
   std::string ostree_server;


### PR DESCRIPTION
Signed-off-by: Kostiantyn Bushko <kbushko@intellias.com>
By default, aktualizr will be built with the PackageConfig::kNone, the PackageConfig::kOstree is used only when the -DBUILD_OSTREE is defined.

This fix has no effect on meta-updater.