### PR TITLE
sotauptaneclient: Make reportHwInfo smarter

### DIFF
--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -186,7 +186,11 @@ data::InstallationResult SotaUptaneClient::PackageInstallSetResult(const Uptane:
 void SotaUptaneClient::reportHwInfo() {
   Json::Value hw_info = Utils::getHardwareInfo();
   if (!hw_info.empty()) {
-    http->put(config.tls.server + "/system_info", hw_info);
+    if (hw_info != last_hw_info_reported) {
+      if (http->put(config.tls.server + "/system_info", hw_info).isOk()) {
+        last_hw_info_reported = hw_info;
+      }
+    }
   } else {
     LOG_WARNING << "Unable to fetch hardware information from host system.";
   }

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -151,6 +151,7 @@ class SotaUptaneClient {
   std::shared_ptr<Bootloader> bootloader;
   std::shared_ptr<ReportQueue> report_queue;
   Json::Value last_network_info_reported;
+  Json::Value last_hw_info_reported;
   Uptane::EcuMap hw_ids;
   std::shared_ptr<event::Channel> events_channel;
   boost::signals2::connection conn;


### PR DESCRIPTION
Make the reportHwInfo call be like reportNetworkInfo and only send
things when they've changed.

Signed-off-by: Andy Doan <andy@foundries.io>