### PR TITLE
dockerappmanager: Handle removed apps

### DIFF
--- a/src/libaktualizr/package_manager/docker_fake.sh
+++ b/src/libaktualizr/package_manager/docker_fake.sh
@@ -30,5 +30,10 @@ if [ "$1" = "up" ] ; then
   fi
   exit 0
 fi
+if [ "$1" = "down" ] ; then
+  echo "Fake downing the docker-app in $(pwd)"
+  touch ../docker-compose-down-called
+  exit 0
+fi
 echo "Unknown command: $*"
 exit 1

--- a/src/libaktualizr/package_manager/dockerappmanager.h
+++ b/src/libaktualizr/package_manager/dockerappmanager.h
@@ -21,6 +21,7 @@ class DockerAppManager : public OstreeManager {
 
  private:
   bool iterate_apps(const Uptane::Target &target, const DockerAppCb &cb) const;
+  void handleRemovedApps() const;
 
   // iterate_apps needs an Uptane::Fetcher. However, its an unused parameter
   // and we just need to construct a dummy one to make the compiler happy.

--- a/src/libaktualizr/package_manager/packagemanagerconfig.cc
+++ b/src/libaktualizr/package_manager/packagemanagerconfig.cc
@@ -34,15 +34,15 @@ void PackageConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt
   CopyFromConfig(packages_file, "packages_file", pt);
   CopyFromConfig(fake_need_reboot, "fake_need_reboot", pt);
 #ifdef BUILD_DOCKERAPP
+  CopyFromConfig(docker_apps_root, "docker_apps_root", pt);
+  CopyFromConfig(docker_compose_bin, "docker_compose_bin", pt);
   std::string val;
   CopyFromConfig(val, "docker_apps", pt);
   if (val.length() > 0) {
     // token_compress_on allows lists like: "foo,bar", "foo, bar", or "foo bar"
     boost::split(docker_apps, val, boost::is_any_of(", "), boost::token_compress_on);
-    CopyFromConfig(docker_apps_root, "docker_apps_root", pt);
     CopyFromConfig(docker_app_params, "docker_app_params", pt);
     CopyFromConfig(docker_app_bin, "docker_app_bin", pt);
-    CopyFromConfig(docker_compose_bin, "docker_compose_bin", pt);
   }
 #endif
 }


### PR DESCRIPTION
There's a bug where:

 1) sota.toml is configured with 2 docker apps: "app1, app2"
 2) update is applied, so we are now running both app1 and app2
 3) sota.toml is updated with 1 docker app: "app1"

At this point the current logic will leave that app running forever.
This change finds apps that have been removed, stops them, and removes
them from the filesystem.

Signed-off-by: Andy Doan <andy@foundries.io>