### PR TITLE
httpclient: Expose method to update headers

### DIFF
--- a/src/libaktualizr/http/httpclient.cc
+++ b/src/libaktualizr/http/httpclient.cc
@@ -258,4 +258,20 @@ std::future<HttpResponse> HttpClient::downloadAsync(const std::string& url, curl
   return resp_future;
 }
 
+bool HttpClient::updateHeader(const std::string& name, const std::string& value) {
+  curl_slist* item = headers;
+  std::string lookfor(name + ": ");
+
+  while (item != nullptr) {
+    if (strncmp(lookfor.c_str(), item->data, lookfor.length()) == 0) {
+      free(item->data);
+      lookfor += value;
+      item->data = strdup(lookfor.c_str());
+      return true;
+    }
+    item = item->next;
+  }
+  return false;
+}
+
 // vim: set tabstop=2 shiftwidth=2 expandtab:

--- a/src/libaktualizr/http/httpclient.h
+++ b/src/libaktualizr/http/httpclient.h
@@ -41,6 +41,7 @@ class HttpClient : public HttpInterface {
                                           CurlHandler *easyp) override;
   void setCerts(const std::string &ca, CryptoSource ca_source, const std::string &cert, CryptoSource cert_source,
                 const std::string &pkey, CryptoSource pkey_source) override;
+  bool updateHeader(const std::string &name, const std::string &value);
 
  private:
   FRIEND_TEST(GetTest, download_speed_limit);

--- a/src/libaktualizr/http/httpclient_test.cc
+++ b/src/libaktualizr/http/httpclient_test.cc
@@ -100,6 +100,21 @@ TEST(HttpClient, user_agent) {
   }
 }
 
+TEST(Headers, update_header) {
+  std::vector<std::string> headers = {"Authorization: Bearer bad"};
+  HttpClient http(&headers);
+
+  ASSERT_FALSE(http.updateHeader("NOSUCHHEADER", "foo"));
+
+  std::string path = "/auth_call";
+  std::string body = http.get(server + path, HttpInterface::kNoLimit).body;
+  EXPECT_EQ(body, "{}");
+
+  ASSERT_TRUE(http.updateHeader("Authorization", "Bearer token"));
+  Json::Value response = http.get(server + path, HttpInterface::kNoLimit).getJson();
+  EXPECT_EQ(response["status"].asString(), "good");
+}
+
 // TODO: add tests for HttpClient::download
 
 #ifndef __NO_MAIN__


### PR DESCRIPTION
We have a custom client that needs to update HTTP headers after the
object has been instantiated. This shouldn't touch any current code
paths in aktualizr itself.

Signed-off-by: Andy Doan <andy@foundries.io>
Signed-off-by: Ricardo Salveti <ricardo@foundries.io>