### PR TITLE
Fix a use-after-move in Aktualizr()

### DIFF
--- a/src/libaktualizr/primary/aktualizr.cc
+++ b/src/libaktualizr/primary/aktualizr.cc
@@ -12,8 +12,8 @@
 using std::make_shared;
 using std::shared_ptr;
 
-Aktualizr::Aktualizr(Config config)
-    : Aktualizr(std::move(config), INvStorage::newStorage(config.storage), std::make_shared<HttpClient>()) {}
+Aktualizr::Aktualizr(const Config &config)
+    : Aktualizr(config, INvStorage::newStorage(config.storage), std::make_shared<HttpClient>()) {}
 
 Aktualizr::Aktualizr(Config config, std::shared_ptr<INvStorage> storage_in, std::shared_ptr<HttpInterface> http_in)
     : config_{std::move(config)}, sig_{new event::Channel()} {

--- a/src/libaktualizr/primary/aktualizr.h
+++ b/src/libaktualizr/primary/aktualizr.h
@@ -21,7 +21,7 @@ class Aktualizr {
  public:
   /** Aktualizr requires a configuration object. Examples can be found in the
    *  config directory. */
-  explicit Aktualizr(Config config);
+  explicit Aktualizr(const Config& config);
   Aktualizr(const Aktualizr&) = delete;
   Aktualizr& operator=(const Aktualizr&) = delete;
 


### PR DESCRIPTION
This worked fine on x86-64 but causes fatal issues on ARM/raspberrypi