### PR TITLE
Add ecu_version_report counter for primary

### DIFF
--- a/config/sql/migration/migrate.22.sql
+++ b/config/sql/migration/migrate.22.sql
@@ -1,0 +1,9 @@
+-- Don't modify this! Create a new migration instead--see docs/schema-migrations.adoc
+SAVEPOINT MIGRATION;
+
+CREATE TABLE ecu_report_counter(ecu_serial TEXT NOT NULL PRIMARY KEY, counter INTEGER NOT NULL DEFAULT 0);
+
+DELETE FROM version;
+INSERT INTO version VALUES(22);
+
+RELEASE MIGRATION;

--- a/config/sql/rollback/rollback.22.sql
+++ b/config/sql/rollback/rollback.22.sql
@@ -1,0 +1,9 @@
+-- Don't modify this! Create a new migration instead--see docs/schema-migrations.adoc
+SAVEPOINT ROLLBACK_MIGRATION;
+
+DROP TABLE ecu_report_counter;
+
+DELETE FROM version;
+INSERT INTO version VALUES(21);
+
+RELEASE ROLLBACK_MIGRATION;

--- a/config/sql/schema.sql
+++ b/config/sql/schema.sql
@@ -1,5 +1,5 @@
 CREATE TABLE version(version INTEGER);
-INSERT INTO version(rowid,version) VALUES(1,21);
+INSERT INTO version(rowid,version) VALUES(1,22);
 CREATE TABLE device_info(unique_mark INTEGER PRIMARY KEY CHECK (unique_mark = 0), device_id TEXT, is_registered INTEGER NOT NULL DEFAULT 0 CHECK (is_registered IN (0,1)));
 CREATE TABLE ecu_serials(id INTEGER PRIMARY KEY, serial TEXT UNIQUE, hardware_id TEXT NOT NULL, is_primary INTEGER NOT NULL DEFAULT 0 CHECK (is_primary IN (0,1)));
 CREATE TABLE misconfigured_ecus(serial TEXT UNIQUE, hardware_id TEXT NOT NULL, state INTEGER NOT NULL CHECK (state IN (0,1)));
@@ -23,3 +23,4 @@ CREATE TABLE ecu_installation_results(ecu_serial TEXT NOT NULL PRIMARY KEY, succ
 CREATE TABLE need_reboot(unique_mark INTEGER PRIMARY KEY CHECK (unique_mark = 0), flag INTEGER NOT NULL DEFAULT 0);
 CREATE TABLE rollback_migrations(version_from INT PRIMARY KEY, migration TEXT NOT NULL);
 CREATE TABLE delegations(meta BLOB NOT NULL, role_name TEXT NOT NULL, UNIQUE(role_name));
+CREATE TABLE ecu_report_counter(ecu_serial TEXT NOT NULL PRIMARY KEY, counter INTEGER NOT NULL DEFAULT 0);

--- a/src/libaktualizr/primary/initializer.h
+++ b/src/libaktualizr/primary/initializer.h
@@ -36,6 +36,7 @@ class Initializer {
   void resetTlsCreds();
   InitRetCode initEcuRegister();
   bool loadSetTlsCreds();  // TODO -> metadownloader
+  bool initEcuReportCounter();
 };
 
 #endif  // INITIALIZER_H_

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -190,6 +190,13 @@ Json::Value SotaUptaneClient::AssembleManifest() {
   Json::Value version_manifest;
 
   Json::Value primary_ecu_version = package_manager_->getManifest(primary_ecu_serial);
+  std::vector<std::pair<Uptane::EcuSerial, int64_t>> ecu_cnt;
+  if (!storage->loadEcuReportCounter(&ecu_cnt) || (ecu_cnt.size() == 0)) {
+    LOG_ERROR << "No ECU version report counter, please check the database!";
+  } else {
+    primary_ecu_version["report_counter"] = std::to_string(ecu_cnt[0].second + 1);
+    storage->saveEcuReportCounter(ecu_cnt[0].first, ecu_cnt[0].second + 1);
+  }
   version_manifest[primary_ecu_serial.ToString()] = uptane_manifest.signManifest(primary_ecu_version);
 
   for (auto it = secondaries.begin(); it != secondaries.end(); it++) {

--- a/src/libaktualizr/storage/invstorage.h
+++ b/src/libaktualizr/storage/invstorage.h
@@ -181,6 +181,9 @@ class INvStorage {
                                             std::string* correlation_id) = 0;
   virtual void clearInstallationResults() = 0;
 
+  virtual void saveEcuReportCounter(const Uptane::EcuSerial& ecu_serial, int64_t counter) = 0;
+  virtual bool loadEcuReportCounter(std::vector<std::pair<Uptane::EcuSerial, int64_t>>* results) = 0;
+
   virtual boost::optional<std::pair<size_t, std::string>> checkTargetFile(const Uptane::Target& target) const = 0;
 
   // Incremental file API

--- a/src/libaktualizr/storage/sqlstorage.h
+++ b/src/libaktualizr/storage/sqlstorage.h
@@ -80,6 +80,8 @@ class SQLStorage : public SQLStorageBase, public INvStorage {
                                      const std::string& correlation_id) override;
   bool loadDeviceInstallationResult(data::InstallationResult* result, std::string* raw_report,
                                     std::string* correlation_id) override;
+  void saveEcuReportCounter(const Uptane::EcuSerial& ecu_serial, int64_t counter) override;
+  bool loadEcuReportCounter(std::vector<std::pair<Uptane::EcuSerial, int64_t>>* results) override;
   void clearInstallationResults() override;
 
   std::unique_ptr<StorageTargetWHandle> allocateTargetFile(bool from_director, const Uptane::Target& target) override;

--- a/src/libaktualizr/uptane/uptane_test.cc
+++ b/src/libaktualizr/uptane/uptane_test.cc
@@ -155,6 +155,13 @@ TEST(Uptane, AssembleManifestGood) {
   // Manifest should not have an installation result yet.
   EXPECT_FALSE(manifest["testecuserial"]["signed"].isMember("custom"));
   EXPECT_FALSE(manifest["secondary_ecu_serial"]["signed"].isMember("custom"));
+
+  std::string counter_str = manifest["testecuserial"]["signed"]["report_counter"].asString();
+  int64_t primary_ecu_report_counter = std::stoll(counter_str);
+  Json::Value manifest2 = sota_client->AssembleManifest()["ecu_version_manifests"];
+  std::string counter_str2 = manifest2["testecuserial"]["signed"]["report_counter"].asString();
+  int64_t primary_ecu_report_counter2 = std::stoll(counter_str2);
+  EXPECT_EQ(primary_ecu_report_counter2, primary_ecu_report_counter + 1);
 }
 
 /* Bad signatures are ignored when assembling the manifest. */


### PR DESCRIPTION
According to the standard of Uptane, add counter for
ECU version report. Currently, only added for primary.
It's name in the manifest is "report_counter", in the
payload of primary ecu version report.

Signed-off-by: cheng.xiang <ext-cheng.xiang@here.com>