### PR TITLE
logging: Allow logger to use STDERR

### DIFF
--- a/src/libaktualizr/logging/default_log_sink.cc
+++ b/src/libaktualizr/logging/default_log_sink.cc
@@ -30,7 +30,11 @@ static void color_fmt(boost::log::record_view const& rec, boost::log::formatting
 }
 
 void logger_init_sink(bool use_colors = false) {
-  auto sink = boost::log::add_console_log(std::cout, boost::log::keywords::format = "%Message%",
+  auto stream = &std::cerr;
+  if (getenv("LOG_STDERR") == nullptr) {
+    stream = &std::cout;
+  }
+  auto sink = boost::log::add_console_log(*stream, boost::log::keywords::format = "%Message%",
                                           boost::log::keywords::auto_flush = true);
   if (use_colors) {
     sink->set_formatter(&color_fmt);


### PR DESCRIPTION
This allows libaktualizr to log to STDERR if LOG_STDERR is defined
in the environment. A handy way this can be used is for something
like aktualizr-get:

 LOG_STDERR=1 aktualizr-get ....

This allows you to understand what is logging (stderr's fd) and what
is the output (stdout's fd).

Signed-off-by: Andy Doan <andy@foundries.io>