### PR TITLE
Remove reference to updating the Uptane fork.

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/pages/release-process.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/release-process.adoc
@@ -71,10 +71,6 @@ The pages should be updated a few minutes after a successful release pipeline ex
 
 Once the release is ready on github, it should be edited to include a link to the changelog and doxygen documentation for that particular release. You can use a previous release as a model of how to format these links.
 
-== Update the Uptane fork of aktualizr
-
-Uptane has a fork of aktualizr in link:https://github.com/uptane/aktualizr[their namespace]. It should be updated with the same version of aktualizr used to make the new release.
-
 == Update the homebrew recipe for aktualizr
 
 The https://github.com/advancedtelematic/homebrew-otaconnect/blob/master/aktualizr.rb[homebrew aktualizr recipe] should be updated with the new release.

--- a/scripts/make_src_archive.sh
+++ b/scripts/make_src_archive.sh
@@ -11,7 +11,6 @@ python3 -m venv venv
 
 . venv/bin/activate
 
-# Use our fork which makes it easier to add extra files
 # pip install 'git_archive_all==1.19.4'
 pip install git+https://github.com/Kentzo/git-archive-all@1f7938cd6db76bfcf7eb1046ccb818df72b141ad
 


### PR DESCRIPTION
It is now done automatically by our gitlab instance, and not just on new releases!