### PR TITLE
Increase size of targets metadata file accepted

### DIFF
--- a/src/libaktualizr/uptane/fetcher.h
+++ b/src/libaktualizr/uptane/fetcher.h
@@ -11,7 +11,7 @@ constexpr int64_t kMaxRootSize = 64 * 1024;
 constexpr int64_t kMaxDirectorTargetsSize = 64 * 1024;
 constexpr int64_t kMaxTimestampSize = 64 * 1024;
 constexpr int64_t kMaxSnapshotSize = 64 * 1024;
-constexpr int64_t kMaxImagesTargetsSize = 1024 * 1024;
+constexpr int64_t kMaxImagesTargetsSize = 8 * 1024 * 1024;
 
 class IMetadataFetcher {
  public:


### PR DESCRIPTION
Updated after reading contributing guidelines.

Hey All,
I am curious what you think of this PR.

We have run into an issue where we are pushing a whole lot of images and run over the 1MB limit on the targets.json metadata file. We don't anticipate it growing much more than 1MB as we are pruning our nightly images from the previous month, but we kept having issues at the end of each month where we would bump against the limit.

Additionally, I am more than happy to learn that we are doing something stupid :) Perhaps there is a better way to handle large numbers of images???

Thanks,
Ben