### PR TITLE
Fix logging issue from bug #1477

### DIFF
--- a/src/libaktualizr/package_manager/dockerappmanager.h
+++ b/src/libaktualizr/package_manager/dockerappmanager.h
@@ -11,7 +11,7 @@ class DockerAppManager : public OstreeManager {
   DockerAppManager(PackageConfig pconfig, BootloaderConfig bconfig, std::shared_ptr<INvStorage> storage,
                    std::shared_ptr<HttpInterface> http)
       : OstreeManager(std::move(pconfig), std::move(bconfig), std::move(storage), std::move(http)) {
-    fake_fetcher_ = std::make_shared<Uptane::Fetcher>(Config(), http_);
+    fake_fetcher_ = std::make_shared<Uptane::Fetcher>("", "", http_);
   }
   bool fetchTarget(const Uptane::Target &target, Uptane::Fetcher &fetcher, const KeyManager &keys,
                    FetcherProgressCb progress_cb, const api::FlowControlToken *token) override;

--- a/src/libaktualizr/uptane/fetcher.cc
+++ b/src/libaktualizr/uptane/fetcher.cc
@@ -5,7 +5,7 @@ namespace Uptane {
 bool Fetcher::fetchRole(std::string* result, int64_t maxsize, RepositoryType repo, const Uptane::Role& role,
                         Version version) const {
   // TODO: chain-loading root.json
-  std::string url = (repo == RepositoryType::Director()) ? config.uptane.director_server : config.uptane.repo_server;
+  std::string url = (repo == RepositoryType::Director()) ? director_server : repo_server;
   if (role.IsDelegation()) {
     url += "/delegations";
   }

--- a/src/libaktualizr/uptane/fetcher.h
+++ b/src/libaktualizr/uptane/fetcher.h
@@ -32,7 +32,11 @@ class IMetadataFetcher {
 class Fetcher : public IMetadataFetcher {
  public:
   Fetcher(const Config& config_in, std::shared_ptr<HttpInterface> http_in)
-      : http(std::move(http_in)), config(config_in) {}
+      : Fetcher(config_in.uptane.repo_server, config_in.uptane.director_server, std::move(http_in)) {}
+  Fetcher(std::string repo_server_in, std::string director_server_in, std::shared_ptr<HttpInterface> http_in)
+      : http(std::move(http_in)),
+        repo_server(std::move(repo_server_in)),
+        director_server(std::move(director_server_in)) {}
   bool fetchRole(std::string* result, int64_t maxsize, RepositoryType repo, const Uptane::Role& role,
                  Version version) const override;
   bool fetchLatestRole(std::string* result, int64_t maxsize, RepositoryType repo,
@@ -40,11 +44,12 @@ class Fetcher : public IMetadataFetcher {
     return fetchRole(result, maxsize, repo, role, Version());
   }
 
-  std::string getRepoServer() const { return config.uptane.repo_server; }
+  std::string getRepoServer() const { return repo_server; }
 
  private:
   std::shared_ptr<HttpInterface> http;
-  const Config& config;
+  std::string repo_server;
+  std::string director_server;
 };
 
 }  // namespace Uptane


### PR DESCRIPTION
This is subtle so I'm keeping what's really two changes as one commit:

The issue is that DockerAppManger's constructor needs to create a
"fake fetcher" that's not really used but required for constructing
member variables and they don't have access to the global Config. Only
the PackageManagerConfig. Calling the `Config` default constructor
results in a call to `postUpdateValues` that then calls
`logger_set_threshold` with the default logging level, INFO.

This commit updates the Fetch constructor to only use the values that
it needs from the globabl config: repo-server and director-server. The
DockerAppMgr constructor then doesn't to create a fake global config.

Signed-off-by: Andy Doan <andy@foundries.io>