### PR TITLE
DOCS: Fix wonky column widths in secondary bitbake guide

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/pages/posix-secondaries-bitbaking.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/posix-secondaries-bitbaking.adoc
@@ -31,7 +31,7 @@ bitbake primary-image
 ....
 
 .Primary configuration variables
-[cols="1,1,10"]
+[%autowidth.stretch]
 |===
 |Name |Default |Description
 
@@ -63,7 +63,7 @@ bitbake secondary-image
 ....
 
 .Secondary configuration variables
-[cols="1,1,10"]
+[%autowidth.stretch]
 |===
 |Name |Default |Description
 
@@ -103,7 +103,7 @@ The following is specifics of building such images targeting RPi.
 By default ethernet NIC is used which implies that Raspberry Pi is connected to LAN with an access to Internet. To use WiFi NIC the following configuration variables should be defined in your local configuration (local.conf):
 
 .WiFi configuration variables
-[cols="1,7,10"]
+[%autowidth.stretch]
 |===
 |Name |Default |Description
 


### PR DESCRIPTION
The tables on the [secondary bitbaking page](https://docs.ota.here.com/ota-client/latest/posix-secondaries-bitbaking.html) were pretty ugly and awful; this more-or-less fixes the column formatting.