### PR TITLE
Require OpenSSL >= 1.0.2 explicitly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ endif()
 
 find_package(Boost 1.57.0 COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
 find_package(CURL REQUIRED)
-find_package(OpenSSL REQUIRED)
+find_package(OpenSSL 1.0.2 REQUIRED)
 find_package(Threads REQUIRED)
 find_package(LibArchive REQUIRED)
 find_package(sodium REQUIRED)

--- a/README.adoc
+++ b/README.adoc
@@ -48,6 +48,7 @@ The default versions packaged in recent Debian/Ubuntu releases are generally new
 
 * cmake (>= 3.5)
 * curl (>= 7.47)
+* openssl (>= 1.0.2)
 * libboost-* (>= 1.58.0)
 * libcurl4-openssl-dev (>= 7.47)
 * libpthread-stubs0-dev (>= 0.3)


### PR DESCRIPTION
Before our code used RSA_generate_key() deprecated since 0.9.8 while checking for OpenSSL < 1.1.0
    
We also did not epxlicitly check whether OpenSSL's random number generator was properly seeded.
    
Let's make sure that library users won't generate predictable keys by accident:
    * get rid of deprecated function
    * explicitly check for random number generator state
