### PR TITLE
packagemanager: Remove running apps not defined in the Target

### DIFF
--- a/src/libaktualizr/package_manager/dockerappmanager.h
+++ b/src/libaktualizr/package_manager/dockerappmanager.h
@@ -21,7 +21,7 @@ class DockerAppManager : public OstreeManager {
 
  private:
   bool iterate_apps(const Uptane::Target &target, const DockerAppCb &cb) const;
-  void handleRemovedApps() const;
+  void handleRemovedApps(const Uptane::Target &target) const;
 
   // iterate_apps needs an Uptane::Fetcher. However, its an unused parameter
   // and we just need to construct a dummy one to make the compiler happy.

--- a/src/libaktualizr/package_manager/dockerappmanager_test.cc
+++ b/src/libaktualizr/package_manager/dockerappmanager_test.cc
@@ -61,6 +61,7 @@ TEST(DockerAppManager, DockerApp_Fetch) {
   config.pacman.sysroot = test_sysroot;
   config.pacman.docker_apps_root = temp_dir / "docker_apps";
   config.pacman.docker_apps.push_back("app1");
+  config.pacman.docker_apps.push_back("app2");
   config.pacman.docker_app_bin = config.pacman.docker_compose_bin = "src/libaktualizr/package_manager/docker_fake.sh";
   config.pacman.ostree_server = treehub_server;
   config.uptane.repo_server = repo_server + "/repo/repo";
@@ -70,6 +71,9 @@ TEST(DockerAppManager, DockerApp_Fetch) {
   // Create a fake "docker-app" that's not configured. We'll test below
   // to ensure its removed
   boost::filesystem::create_directories(config.pacman.docker_apps_root / "delete-this-app");
+  // This is app is configured, but not a part of the install Target, so
+  // it should get removed below
+  boost::filesystem::create_directories(config.pacman.docker_apps_root / "app2");
 
   std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
   KeyManager keys(storage, config.keymanagerConfig());
@@ -96,6 +100,7 @@ TEST(DockerAppManager, DockerApp_Fetch) {
 
   // Make sure the unconfigured docker app has been removed:
   ASSERT_FALSE(boost::filesystem::exists(config.pacman.docker_apps_root / "delete-this-app"));
+  ASSERT_FALSE(boost::filesystem::exists(config.pacman.docker_apps_root / "app2"));
   ASSERT_TRUE(boost::filesystem::exists(config.pacman.docker_apps_root / "docker-compose-down-called"));
 
   setenv("DOCKER_APP_FAIL", "1", 1);


### PR DESCRIPTION
The original `handleRemovedApps` method only checks apps configured
in the device's sota.toml. However, there is the case where a
Docker App could be *removed* from the installation Target. In this
case the proper action would be to remove this from the device.

Signed-off-by: Andy Doan <andy@foundries.io>