### PR TITLE
Fix import path in tests

### DIFF
--- a/tests/uptane_test_common.h
+++ b/tests/uptane_test_common.h
@@ -95,6 +95,7 @@ struct UptaneTestCommon {
     conf.provision.primary_ecu_serial = "CA:FE:A6:D2:84:9D";
     conf.provision.primary_ecu_hardware_id = "primary_hw";
     conf.storage.path = temp_dir.Path();
+    conf.import.base_path = temp_dir.Path() / "import";
     conf.tls.server = url;
     conf.bootloader.reboot_sentinel_dir = temp_dir.Path();
     UptaneTestCommon::addDefaultSecondary(conf, temp_dir, "secondary_ecu_serial", "secondary_hw");


### PR DESCRIPTION
It should not use the default which reads in /var/sota/import.

ptest has been broken since 3515a2f3a984f7cd8cd68057f1113406686363d4, as
Aktualizr's constructor will call `importData` even if given a storage
object as an argument. It ended up importing the global installed
version running on the embedded system.

Before that, tests were side-stepping the import step, so the issue was
never revealed.