### PR TITLE
sqlite utils fix an issue with reading blob-data

### DIFF
--- a/src/libaktualizr/storage/sql_utils.h
+++ b/src/libaktualizr/storage/sql_utils.h
@@ -54,7 +54,8 @@ class SQLiteStatement {
     if (b == nullptr) {
       return boost::none;
     }
-    return std::string(b);
+    auto length = static_cast<size_t>(sqlite3_column_bytes(stmt_.get(), iCol));
+    return std::string(b, length);
   }
 
   inline boost::optional<std::string> get_result_col_str(int iCol) {


### PR DESCRIPTION
Signed-off-by: Kostiantyn Bushko <kbushko@intellias.com>

Since a blob-data may contain null terminator, we have to explicitly specify the size of bytes sequence for the string.
