### PR TITLE
Don't fetch Snapshot or Targets metadata if we already have the latest.

### DIFF
--- a/src/libaktualizr/primary/CMakeLists.txt
+++ b/src/libaktualizr/primary/CMakeLists.txt
@@ -44,6 +44,9 @@ target_link_libraries(t_custom_url virtual_secondary)
 add_aktualizr_test(NAME target_mismatch SOURCES target_mismatch_test.cc PROJECT_WORKING_DIRECTORY
                    ARGS "$<TARGET_FILE:uptane-generator>" LIBRARIES uptane_generator_lib)
 target_link_libraries(t_target_mismatch virtual_secondary)
+add_aktualizr_test(NAME metadata_fetch SOURCES metadata_fetch_test.cc PROJECT_WORKING_DIRECTORY
+                   ARGS "$<TARGET_FILE:uptane-generator>" LIBRARIES uptane_generator_lib)
+target_link_libraries(t_metadata_fetch virtual_secondary)
 
 add_aktualizr_test(NAME device_cred_prov SOURCES device_cred_prov_test.cc PROJECT_WORKING_DIRECTORY LIBRARIES PUBLIC uptane_generator_lib)
 set_tests_properties(test_device_cred_prov PROPERTIES LABELS "crypto")

--- a/src/libaktualizr/primary/metadata_fetch_test.cc
+++ b/src/libaktualizr/primary/metadata_fetch_test.cc
@@ -1,0 +1,162 @@
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "httpfake.h"
+#include "primary/aktualizr.h"
+#include "test_utils.h"
+#include "uptane_test_common.h"
+
+boost::filesystem::path uptane_generator_path;
+
+class HttpFakeMetaCounter : public HttpFake {
+ public:
+  HttpFakeMetaCounter(const boost::filesystem::path &test_dir_in, const boost::filesystem::path &meta_dir_in)
+      : HttpFake(test_dir_in, "", meta_dir_in) {}
+
+  HttpResponse get(const std::string &url, int64_t maxsize) override {
+    if (url.find("director/1.root.json") != std::string::npos) {
+      ++director_1root_count;
+    }
+    if (url.find("director/2.root.json") != std::string::npos) {
+      ++director_2root_count;
+    }
+    if (url.find("director/targets.json") != std::string::npos) {
+      ++director_targets_count;
+    }
+    if (url.find("repo/1.root.json") != std::string::npos) {
+      ++images_1root_count;
+    }
+    if (url.find("repo/2.root.json") != std::string::npos) {
+      ++images_2root_count;
+    }
+    if (url.find("repo/timestamp.json") != std::string::npos) {
+      ++images_timestamp_count;
+    }
+    if (url.find("repo/snapshot.json") != std::string::npos) {
+      ++images_snapshot_count;
+    }
+    if (url.find("repo/targets.json") != std::string::npos) {
+      ++images_targets_count;
+    }
+
+    return HttpFake::get(url, maxsize);
+  }
+
+  int director_1root_count{0};
+  int director_2root_count{0};
+  int director_targets_count{0};
+  int images_1root_count{0};
+  int images_2root_count{0};
+  int images_timestamp_count{0};
+  int images_snapshot_count{0};
+  int images_targets_count{0};
+};
+
+/*
+ * Don't download Image repo metadata if Director reports no new targets. Don't
+ * download Snapshot and Targets metadata from the Image repo if the Timestamp
+ * indicates nothing has changed.
+ */
+TEST(Aktualizr, MetadataFetch) {
+  TemporaryDirectory temp_dir;
+  TemporaryDirectory meta_dir;
+  auto http = std::make_shared<HttpFakeMetaCounter>(temp_dir.Path(), meta_dir.Path() / "repo");
+  Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
+  logger_set_threshold(boost::log::trivial::trace);
+
+  auto storage = INvStorage::newStorage(conf.storage);
+  UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
+  aktualizr.Initialize();
+
+  // No updates scheduled: only download Director Root and Targets metadata.
+  Process uptane_gen(uptane_generator_path.string());
+  uptane_gen.run({"generate", "--path", meta_dir.PathString()});
+
+  result::UpdateCheck update_result = aktualizr.CheckUpdates().get();
+  EXPECT_EQ(update_result.status, result::UpdateStatus::kNoUpdatesAvailable);
+  EXPECT_EQ(http->director_1root_count, 1);
+  EXPECT_EQ(http->director_2root_count, 1);
+  EXPECT_EQ(http->director_targets_count, 1);
+  EXPECT_EQ(http->images_1root_count, 0);
+  EXPECT_EQ(http->images_2root_count, 0);
+  EXPECT_EQ(http->images_timestamp_count, 0);
+  EXPECT_EQ(http->images_snapshot_count, 0);
+  EXPECT_EQ(http->images_targets_count, 0);
+
+  // Two images added, but only one update scheduled: all metadata objects
+  // should be fetched once.
+  uptane_gen.run({"image", "--path", meta_dir.PathString(), "--filename", "tests/test_data/firmware.txt",
+                  "--targetname", "firmware.txt", "--hwid", "primary_hw"});
+  uptane_gen.run({"image", "--path", meta_dir.PathString(), "--filename", "tests/test_data/firmware_name.txt",
+                  "--targetname", "firmware_name.txt", "--hwid", "primary_hw"});
+  uptane_gen.run({"addtarget", "--path", meta_dir.PathString(), "--targetname", "firmware.txt", "--hwid", "primary_hw",
+                  "--serial", "CA:FE:A6:D2:84:9D"});
+  uptane_gen.run({"adddelegation", "--path", meta_dir.PathString(), "--dname", "role-abc", "--dpattern", "abc/*"});
+  uptane_gen.run({"signtargets", "--path", meta_dir.PathString()});
+
+  update_result = aktualizr.CheckUpdates().get();
+  EXPECT_EQ(update_result.status, result::UpdateStatus::kUpdatesAvailable);
+  EXPECT_EQ(http->director_1root_count, 1);
+  EXPECT_EQ(http->director_2root_count, 2);
+  EXPECT_EQ(http->director_targets_count, 2);
+  EXPECT_EQ(http->images_1root_count, 1);
+  EXPECT_EQ(http->images_2root_count, 1);
+  EXPECT_EQ(http->images_timestamp_count, 1);
+  EXPECT_EQ(http->images_snapshot_count, 1);
+  EXPECT_EQ(http->images_targets_count, 1);
+
+  // Update scheduled with pre-existing image: no need to refetch Image repo
+  // Snapshot or Targets metadata.
+  uptane_gen.run({"addtarget", "--path", meta_dir.PathString(), "--targetname", "firmware_name.txt", "--hwid",
+                  "primary_hw", "--serial", "CA:FE:A6:D2:84:9D"});
+  uptane_gen.run({"signtargets", "--path", meta_dir.PathString()});
+
+  update_result = aktualizr.CheckUpdates().get();
+  EXPECT_EQ(update_result.status, result::UpdateStatus::kUpdatesAvailable);
+  EXPECT_EQ(http->director_1root_count, 1);
+  EXPECT_EQ(http->director_2root_count, 3);
+  EXPECT_EQ(http->director_targets_count, 3);
+  EXPECT_EQ(http->images_1root_count, 1);
+  EXPECT_EQ(http->images_2root_count, 2);
+  EXPECT_EQ(http->images_timestamp_count, 2);
+  EXPECT_EQ(http->images_snapshot_count, 1);
+  EXPECT_EQ(http->images_targets_count, 1);
+
+  // Delegation added to an existing delegation; update scheduled with
+  // pre-existing image: Snapshot must be refetched, but Targets are unchanged.
+  uptane_gen.run({"addtarget", "--path", meta_dir.PathString(), "--targetname", "firmware.txt", "--hwid", "primary_hw",
+                  "--serial", "CA:FE:A6:D2:84:9D"});
+  uptane_gen.run({"adddelegation", "--path", meta_dir.PathString(), "--dname", "role-def", "--dpattern", "def/*",
+                  "--dparent", "role-abc"});
+  uptane_gen.run({"signtargets", "--path", meta_dir.PathString()});
+
+  update_result = aktualizr.CheckUpdates().get();
+  EXPECT_EQ(update_result.status, result::UpdateStatus::kUpdatesAvailable);
+  EXPECT_EQ(http->director_1root_count, 1);
+  EXPECT_EQ(http->director_2root_count, 4);
+  EXPECT_EQ(http->director_targets_count, 4);
+  EXPECT_EQ(http->images_1root_count, 1);
+  EXPECT_EQ(http->images_2root_count, 3);
+  EXPECT_EQ(http->images_timestamp_count, 3);
+  EXPECT_EQ(http->images_snapshot_count, 2);
+  EXPECT_EQ(http->images_targets_count, 1);
+}
+
+#ifndef __NO_MAIN__
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  if (argc != 2) {
+    std::cerr << "Error: " << argv[0] << " requires the path to the uptane-generator utility\n";
+    return EXIT_FAILURE;
+  }
+  uptane_generator_path = argv[1];
+
+  logger_init();
+  logger_set_threshold(boost::log::trivial::trace);
+
+  return RUN_ALL_TESTS();
+}
+#endif
+
+// vim: set tabstop=2 shiftwidth=2 expandtab:

--- a/src/libaktualizr/uptane/imagesrepository.h
+++ b/src/libaktualizr/uptane/imagesrepository.h
@@ -40,6 +40,9 @@ class ImagesRepository : public RepositoryCommon {
   bool updateMeta(INvStorage& storage, const IMetadataFetcher& fetcher) override;
 
  private:
+  bool fetchSnapshot(INvStorage& storage, const IMetadataFetcher& fetcher, int local_version);
+  bool fetchTargets(INvStorage& storage, const IMetadataFetcher& fetcher, int local_version);
+
   std::shared_ptr<Uptane::Targets> targets;
   Uptane::TimestampMeta timestamp;
   Uptane::Snapshot snapshot;


### PR DESCRIPTION
Also test that we don't fetch anything from the Image repo if the Director does not indicate that there are updates.

~~This should probably wait until https://github.com/advancedtelematic/aktualizr/pull/1501 is merged, since that will change how root metadata is fetched.~~

I did some manual testing to verify that the bandwidth savings are real. Note that my account has a rather large `targets.json` in the Image repo, so this demonstrates it well. I did a rather naive comparison by counting the bytes dumped to the log for each server response. (This is flawed for many reasons but should still give a reasonable idea of the benefit.) I did this three times: once for initialization (no updates, only Director metadata fetched), again for an update (all metadata fetched), and a third time for a second, pre-existing update (all metadata fetched on master, but with this PR, the Snapshot and Targets from the Image repo are skipped).

On current master:
```
$ grep "response:" dump_init.txt | wc -c
34
$ grep "response:" dump_first.txt | wc -c
190934
$ grep "response:" dump_second.txt | wc -c
184349
```

With these changes:
```
$ grep "response:" dump_init.txt | wc -c
34
$ grep "response:" dump_first.txt | wc -c
190934
$ grep "response:" dump_second.txt | wc -c
8419
```

FYI @doanac this hopefully helps address https://github.com/advancedtelematic/aktualizr/issues/1446.