### PR TITLE
Switch to dynamic libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,7 +387,7 @@ if(hasParent)
     set (AKTUALIZR_EXTERNAL_LIBS ${AKTUALIZR_EXTERNAL_LIBS} PARENT_SCOPE)
 endif()
 
-set (TEST_LIBS ${AKTUALIZR_EXTERNAL_LIBS} gtest gmock)
+set (TEST_LIBS gtest gmock)
 if(BUILD_WITH_CODE_COVERAGE)
     set(COVERAGE_LCOV_EXCLUDES '/usr/include/*' ${CMAKE_BINARY_DIR}'*' ${CMAKE_SOURCE_DIR}'/third_party/*' ${CMAKE_SOURCE_DIR}'/tests/*' '*_test.cc')
     include(CodeCoverage)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,7 +387,7 @@ if(hasParent)
     set (AKTUALIZR_EXTERNAL_LIBS ${AKTUALIZR_EXTERNAL_LIBS} PARENT_SCOPE)
 endif()
 
-set (TEST_LIBS gtest gmock)
+set (TEST_LIBS gtest gmock aktualizr_lib)
 if(BUILD_WITH_CODE_COVERAGE)
     set(COVERAGE_LCOV_EXCLUDES '/usr/include/*' ${CMAKE_BINARY_DIR}'*' ${CMAKE_SOURCE_DIR}'/third_party/*' ${CMAKE_SOURCE_DIR}'/tests/*' '*_test.cc')
     include(CodeCoverage)

--- a/cmake-modules/AddAktualizrTest.cmake
+++ b/cmake-modules/AddAktualizrTest.cmake
@@ -7,7 +7,6 @@ function(add_aktualizr_test)
     add_executable(${TEST_TARGET} EXCLUDE_FROM_ALL ${AKTUALIZR_TEST_SOURCES} ${PROJECT_SOURCE_DIR}/tests/test_utils.cc)
     target_link_libraries(${TEST_TARGET}
         ${AKTUALIZR_TEST_LIBRARIES}
-        aktualizr_lib
         ${TEST_LIBS})
     target_include_directories(${TEST_TARGET} PUBLIC ${PROJECT_SOURCE_DIR}/tests)
 

--- a/cmake-modules/AddAktualizrTest.cmake
+++ b/cmake-modules/AddAktualizrTest.cmake
@@ -7,7 +7,7 @@ function(add_aktualizr_test)
     add_executable(${TEST_TARGET} EXCLUDE_FROM_ALL ${AKTUALIZR_TEST_SOURCES} ${PROJECT_SOURCE_DIR}/tests/test_utils.cc)
     target_link_libraries(${TEST_TARGET}
         ${AKTUALIZR_TEST_LIBRARIES}
-        aktualizr_static_lib
+        aktualizr_lib
         ${TEST_LIBS})
     target_include_directories(${TEST_TARGET} PUBLIC ${PROJECT_SOURCE_DIR}/tests)
 

--- a/docs/ota-client-guide/modules/ROOT/pages/libaktualizr-getstarted.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/libaktualizr-getstarted.adoc
@@ -48,7 +48,7 @@ make
 
 NOTE: The `--recursive` flag in the `git clone` command is needed to recursively clone all the *git submodules*.
 
-After the build is finished, you'll find the client library at the following location: `$\{PROJECT_ROOT}/build/src/libaktualizr/libaktualizr_static_lib.a`.
+After the build is finished, you'll find the client library at the following location: `$\{PROJECT_ROOT}/build/src/libaktualizr/libaktualizr_lib.so`.
 
 == Integrating libaktualizr into your application
 
@@ -75,12 +75,18 @@ $ git clone --recursive https://github.com/advancedtelematic/aktualizr.git
 add_subdirectory(aktualizr)
 ----
 +
-This command automatically adds the needed entries to `INCLUDE_DIRECTORIES` variable, create the `AKTUALIZR_EXTERNAL_LIBS` variable, which contains the list of external libraries required for linking with libaktualizr, and create the `aktualizr_static_lib` target.
+This command automatically adds the needed entries to `INCLUDE_DIRECTORIES` variable, create the `AKTUALIZR_EXTERNAL_LIBS` variable, which contains the list of external libraries required for linking with libaktualizr, and create the `aktualizr_static_lib` and `aktualizr_lib` targets.
 . Do a test build of your application
 +
 Whenever you build your application you must add these libraries as follows:
 +
 [source,cmake]
+target_link_libraries(your-app aktualizr_lib)
++
+Or:
++
+[source,cmake]
+# DEPRECATED!
 target_link_libraries(your-app aktualizr_static_lib ${AKTUALIZR_EXTERNAL_LIBS})
 +
 You also might need to add the following line if you are using boost libraries:
@@ -93,7 +99,7 @@ If you don't want to make libaktualizr part of your cmake project, it's also pos
 Here's an example of how to specify the required libraries for an out-of-tree build in cmake project:
 [source,cmake]
 ----
-target_link_libraries(your-app ${AKTUALIZR_PROJECT_DIR}/build/src/libaktualizr/libaktualizr_static_lib.a)
+target_link_libraries(your-app aktualizr_lib)
 target_link_libraries(your-app pthread)
 target_link_libraries(your-app archive)
 target_link_libraries(your-app boost_atomic)

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -6,7 +6,7 @@ if (ENABLE_FUZZING)
     endif()
 
     add_executable(afl afl.cc)
-    target_link_libraries(afl aktualizr_static_lib ${AKTUALIZR_EXTERNAL_LIBS})
+    target_link_libraries(afl aktualizr_lib)
 
     if (NOT ENABLE_SANITIZERS)
         message(FATAL_ERROR "Enable sanitizers with -DENABLE_SANITIZERS=On to do fuzzing.")

--- a/src/aktualizr_get/CMakeLists.txt
+++ b/src/aktualizr_get/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 add_executable(aktualizr-get main.cc get.cc)
-target_link_libraries(aktualizr-get aktualizr_static_lib ${AKTUALIZR_EXTERNAL_LIBS})
+target_link_libraries(aktualizr-get aktualizr_lib)
 
 install(TARGETS aktualizr-get RUNTIME DESTINATION bin COMPONENT aktualizr-get)
 

--- a/src/aktualizr_info/CMakeLists.txt
+++ b/src/aktualizr_info/CMakeLists.txt
@@ -3,7 +3,7 @@ set(AKTUALIZR_INFO_SRC main.cc aktualizr_info_config.cc)
 set(AKTUALIZR_INFO_HEADERS aktualizr_info_config.h)
 
 add_executable(aktualizr-info ${AKTUALIZR_INFO_SRC})
-target_link_libraries(aktualizr-info aktualizr_static_lib ${AKTUALIZR_EXTERNAL_LIBS})
+target_link_libraries(aktualizr-info aktualizr_lib)
 
 
 install(TARGETS aktualizr-info

--- a/src/aktualizr_lite/CMakeLists.txt
+++ b/src/aktualizr_lite/CMakeLists.txt
@@ -3,7 +3,7 @@ set(AKTUALIZR_LITE_HEADERS helpers.h)
 
 if(BUILD_OSTREE)
 add_executable(aktualizr-lite ${AKTUALIZR_LITE_SRC})
-target_link_libraries(aktualizr-lite aktualizr_static_lib ${AKTUALIZR_EXTERNAL_LIBS})
+target_link_libraries(aktualizr-lite aktualizr_lib)
 
 install(TARGETS aktualizr-lite RUNTIME DESTINATION bin COMPONENT aktualizr-lite)
 

--- a/src/aktualizr_primary/CMakeLists.txt
+++ b/src/aktualizr_primary/CMakeLists.txt
@@ -1,8 +1,8 @@
 set(TARGET aktualizr)
 set(SOURCES main.cc secondary_config.h secondary_config.cc secondary.h secondary.cc)
 
-add_executable(${TARGET} ${SOURCES})
-target_link_libraries(${TARGET} aktualizr_static_lib aktualizr-posix virtual_secondary ${AKTUALIZR_EXTERNAL_LIBS})
+add_executable(${TARGET} ${SOURCES} $<TARGET_OBJECTS:aktualizr-posix>)
+target_link_libraries(${TARGET} aktualizr_lib virtual_secondary)
 target_include_directories(${TARGET} PUBLIC
   ${PROJECT_SOURCE_DIR}/src/libaktualizr-posix
   ${PROJECT_SOURCE_DIR}/third_party)

--- a/src/aktualizr_secondary/CMakeLists.txt
+++ b/src/aktualizr_secondary/CMakeLists.txt
@@ -8,6 +8,9 @@ set(AKTUALIZR_SECONDARY_LIB_SRC
     socket_server.cc
     )
 
+# do not link tests with libaktualizr
+list(REMOVE_ITEM TEST_LIBS aktualizr_lib)
+
 # TODO: a lot of these should be removed
 add_library(aktualizr_secondary_lib SHARED
     ${AKTUALIZR_SECONDARY_LIB_SRC}
@@ -57,27 +60,27 @@ include(AddAktualizrTest)
 list(INSERT TEST_LIBS 0 aktualizr_secondary_lib)
 
 add_aktualizr_test(NAME aktualizr_secondary_config
-                   SOURCES aktualizr_secondary_config_test.cc PROJECT_WORKING_DIRECTORY)
+    SOURCES aktualizr_secondary_config_test.cc PROJECT_WORKING_DIRECTORY LIBRARIES aktualizr_secondary_lib)
 
 add_aktualizr_test(NAME aktualizr_secondary_update
                    SOURCES update_test.cc
-                   ARGS ${PROJECT_BINARY_DIR}/ostree_repo PROJECT_WORKING_DIRECTORY)
+                   ARGS ${PROJECT_BINARY_DIR}/ostree_repo
+                   PROJECT_WORKING_DIRECTORY LIBRARIES aktualizr_secondary_lib)
 
 if(BUILD_OSTREE)
     add_aktualizr_test(NAME aktualizr_secondary_uptane_verification
                        SOURCES uptane_verification_test.cc
                        ARGS ${PROJECT_BINARY_DIR}/ostree_repo
-                       PROJECT_WORKING_DIRECTORY)
+                       LIBRARIES aktualizr_secondary_lib uptane_generator_lib $<TARGET_OBJECTS:campaign>
+                       PROJECT_WORKING_DIRECTORY )
 
     set_target_properties(t_aktualizr_secondary_uptane_verification PROPERTIES LINK_FLAGS -Wl,--export-dynamic)
     target_link_libraries(t_aktualizr_secondary_uptane_verification aktualizr_secondary_lib uptane_generator_lib)
 
     add_aktualizr_test(NAME aktualizr_secondary_uptane
                        SOURCES uptane_test.cc
-                       LIBRARIES uptane_generator_lib
-                       LIBRARIES aktualizr-posix
+                       LIBRARIES aktualizr_secondary_lib uptane_generator_lib virtual_secondary $<TARGET_OBJECTS:campaign> $<TARGET_OBJECTS:primary> $<TARGET_OBJECTS:http>
                        ARGS ${PROJECT_BINARY_DIR}/ostree_repo PROJECT_WORKING_DIRECTORY)
-    target_link_libraries(t_aktualizr_secondary_uptane virtual_secondary)
 else(BUILD_OSTREE)
     list(APPEND TEST_SOURCES uptane_verification_test.cc uptane_test.cc)
 endif(BUILD_OSTREE)

--- a/src/aktualizr_secondary/CMakeLists.txt
+++ b/src/aktualizr_secondary/CMakeLists.txt
@@ -53,19 +53,19 @@ list(INSERT TEST_LIBS 0 aktualizr_secondary_static_lib)
 add_aktualizr_test(NAME aktualizr_secondary_config
                    SOURCES aktualizr_secondary_config_test.cc PROJECT_WORKING_DIRECTORY)
 
-add_aktualizr_test(NAME aktualizr_secondary_uptane_verification
-                   SOURCES uptane_verification_test.cc
-                   ARGS ${PROJECT_BINARY_DIR}/ostree_repo
-                   PROJECT_WORKING_DIRECTORY)
-
-set_target_properties(t_aktualizr_secondary_uptane_verification PROPERTIES LINK_FLAGS -Wl,--export-dynamic)
-target_link_libraries(t_aktualizr_secondary_uptane_verification aktualizr_secondary_static_lib uptane_generator_lib)
-
 add_aktualizr_test(NAME aktualizr_secondary_update
                    SOURCES update_test.cc
                    ARGS ${PROJECT_BINARY_DIR}/ostree_repo PROJECT_WORKING_DIRECTORY)
 
 if(BUILD_OSTREE)
+    add_aktualizr_test(NAME aktualizr_secondary_uptane_verification
+                       SOURCES uptane_verification_test.cc
+                       ARGS ${PROJECT_BINARY_DIR}/ostree_repo
+                       PROJECT_WORKING_DIRECTORY)
+
+    set_target_properties(t_aktualizr_secondary_uptane_verification PROPERTIES LINK_FLAGS -Wl,--export-dynamic)
+    target_link_libraries(t_aktualizr_secondary_uptane_verification aktualizr_secondary_static_lib uptane_generator_lib)
+
     add_aktualizr_test(NAME aktualizr_secondary_uptane
                        SOURCES uptane_test.cc
                        LIBRARIES uptane_generator_lib
@@ -73,7 +73,7 @@ if(BUILD_OSTREE)
                        ARGS ${PROJECT_BINARY_DIR}/ostree_repo PROJECT_WORKING_DIRECTORY)
     target_link_libraries(t_aktualizr_secondary_uptane virtual_secondary)
 else(BUILD_OSTREE)
-    list(APPEND TEST_SOURCES uptane_test.cc)
+    list(APPEND TEST_SOURCES uptane_verification_test.cc uptane_test.cc)
 endif(BUILD_OSTREE)
 
 # test running the executable with command line option --help

--- a/src/aktualizr_secondary/CMakeLists.txt
+++ b/src/aktualizr_secondary/CMakeLists.txt
@@ -8,8 +8,14 @@ set(AKTUALIZR_SECONDARY_LIB_SRC
     socket_server.cc
     )
 
-add_library(aktualizr_secondary_static_lib STATIC
+# TODO: a lot of these should be removed
+add_library(aktualizr_secondary_lib SHARED
     ${AKTUALIZR_SECONDARY_LIB_SRC}
+    $<TARGET_OBJECTS:aktualizr-posix>
+    $<TARGET_OBJECTS:asn1>
+    $<TARGET_OBJECTS:asn1_lib>
+    $<TARGET_OBJECTS:bootstrap>
+    $<TARGET_OBJECTS:config>
     $<TARGET_OBJECTS:bootloader>
     $<TARGET_OBJECTS:crypto>
     $<TARGET_OBJECTS:jsoncpp>
@@ -18,19 +24,19 @@ add_library(aktualizr_secondary_static_lib STATIC
     $<TARGET_OBJECTS:storage>
     $<TARGET_OBJECTS:logging>
     $<TARGET_OBJECTS:uptane>)
-
-target_link_libraries(aktualizr_secondary_static_lib aktualizr-posix)
-
-target_include_directories(aktualizr_secondary_static_lib PUBLIC
+target_link_libraries(aktualizr_secondary_lib ${AKTUALIZR_EXTERNAL_LIBS})
+target_include_directories(aktualizr_secondary_lib PUBLIC
     $<TARGET_PROPERTY:asn1_lib,INCLUDE_DIRECTORIES>
     ${PROJECT_SOURCE_DIR}/src/libaktualizr-posix
     )
 
+if (BUILD_ISOTP)
+    target_sources(aktualizr_secondary_lib PRIVATE $<TARGET_OBJECTS:isotp_conn>)
+endif (BUILD_ISOTP)
+
 add_executable(aktualizr-secondary ${AKTUALIZR_SECONDARY_SRC})
-target_link_libraries(aktualizr-secondary
-    aktualizr_secondary_static_lib
-    ${AKTUALIZR_EXTERNAL_LIBS}
-    )
+target_link_libraries(aktualizr-secondary aktualizr_secondary_lib)
+install(TARGETS aktualizr_secondary_lib LIBRARY DESTINATION lib COMPONENT aktualizr)
 
 install(TARGETS aktualizr-secondary
         COMPONENT aktualizr
@@ -48,7 +54,7 @@ set(ALL_AKTUALIZR_SECONDARY_HEADERS
 include(AddAktualizrTest)
 
 # insert in front, so that the order matches the dependencies to the system libraries
-list(INSERT TEST_LIBS 0 aktualizr_secondary_static_lib)
+list(INSERT TEST_LIBS 0 aktualizr_secondary_lib)
 
 add_aktualizr_test(NAME aktualizr_secondary_config
                    SOURCES aktualizr_secondary_config_test.cc PROJECT_WORKING_DIRECTORY)
@@ -64,7 +70,7 @@ if(BUILD_OSTREE)
                        PROJECT_WORKING_DIRECTORY)
 
     set_target_properties(t_aktualizr_secondary_uptane_verification PROPERTIES LINK_FLAGS -Wl,--export-dynamic)
-    target_link_libraries(t_aktualizr_secondary_uptane_verification aktualizr_secondary_static_lib uptane_generator_lib)
+    target_link_libraries(t_aktualizr_secondary_uptane_verification aktualizr_secondary_lib uptane_generator_lib)
 
     add_aktualizr_test(NAME aktualizr_secondary_uptane
                        SOURCES uptane_test.cc

--- a/src/libaktualizr-posix/CMakeLists.txt
+++ b/src/libaktualizr-posix/CMakeLists.txt
@@ -4,18 +4,9 @@ set(SOURCES ipuptanesecondary.cc)
 
 set(HEADERS ipuptanesecondary.h)
 
-set(TARGET aktualizr-posix)
-
-add_library(${TARGET} STATIC
-  ${SOURCES}
-  $<TARGET_OBJECTS:asn1>
-  $<TARGET_OBJECTS:asn1_lib>
-)
+add_library(aktualizr-posix OBJECT ${SOURCES})
 
 get_property(ASN1_INCLUDE_DIRS TARGET asn1_lib PROPERTY INCLUDE_DIRECTORIES)
-target_include_directories(${TARGET} PUBLIC ${ASN1_INCLUDE_DIRS})
-
-target_link_libraries(${TARGET} aktualizr_static_lib)
-
+target_include_directories(aktualizr-posix PUBLIC ${ASN1_INCLUDE_DIRS})
 
 aktualizr_source_file_checks(${HEADERS} ${SOURCES})

--- a/src/libaktualizr/CMakeLists.txt
+++ b/src/libaktualizr/CMakeLists.txt
@@ -18,7 +18,10 @@ if(BUILD_ISOTP)
     add_subdirectory("isotp_conn")
 endif(BUILD_ISOTP)
 
+# deprecated, we recommend using aktualizr_lib
 add_library(aktualizr_static_lib STATIC
+    $<TARGET_OBJECTS:asn1>
+    $<TARGET_OBJECTS:asn1_lib>
     $<TARGET_OBJECTS:bootloader>
     $<TARGET_OBJECTS:bootstrap>
     $<TARGET_OBJECTS:campaign>
@@ -33,9 +36,26 @@ add_library(aktualizr_static_lib STATIC
     $<TARGET_OBJECTS:storage>
     $<TARGET_OBJECTS:uptane>)
 
+add_library(aktualizr_lib SHARED
+    $<TARGET_OBJECTS:asn1>
+    $<TARGET_OBJECTS:asn1_lib>
+    $<TARGET_OBJECTS:bootloader>
+    $<TARGET_OBJECTS:bootstrap>
+    $<TARGET_OBJECTS:campaign>
+    $<TARGET_OBJECTS:config>
+    $<TARGET_OBJECTS:crypto>
+    $<TARGET_OBJECTS:http>
+    $<TARGET_OBJECTS:jsoncpp>
+    $<TARGET_OBJECTS:package_manager>
+    $<TARGET_OBJECTS:primary>
+    $<TARGET_OBJECTS:utilities>
+    $<TARGET_OBJECTS:logging>
+    $<TARGET_OBJECTS:storage>
+    $<TARGET_OBJECTS:uptane>)
+target_link_libraries(aktualizr_lib ${AKTUALIZR_EXTERNAL_LIBS})
+install(TARGETS aktualizr_lib LIBRARY DESTINATION lib COMPONENT aktualizr)
+
 if (BUILD_ISOTP)
     target_sources(aktualizr_static_lib PRIVATE $<TARGET_OBJECTS:isotp_conn>)
+    target_sources(aktualizr_lib PRIVATE $<TARGET_OBJECTS:isotp_conn>)
 endif (BUILD_ISOTP)
-
-target_include_directories(aktualizr_static_lib PUBLIC
-    $<TARGET_PROPERTY:package_manager,INCLUDE_DIRECTORIES>)

--- a/src/libaktualizr/package_manager/CMakeLists.txt
+++ b/src/libaktualizr/package_manager/CMakeLists.txt
@@ -18,12 +18,9 @@ add_aktualizr_test(NAME packagemanagerfake SOURCES packagemanagerfake_test.cc LI
 if(BUILD_DEB)
     set_property(SOURCE packagemanagerfactory.cc packagemanagerfactory_test.cc PROPERTY COMPILE_DEFINITIONS BUILD_DEB)
     target_sources(package_manager PRIVATE debianmanager.cc)
-    add_executable(t_packagemanager_deb EXCLUDE_FROM_ALL debianmanager_test.cc)
-    add_dependencies(build_tests t_packagemanager_deb)
-    target_link_libraries(t_packagemanager_deb aktualizr_static_lib ${TEST_LIBS})
 
-    add_test(NAME test_packagemanager_deb COMMAND ${PROJECT_SOURCE_DIR}/tests/run_debian_tests.sh ${CMAKE_CURRENT_BINARY_DIR}/t_packagemanager_deb
-            ${PROJECT_SOURCE_DIR}/tests/test_data/fake_dpkg)
+    add_aktualizr_test(NAME debianmanager SOURCES debianmanager_test.cc)
+    set_tests_properties(test_debianmanager PROPERTIES ENVIRONMENT PATH=${PROJECT_SOURCE_DIR}/tests/test_data/fake_dpkg:$ENV{PATH})
 
 endif(BUILD_DEB)
 aktualizr_source_file_checks(debianmanager.cc debianmanager.h debianmanager_test.cc)

--- a/src/libaktualizr/storage/CMakeLists.txt
+++ b/src/libaktualizr/storage/CMakeLists.txt
@@ -24,8 +24,7 @@ target_sources(config PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/storage_config.cc)
 if(STORAGE_TYPE STREQUAL "sqlite")
   add_aktualizr_test(NAME storage_atomic SOURCES storage_atomic_test.cc PROJECT_WORKING_DIRECTORY)
   add_aktualizr_test(NAME sql_utils SOURCES sql_utils_test.cc PROJECT_WORKING_DIRECTORY)
-  add_aktualizr_test(NAME sqlstorage SOURCES sqlstorage_test.cc sql_schemas.cc
-      ARGS ${CMAKE_CURRENT_SOURCE_DIR}/test)
+  add_aktualizr_test(NAME sqlstorage SOURCES sqlstorage_test.cc ARGS ${CMAKE_CURRENT_SOURCE_DIR}/test)
   list(REMOVE_ITEM TEST_SOURCES sql_schemas.cc)
   add_aktualizr_test(NAME storage SOURCES storage_common_test.cc PROJECT_WORKING_DIRECTORY)
 

--- a/src/load_tests/CMakeLists.txt
+++ b/src/load_tests/CMakeLists.txt
@@ -13,31 +13,16 @@ if (BUILD_LOAD_TESTS)
     add_executable(ota-load-tests ${LOAD_TESTS_SRC})
 
     if (BUILD_OSTREE)
-        target_sources(ota-load-tests PUBLIC ${LT_TREEHUB_SRC})
+        target_sources(ota-load-tests PRIVATE ${LT_TREEHUB_SRC})
     endif (BUILD_OSTREE)
 
     add_dependencies(ota-load-tests aktualizr hdr_histogram)
 
-    target_include_directories(ota-load-tests PUBLIC
-            ${PROJECT_SOURCE_DIR}/third_party/HdrHistogram_c/src)
+    target_include_directories(ota-load-tests PRIVATE ${PROJECT_SOURCE_DIR}/third_party/HdrHistogram_c/src)
 
-    target_link_libraries(ota-load-tests
-            aktualizr_static_lib
-            hdr_histogram_static
-            ${Boost_LIBRARIES}
-            ${OPENSSL_LIBRARIES}
-            ${sodium_LIBRARY_RELEASE}
-            ${CMAKE_THREAD_LIBS_INIT}
-            ${CURL_LIBRARIES}
-            ${GLIB2_LIBRARIES}
-            ${LibArchive_LIBRARIES}
-            ${LIBOSTREE_LIBRARIES}
-            ${LIBP11_LIBRARIES}
-            ${SQLITE3_LIBRARIES})
+    target_link_libraries(ota-load-tests aktualizr_lib hdr_histogram_static)
 
-    install(TARGETS ota-load-tests
-            COMPONENT aktualizr
-            RUNTIME DESTINATION bin)
+    install(TARGETS ota-load-tests COMPONENT aktualizr RUNTIME DESTINATION bin)
 endif (BUILD_LOAD_TESTS)
 
 aktualizr_source_file_checks(${LOAD_TESTS_SRC} ${LT_TREEHUB_SRC})

--- a/src/sota_tools/CMakeLists.txt
+++ b/src/sota_tools/CMakeLists.txt
@@ -15,33 +15,35 @@ set(SOTA_TOOLS_LIB_SRC
     server_credentials.cc
     treehub_server.cc)
 
-if (BUILD_SOTA_TOOLS)
-    set(GARAGE_TOOLS_VERSION "${AKTUALIZR_VERSION}")
-    set_property(SOURCE garage_tools_version.cc PROPERTY COMPILE_DEFINITIONS GARAGE_TOOLS_VERSION="${GARAGE_TOOLS_VERSION}")
-    add_library(sota_tools_static_lib STATIC ${SOTA_TOOLS_LIB_SRC})
-    target_include_directories(sota_tools_static_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${PROJECT_SOURCE_DIR} ${GLIB2_INCLUDE_DIRS})
-endif (BUILD_SOTA_TOOLS)
-
-
 ##### garage-push targets
 set(GARAGE_PUSH_SRCS
     garage_push.cc)
 
-set(SOTA_TOOLS_EXTERNAL_LIBS
-    ${Boost_SYSTEM_LIBRARIES}
-    ${Boost_LIBRARIES}
-    ${JSONCPP_LIBRARIES}
-    ${CMAKE_THREAD_LIBS_INIT}
-    ${LibArchive_LIBRARIES}
-    ${CURL_LIBRARIES}
-    ${OPENSSL_LIBRARIES}
-    ${sodium_LIBRARY_RELEASE}
-    ${GLIB2_LIBRARIES})
+if (BUILD_SOTA_TOOLS)
+    set(SOTA_TOOLS_EXTERNAL_LIBS
+        ${Boost_SYSTEM_LIBRARIES}
+        ${Boost_LIBRARIES}
+        ${JSONCPP_LIBRARIES}
+        ${CMAKE_THREAD_LIBS_INIT}
+        ${LibArchive_LIBRARIES}
+        ${CURL_LIBRARIES}
+        ${OPENSSL_LIBRARIES}
+        ${sodium_LIBRARY_RELEASE}
+        ${GLIB2_LIBRARIES})
+
+    set(GARAGE_TOOLS_VERSION "${AKTUALIZR_VERSION}")
+    set_property(SOURCE garage_tools_version.cc PROPERTY COMPILE_DEFINITIONS GARAGE_TOOLS_VERSION="${GARAGE_TOOLS_VERSION}")
+    add_library(sota_tools_lib SHARED ${SOTA_TOOLS_LIB_SRC})
+    target_include_directories(sota_tools_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${PROJECT_SOURCE_DIR} ${GLIB2_INCLUDE_DIRS})
+    target_link_libraries(sota_tools_lib ${SOTA_TOOLS_EXTERNAL_LIBS})
+    install(TARGETS sota_tools_lib LIBRARY DESTINATION lib COMPONENT garage_deploy)
+endif (BUILD_SOTA_TOOLS)
+
 
 if (BUILD_SOTA_TOOLS)
     add_executable(garage-push ${GARAGE_PUSH_SRCS})
 
-    target_link_libraries(garage-push sota_tools_static_lib aktualizr_static_lib ${SOTA_TOOLS_EXTERNAL_LIBS})
+    target_link_libraries(garage-push sota_tools_lib aktualizr_lib)
 
     install(TARGETS garage-push RUNTIME DESTINATION bin COMPONENT garage_deploy)
 endif (BUILD_SOTA_TOOLS)
@@ -54,7 +56,7 @@ set(GARAGE_CHECK_SRCS
 if (BUILD_SOTA_TOOLS)
     add_executable(garage-check ${GARAGE_CHECK_SRCS})
 
-    target_link_libraries(garage-check sota_tools_static_lib aktualizr_static_lib ${SOTA_TOOLS_EXTERNAL_LIBS})
+    target_link_libraries(garage-check sota_tools_lib aktualizr_lib)
 
     install(TARGETS garage-check RUNTIME DESTINATION bin COMPONENT garage_deploy)
 endif (BUILD_SOTA_TOOLS)
@@ -66,7 +68,7 @@ set(GARAGE_DEPLOY_SRCS
 
 if (BUILD_SOTA_TOOLS)
     add_executable(garage-deploy ${GARAGE_DEPLOY_SRCS})
-    target_link_libraries(garage-deploy sota_tools_static_lib aktualizr_static_lib ${SOTA_TOOLS_EXTERNAL_LIBS})
+    target_link_libraries(garage-deploy sota_tools_lib aktualizr_lib)
 
     add_dependencies(build_tests garage-deploy)
 
@@ -139,42 +141,42 @@ if (BUILD_SOTA_TOOLS)
     ### common tests
     add_aktualizr_test(NAME sota_tools_auth_test
                        SOURCES authenticate_test.cc
-                       LIBRARIES sota_tools_static_lib aktualizr_static_lib
+                       LIBRARIES sota_tools_lib
                        PROJECT_WORKING_DIRECTORY
                        ARGS ${PROJECT_BINARY_DIR}/sota_tools/certs)
     add_dependencies(t_sota_tools_auth_test sota_tools_cert_generation)
 
     add_aktualizr_test(NAME ostree_hash
-                       LIBRARIES sota_tools_static_lib
+                       LIBRARIES sota_tools_lib
                        SOURCES ostree_hash_test.cc)
 
     add_aktualizr_test(NAME rate_controller
-                       LIBRARIES sota_tools_static_lib
+                       LIBRARIES sota_tools_lib
                        SOURCES rate_controller_test.cc)
 
     add_aktualizr_test(NAME ostree_dir_repo
                        SOURCES ostree_dir_repo_test.cc
-                       LIBRARIES sota_tools_static_lib
+                       LIBRARIES sota_tools_lib
                        PROJECT_WORKING_DIRECTORY)
 
     add_aktualizr_test(NAME ostree_http_repo
                        SOURCES ostree_http_repo_test.cc
-                       LIBRARIES sota_tools_static_lib
+                       LIBRARIES sota_tools_lib
                        PROJECT_WORKING_DIRECTORY)
 
     add_aktualizr_test(NAME treehub_server
                        SOURCES treehub_server_test.cc
-                       LIBRARIES sota_tools_static_lib
+                       LIBRARIES sota_tools_lib
                        PROJECT_WORKING_DIRECTORY)
 
     add_aktualizr_test(NAME deploy
                        SOURCES deploy_test.cc
-                       LIBRARIES sota_tools_static_lib
+                       LIBRARIES sota_tools_lib
                        PROJECT_WORKING_DIRECTORY)
 
     add_aktualizr_test(NAME ostree_object
                        SOURCES ostree_object_test.cc
-                       LIBRARIES sota_tools_static_lib
+                       LIBRARIES sota_tools_lib
                        PROJECT_WORKING_DIRECTORY)
 
     ### garage-check tests

--- a/src/sota_tools/CMakeLists.txt
+++ b/src/sota_tools/CMakeLists.txt
@@ -35,15 +35,13 @@ if (BUILD_SOTA_TOOLS)
     set_property(SOURCE garage_tools_version.cc PROPERTY COMPILE_DEFINITIONS GARAGE_TOOLS_VERSION="${GARAGE_TOOLS_VERSION}")
     add_library(sota_tools_lib SHARED ${SOTA_TOOLS_LIB_SRC})
     target_include_directories(sota_tools_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${PROJECT_SOURCE_DIR} ${GLIB2_INCLUDE_DIRS})
-    target_link_libraries(sota_tools_lib ${SOTA_TOOLS_EXTERNAL_LIBS})
+
+    # we link with aktualizr static lib here, to bundle everything in sota_tools_lib
+    target_link_libraries(sota_tools_lib aktualizr_static_lib ${SOTA_TOOLS_EXTERNAL_LIBS})
     install(TARGETS sota_tools_lib LIBRARY DESTINATION lib COMPONENT garage_deploy)
-endif (BUILD_SOTA_TOOLS)
 
-
-if (BUILD_SOTA_TOOLS)
     add_executable(garage-push ${GARAGE_PUSH_SRCS})
-
-    target_link_libraries(garage-push sota_tools_lib aktualizr_lib)
+    target_link_libraries(garage-push sota_tools_lib)
 
     install(TARGETS garage-push RUNTIME DESTINATION bin COMPONENT garage_deploy)
 endif (BUILD_SOTA_TOOLS)
@@ -56,7 +54,7 @@ set(GARAGE_CHECK_SRCS
 if (BUILD_SOTA_TOOLS)
     add_executable(garage-check ${GARAGE_CHECK_SRCS})
 
-    target_link_libraries(garage-check sota_tools_lib aktualizr_lib)
+    target_link_libraries(garage-check sota_tools_lib)
 
     install(TARGETS garage-check RUNTIME DESTINATION bin COMPONENT garage_deploy)
 endif (BUILD_SOTA_TOOLS)
@@ -68,7 +66,7 @@ set(GARAGE_DEPLOY_SRCS
 
 if (BUILD_SOTA_TOOLS)
     add_executable(garage-deploy ${GARAGE_DEPLOY_SRCS})
-    target_link_libraries(garage-deploy sota_tools_lib aktualizr_lib)
+    target_link_libraries(garage-deploy sota_tools_lib)
 
     add_dependencies(build_tests garage-deploy)
 
@@ -134,49 +132,46 @@ endif(NOT BUILD_SOTA_TOOLS)
 
 ##### tests
 if (BUILD_SOTA_TOOLS)
+
     add_custom_target(sota_tools_cert_generation
         COMMAND ${PROJECT_SOURCE_DIR}/tests/sota_tools/cert_generation/generate-zips.sh
         ${PROJECT_BINARY_DIR}/sota_tools/certs)
 
+    # do not link tests with libaktualizr, but sota_tools_lib
+    list(REMOVE_ITEM TEST_LIBS aktualizr_lib)
+    list(INSERT TEST_LIBS 0 sota_tools_lib)
+
     ### common tests
     add_aktualizr_test(NAME sota_tools_auth_test
                        SOURCES authenticate_test.cc
-                       LIBRARIES sota_tools_lib
                        PROJECT_WORKING_DIRECTORY
                        ARGS ${PROJECT_BINARY_DIR}/sota_tools/certs)
     add_dependencies(t_sota_tools_auth_test sota_tools_cert_generation)
 
     add_aktualizr_test(NAME ostree_hash
-                       LIBRARIES sota_tools_lib
                        SOURCES ostree_hash_test.cc)
 
     add_aktualizr_test(NAME rate_controller
-                       LIBRARIES sota_tools_lib
                        SOURCES rate_controller_test.cc)
 
     add_aktualizr_test(NAME ostree_dir_repo
                        SOURCES ostree_dir_repo_test.cc
-                       LIBRARIES sota_tools_lib
                        PROJECT_WORKING_DIRECTORY)
 
     add_aktualizr_test(NAME ostree_http_repo
                        SOURCES ostree_http_repo_test.cc
-                       LIBRARIES sota_tools_lib
                        PROJECT_WORKING_DIRECTORY)
 
     add_aktualizr_test(NAME treehub_server
                        SOURCES treehub_server_test.cc
-                       LIBRARIES sota_tools_lib
                        PROJECT_WORKING_DIRECTORY)
 
     add_aktualizr_test(NAME deploy
                        SOURCES deploy_test.cc
-                       LIBRARIES sota_tools_lib
                        PROJECT_WORKING_DIRECTORY)
 
     add_aktualizr_test(NAME ostree_object
                        SOURCES ostree_object_test.cc
-                       LIBRARIES sota_tools_lib
                        PROJECT_WORKING_DIRECTORY)
 
     ### garage-check tests

--- a/src/uptane_generator/CMakeLists.txt
+++ b/src/uptane_generator/CMakeLists.txt
@@ -2,10 +2,7 @@
 set(UPTANE_GENERATOR_SRC repo.cc director_repo.cc image_repo.cc uptane_repo.cc)
 set(UPTANE_GENERATOR_HDR repo.h director_repo.h image_repo.h uptane_repo.h)
 
-set(UPTANE_GENERATOR_LIBS
-    aktualizr_static_lib
-    ${AKTUALIZR_EXTERNAL_LIBS}
-)
+set(UPTANE_GENERATOR_LIBS aktualizr_lib)
 add_library(uptane_generator_lib ${UPTANE_GENERATOR_SRC})
 target_include_directories(uptane_generator_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 add_executable(uptane-generator main.cc ${UPTANE_GENERATOR_SRC})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,7 +80,7 @@ endif()
 
 
 add_executable(aktualizr_uptane_vector_tests uptane_vector_tests.cc)
-target_link_libraries(aktualizr_uptane_vector_tests aktualizr_lib ${TEST_LIBS})
+target_link_libraries(aktualizr_uptane_vector_tests ${TEST_LIBS})
 add_dependencies(build_tests aktualizr_uptane_vector_tests)
 
 if(TESTSUITE_VALGRIND)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,7 +80,7 @@ endif()
 
 
 add_executable(aktualizr_uptane_vector_tests uptane_vector_tests.cc)
-target_link_libraries(aktualizr_uptane_vector_tests aktualizr_static_lib ${TEST_LIBS})
+target_link_libraries(aktualizr_uptane_vector_tests aktualizr_lib ${TEST_LIBS})
 add_dependencies(build_tests aktualizr_uptane_vector_tests)
 
 if(TESTSUITE_VALGRIND)
@@ -212,7 +212,7 @@ add_test(NAME test_install_aktualizr_and_update COMMAND ${PROJECT_SOURCE_DIR}/te
 set_tests_properties(test_install_aktualizr_and_update PROPERTIES LABELS "noptest")
 
 add_executable(aktualizr-cycle-simple aktualizr_cycle_simple.cc)
-target_link_libraries(aktualizr-cycle-simple aktualizr_static_lib ${AKTUALIZR_EXTERNAL_LIBS})
+target_link_libraries(aktualizr-cycle-simple aktualizr_lib)
 aktualizr_source_file_checks(aktualizr_cycle_simple.cc)
 add_dependencies(build_tests aktualizr-cycle-simple)
 

--- a/tests/run_debian_tests.sh
+++ b/tests/run_debian_tests.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -e
-PATH="$2":$PATH
-
-exec $1


### PR DESCRIPTION
Besides the obvious reuse we have between aktualizr and aktualizr-info, it might be time to ship libaktualizr as a standalone library.
For now, `aktualizr_static_lib` still exists, we might remove it at a later point.

This will also allow some simplifications in #1498.