### PR TITLE
OTA-4174: IP-Secondary: match Director's and Imagerepo's targets

### DIFF
--- a/src/aktualizr_secondary/CMakeLists.txt
+++ b/src/aktualizr_secondary/CMakeLists.txt
@@ -60,7 +60,7 @@ include(AddAktualizrTest)
 list(INSERT TEST_LIBS 0 aktualizr_secondary_lib)
 
 add_aktualizr_test(NAME aktualizr_secondary_config
-    SOURCES aktualizr_secondary_config_test.cc PROJECT_WORKING_DIRECTORY LIBRARIES aktualizr_secondary_lib)
+                   SOURCES aktualizr_secondary_config_test.cc PROJECT_WORKING_DIRECTORY LIBRARIES aktualizr_secondary_lib)
 
 add_aktualizr_test(NAME aktualizr_secondary_update
                    SOURCES update_test.cc
@@ -81,8 +81,17 @@ if(BUILD_OSTREE)
                        SOURCES uptane_test.cc
                        LIBRARIES aktualizr_secondary_lib uptane_generator_lib virtual_secondary $<TARGET_OBJECTS:campaign> $<TARGET_OBJECTS:primary> $<TARGET_OBJECTS:http>
                        ARGS ${PROJECT_BINARY_DIR}/ostree_repo PROJECT_WORKING_DIRECTORY)
+
+    add_aktualizr_test(NAME aktualizr_secondary_uptane_verification_ostree
+                       SOURCES uptane_verification_ostree_test.cc
+                       ARGS ${PROJECT_BINARY_DIR}/ostree_repo
+                       LIBRARIES aktualizr_secondary_lib uptane_generator_lib $<TARGET_OBJECTS:campaign>
+                       PROJECT_WORKING_DIRECTORY)
+
+    set_target_properties(t_aktualizr_secondary_uptane_verification_ostree PROPERTIES LINK_FLAGS -Wl,--export-dynamic)
+    target_link_libraries(t_aktualizr_secondary_uptane_verification_ostree aktualizr_secondary_lib uptane_generator_lib)
 else(BUILD_OSTREE)
-    list(APPEND TEST_SOURCES uptane_verification_test.cc uptane_test.cc)
+    list(APPEND TEST_SOURCES uptane_verification_test.cc uptane_test.cc uptane_verification_ostree_test.cc)
 endif(BUILD_OSTREE)
 
 # test running the executable with command line option --help

--- a/src/aktualizr_secondary/aktualizr_secondary.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary.cc
@@ -269,7 +269,7 @@ bool AktualizrSecondary::doFullVerification(const Metadata& metadata) {
   }
 
   // 10. Verify that Targets metadata from the Director and Image repositories match.
-  if (!(director_repo_.getTargets() == *image_repo_.getTargets())) {
+  if (!director_repo_.matchTargetsWithImageTargets(*(image_repo_.getTargets()))) {
     LOG_ERROR << "Targets metadata from the Director and Image repositories DOES NOT match ";
     return false;
   }

--- a/src/aktualizr_secondary/aktualizr_secondary_config_test.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_config_test.cc
@@ -13,8 +13,11 @@ TEST(aktualizr_secondary_config, config_toml_parsing) {
   AktualizrSecondaryConfig conf("tests/config/aktualizr_secondary.toml");
 
   EXPECT_EQ(conf.network.port, 9031);
-
+#ifdef BUILD_OSTREE
   EXPECT_EQ(conf.pacman.type, PackageManager::kOstree);
+#else
+  EXPECT_EQ(conf.pacman.type, PackageManager::kNone);
+#endif
   EXPECT_EQ(conf.pacman.os, std::string("testos"));
   EXPECT_EQ(conf.pacman.sysroot, boost::filesystem::path("testsysroot"));
   EXPECT_EQ(conf.pacman.ostree_server, std::string("test_server"));

--- a/src/aktualizr_secondary/uptane_verification_ostree_test.cc
+++ b/src/aktualizr_secondary/uptane_verification_ostree_test.cc
@@ -1,0 +1,288 @@
+#include <gtest/gtest.h>
+
+#include <boost/process.hpp>
+#include "aktualizr_secondary.h"
+#include "test_utils.h"
+#include "uptane_repo.h"
+
+#include <ostree.h>
+#include "package_manager/ostreemanager.h"
+
+class Treehub {
+ public:
+  Treehub(const std::string& server_path)
+      : _port(TestUtils::getFreePort()),
+        _url("http://127.0.0.1:" + _port),
+        _process(server_path, "-p", _port, "-d", _root_dir.PathString(), "-s0.5", "--create") {
+    TestUtils::waitForServer(url() + "/");
+    auto rev_process = Process("ostree").run({"rev-parse", "--repo", _root_dir.PathString(), "master"});
+    EXPECT_EQ(std::get<0>(rev_process), 0) << std::get<2>(rev_process);
+    _cur_rev = std::get<1>(rev_process);
+    boost::trim_right_if(_cur_rev, boost::is_any_of(" \t\r\n"));
+
+    LOG_INFO << "Treehub is running on: " << _port << " current revision: " << _cur_rev;
+  }
+
+  ~Treehub() {
+    _process.terminate();
+    _process.wait_for(std::chrono::seconds(10));
+    if (_process.running()) {
+      LOG_ERROR << "Failed to stop Treehub server";
+    } else {
+      LOG_INFO << "Treehub server has been stopped";
+    }
+  }
+
+ public:
+  const std::string& url() const { return _url; }
+  const std::string curRev() const { return _cur_rev; }
+
+ private:
+  TemporaryDirectory _root_dir;
+  const std::string _port;
+  const std::string _url;
+  boost::process::child _process;
+  std::string _cur_rev;
+};
+
+class OstreeRootfs {
+ public:
+  OstreeRootfs(const std::string& rootfs_template) {
+    auto sysroot_copy = Process("cp").run({"-r", rootfs_template, getPath()});
+    EXPECT_EQ(std::get<0>(sysroot_copy), 0) << std::get<1>(sysroot_copy);
+
+    auto deployment_rev = Process("ostree").run(
+        {"rev-parse", std::string("--repo"), getPath() + "/ostree/repo", "generate-remote/generated"});
+
+    EXPECT_EQ(std::get<0>(deployment_rev), 0) << std::get<2>(deployment_rev);
+
+    _rev = std::get<1>(deployment_rev);
+    boost::trim_right_if(_rev, boost::is_any_of(" \t\r\n"));
+
+    _deployment.reset(ostree_deployment_new(0, getOSName(), getDeploymentRev(), getDeploymentSerial(),
+                                            getDeploymentRev(), getDeploymentSerial()));
+  }
+
+  const std::string getPath() const { return _sysroot_dir; }
+  const char* getDeploymentRev() const { return _rev.c_str(); }
+  int getDeploymentSerial() const { return 0; }
+  const char* getOSName() const { return _os_name.c_str(); }
+
+  OstreeDeployment* getDeployment() const { return _deployment.get(); }
+
+ private:
+  const std::string _os_name{"dummy-os"};
+  TemporaryDirectory _tmp_dir;
+  std::string _sysroot_dir{(_tmp_dir / "ostree-rootfs").c_str()};
+  std::string _rev;
+  GObjectUniquePtr<OstreeDeployment> _deployment;
+};
+
+class AktualizrSecondaryWrapper {
+ public:
+  AktualizrSecondaryWrapper(const OstreeRootfs& sysroot, const Treehub& treehub) {
+    // ostree update
+    AktualizrSecondaryConfig config;
+
+    config.pacman.type = PackageManager::kOstree;
+    config.pacman.os = sysroot.getOSName();
+    config.pacman.sysroot = sysroot.getPath();
+    config.pacman.ostree_server = treehub.url();
+
+    config.storage.path = _storage_dir.Path();
+    config.storage.type = StorageType::kSqlite;
+
+    _storage = INvStorage::newStorage(config.storage);
+    _secondary = std::make_shared<AktualizrSecondary>(config, _storage);
+  }
+
+  AktualizrSecondaryWrapper() {
+    // binary update
+    AktualizrSecondaryConfig config;
+    config.pacman.type = PackageManager::kNone;
+
+    config.storage.path = _storage_dir.Path();
+    config.storage.type = StorageType::kSqlite;
+
+    auto storage = INvStorage::newStorage(config.storage);
+    _secondary = std::make_shared<AktualizrSecondary>(config, storage);
+  }
+
+ public:
+  std::shared_ptr<AktualizrSecondary>& operator->() { return _secondary; }
+
+  Uptane::Target getPendingVersion() const {
+    boost::optional<Uptane::Target> pending_target;
+
+    _storage->loadInstalledVersions(_secondary->getSerialResp().ToString(), nullptr, &pending_target);
+    return *pending_target;
+  }
+
+  std::string hardwareID() const { return _secondary->getHwIdResp().ToString(); }
+
+  std::string serial() const { return _secondary->getSerialResp().ToString(); }
+
+ private:
+  TemporaryDirectory _storage_dir;
+  std::shared_ptr<AktualizrSecondary> _secondary;
+  std::shared_ptr<INvStorage> _storage;
+};
+
+class UptaneRepoWrapper {
+ public:
+  UptaneRepoWrapper() { _uptane_repo.generateRepo(KeyType::kED25519); }
+
+  Metadata addOstreeRev(const std::string& rev, const std::string& hardware_id, const std::string& serial) {
+    // it makes sense to add 'addOstreeImage' to UptaneRepo interface/class uptane_repo.h
+    auto custom = Json::Value();
+    custom["targetFormat"] = "OSTREE";
+    _uptane_repo.addCustomImage(rev, Uptane::Hash(Uptane::Hash::Type::kSha256, rev), 0, hardware_id, "", Delegation(),
+                                custom);
+
+    _uptane_repo.addTarget(rev, hardware_id, serial, "");
+    _uptane_repo.signTargets();
+
+    return getCurrentMetadata();
+  }
+
+  Uptane::RawMetaPack getCurrentMetadata() const {
+    Uptane::RawMetaPack metadata;
+
+    boost::filesystem::load_string_file(_director_dir / "root.json", metadata.director_root);
+    boost::filesystem::load_string_file(_director_dir / "targets.json", metadata.director_targets);
+
+    boost::filesystem::load_string_file(_imagerepo_dir / "root.json", metadata.image_root);
+    boost::filesystem::load_string_file(_imagerepo_dir / "timestamp.json", metadata.image_timestamp);
+    boost::filesystem::load_string_file(_imagerepo_dir / "snapshot.json", metadata.image_snapshot);
+    boost::filesystem::load_string_file(_imagerepo_dir / "targets.json", metadata.image_targets);
+
+    return metadata;
+  }
+
+  std::shared_ptr<std::string> getImageData(const std::string& targetname) const {
+    auto image_data = std::make_shared<std::string>();
+    boost::filesystem::load_string_file(_root_dir / targetname, *image_data);
+    return image_data;
+  }
+
+ private:
+  TemporaryDirectory _root_dir;
+  boost::filesystem::path _director_dir{_root_dir / "repo/director"};
+  boost::filesystem::path _imagerepo_dir{_root_dir / "repo/repo"};
+  UptaneRepo _uptane_repo{_root_dir.Path(), "", ""};
+};
+
+class OstreeSecondaryUptaneVerificationTest : public ::testing::Test {
+ public:
+  static const char* curOstreeRootfsRev(OstreeDeployment* ostree_depl) {
+    (void)ostree_depl;
+    return _sysroot->getDeploymentRev();
+  }
+
+  static OstreeDeployment* curOstreeDeployment(OstreeSysroot* ostree_sysroot) {
+    (void)ostree_sysroot;
+    return _sysroot->getDeployment();
+  }
+
+  static void setOstreeRootfsTemplate(const std::string& ostree_rootfs_template) {
+    _ostree_rootfs_template = ostree_rootfs_template;
+  }
+
+ protected:
+  static void SetUpTestSuite() {
+    _treehub = std::make_shared<Treehub>("tests/sota_tools/treehub_server.py");
+    _sysroot = std::make_shared<OstreeRootfs>(_ostree_rootfs_template);
+  }
+
+  static void TearDownTestSuite() {
+    _treehub.reset();
+    _sysroot.reset();
+  }
+
+ protected:
+  OstreeSecondaryUptaneVerificationTest() {}
+
+  Metadata addDefaultTarget() { return addTarget(_treehub->curRev()); }
+
+  Metadata addTarget(const std::string& rev = "", const std::string& hardware_id = "", const std::string& serial = "") {
+    auto rev_to_apply = rev.empty() ? _treehub->curRev() : rev;
+    auto hw_id = hardware_id.empty() ? _secondary.hardwareID() : hardware_id;
+    auto serial_id = serial.empty() ? _secondary.serial() : serial;
+
+    _uptane_repo.addOstreeRev(rev, hw_id, serial_id);
+
+    return currentMetadata();
+  }
+
+  Metadata currentMetadata() const { return _uptane_repo.getCurrentMetadata(); }
+
+  std::shared_ptr<std::string> getCredsToSend() const {
+    std::map<std::string, std::string> creds_map = {
+        {"ca.pem", ""}, {"client.pem", ""}, {"pkey.pem", ""}, {"server.url", _treehub->url()}};
+
+    std::stringstream creads_strstream;
+    Utils::writeArchive(creds_map, creads_strstream);
+
+    return std::make_shared<std::string>(creads_strstream.str());
+  }
+
+  Uptane::Hash treehubCurRev() const { return Uptane::Hash(Uptane::Hash::Type::kSha256, _treehub->curRev()); }
+
+ protected:
+  static std::shared_ptr<Treehub> _treehub;
+  static std::string _ostree_rootfs_template;
+  static std::shared_ptr<OstreeRootfs> _sysroot;
+
+  AktualizrSecondaryWrapper _secondary{*_sysroot, *_treehub};
+  UptaneRepoWrapper _uptane_repo;
+};
+
+std::shared_ptr<Treehub> OstreeSecondaryUptaneVerificationTest::_treehub{nullptr};
+std::string OstreeSecondaryUptaneVerificationTest::_ostree_rootfs_template{"./build/ostree_repo"};
+std::shared_ptr<OstreeRootfs> OstreeSecondaryUptaneVerificationTest::_sysroot{nullptr};
+
+TEST_F(OstreeSecondaryUptaneVerificationTest, fullUptaneVerificationPositive) {
+  EXPECT_TRUE(_secondary->putMetadataResp(addDefaultTarget()));
+  EXPECT_TRUE(_secondary->sendFirmwareResp(getCredsToSend()));
+  EXPECT_TRUE(_secondary.getPendingVersion().MatchHash(treehubCurRev()));
+  // TODO: emulate reboot and check installed version once ostree update finalization is supported by secondary
+}
+
+TEST_F(OstreeSecondaryUptaneVerificationTest, fullUptaneVerificationInvalidRevision) {
+  EXPECT_TRUE(_secondary->putMetadataResp(addTarget("invalid-revision")));
+  EXPECT_FALSE(_secondary->sendFirmwareResp(getCredsToSend()));
+}
+
+TEST_F(OstreeSecondaryUptaneVerificationTest, fullUptaneVerificationInvalidHwID) {
+  EXPECT_FALSE(_secondary->putMetadataResp(addTarget("", "invalid-hardware-id", "")));
+}
+
+TEST_F(OstreeSecondaryUptaneVerificationTest, fullUptaneVerificationInvalidSerial) {
+  EXPECT_FALSE(_secondary->putMetadataResp(addTarget("", "", "invalid-serial-id")));
+}
+
+#ifndef __NO_MAIN__
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+  if (argc != 2) {
+    std::cerr << "Error: " << argv[0] << " <ostree rootfs path>\n";
+    return EXIT_FAILURE;
+  }
+
+  OstreeSecondaryUptaneVerificationTest::setOstreeRootfsTemplate(argv[1]);
+
+  logger_init();
+  logger_set_threshold(boost::log::trivial::info);
+
+  return RUN_ALL_TESTS();
+}
+#endif
+
+extern "C" OstreeDeployment* ostree_sysroot_get_booted_deployment(OstreeSysroot* ostree_sysroot) {
+  return OstreeSecondaryUptaneVerificationTest::curOstreeDeployment(ostree_sysroot);
+}
+
+extern "C" const char* ostree_deployment_get_csum(OstreeDeployment* ostree_deployment) {
+  return OstreeSecondaryUptaneVerificationTest::curOstreeRootfsRev(ostree_deployment);
+}

--- a/src/aktualizr_secondary/uptane_verification_test.cc
+++ b/src/aktualizr_secondary/uptane_verification_test.cc
@@ -1,100 +1,12 @@
 #include <gtest/gtest.h>
 
-#include <ostree.h>
 #include <boost/process.hpp>
 #include "aktualizr_secondary.h"
-#include "package_manager/ostreemanager.h"
 #include "test_utils.h"
 #include "uptane_repo.h"
 
-class Treehub {
- public:
-  Treehub(const std::string& server_path)
-      : _port(TestUtils::getFreePort()),
-        _url("http://127.0.0.1:" + _port),
-        _process(server_path, "-p", _port, "-d", _root_dir.PathString(), "-s0.5", "--create") {
-    TestUtils::waitForServer(url() + "/");
-    auto rev_process = Process("ostree").run({"rev-parse", "--repo", _root_dir.PathString(), "master"});
-    EXPECT_EQ(std::get<0>(rev_process), 0) << std::get<2>(rev_process);
-    _cur_rev = std::get<1>(rev_process);
-    boost::trim_right_if(_cur_rev, boost::is_any_of(" \t\r\n"));
-
-    LOG_INFO << "Treehub is running on: " << _port << " current revision: " << _cur_rev;
-  }
-
-  ~Treehub() {
-    _process.terminate();
-    _process.wait_for(std::chrono::seconds(10));
-    if (_process.running()) {
-      LOG_ERROR << "Failed to stop Treehub server";
-    } else {
-      LOG_INFO << "Treehub server has been stopped";
-    }
-  }
-
- public:
-  const std::string& url() const { return _url; }
-  const std::string curRev() const { return _cur_rev; }
-
- private:
-  TemporaryDirectory _root_dir;
-  const std::string _port;
-  const std::string _url;
-  boost::process::child _process;
-  std::string _cur_rev;
-};
-
-class OstreeRootfs {
- public:
-  OstreeRootfs(const std::string& rootfs_template) {
-    auto sysroot_copy = Process("cp").run({"-r", rootfs_template, getPath()});
-    EXPECT_EQ(std::get<0>(sysroot_copy), 0) << std::get<1>(sysroot_copy);
-
-    auto deployment_rev = Process("ostree").run(
-        {"rev-parse", std::string("--repo"), getPath() + "/ostree/repo", "generate-remote/generated"});
-
-    EXPECT_EQ(std::get<0>(deployment_rev), 0) << std::get<2>(deployment_rev);
-
-    _rev = std::get<1>(deployment_rev);
-    boost::trim_right_if(_rev, boost::is_any_of(" \t\r\n"));
-
-    _deployment.reset(ostree_deployment_new(0, getOSName(), getDeploymentRev(), getDeploymentSerial(),
-                                            getDeploymentRev(), getDeploymentSerial()));
-  }
-
-  const std::string getPath() const { return _sysroot_dir; }
-  const char* getDeploymentRev() const { return _rev.c_str(); }
-  int getDeploymentSerial() const { return 0; }
-  const char* getOSName() const { return _os_name.c_str(); }
-
-  OstreeDeployment* getDeployment() const { return _deployment.get(); }
-
- private:
-  const std::string _os_name{"dummy-os"};
-  TemporaryDirectory _tmp_dir;
-  std::string _sysroot_dir{(_tmp_dir / "ostree-rootfs").c_str()};
-  std::string _rev;
-  GObjectUniquePtr<OstreeDeployment> _deployment;
-};
-
 class AktualizrSecondaryWrapper {
  public:
-  AktualizrSecondaryWrapper(const OstreeRootfs& sysroot, const Treehub& treehub) {
-    // ostree update
-    AktualizrSecondaryConfig config;
-
-    config.pacman.type = PackageManager::kOstree;
-    config.pacman.os = sysroot.getOSName();
-    config.pacman.sysroot = sysroot.getPath();
-    config.pacman.ostree_server = treehub.url();
-
-    config.storage.path = _storage_dir.Path();
-    config.storage.type = StorageType::kSqlite;
-
-    _storage = INvStorage::newStorage(config.storage);
-    _secondary = std::make_shared<AktualizrSecondary>(config, _storage);
-  }
-
   AktualizrSecondaryWrapper() {
     // binary update
     AktualizrSecondaryConfig config;
@@ -131,26 +43,16 @@ class UptaneRepoWrapper {
  public:
   UptaneRepoWrapper() { _uptane_repo.generateRepo(KeyType::kED25519); }
 
-  Metadata addImageFile(const std::string& targetname, const std::string& hardware_id, const std::string& serial) {
+  Metadata addImageFile(const std::string& targetname, const std::string& hardware_id, const std::string& serial,
+                        bool add_and_sign_target = true) {
     const auto image_file_path = _root_dir / targetname;
     boost::filesystem::ofstream(image_file_path) << "some data";
 
     _uptane_repo.addImage(image_file_path, targetname, hardware_id, "", Delegation());
-    _uptane_repo.addTarget(targetname, hardware_id, serial, "");
-    _uptane_repo.signTargets();
-
-    return getCurrentMetadata();
-  }
-
-  Metadata addOstreeRev(const std::string& rev, const std::string& hardware_id, const std::string& serial) {
-    // it makes sense to add 'addOstreeImage' to UptaneRepo interface/class uptane_repo.h
-    auto custom = Json::Value();
-    custom["targetFormat"] = "OSTREE";
-    _uptane_repo.addCustomImage(rev, Uptane::Hash(Uptane::Hash::Type::kSha256, rev), 0, hardware_id, "", Delegation(),
-                                custom);
-
-    _uptane_repo.addTarget(rev, hardware_id, serial, "");
-    _uptane_repo.signTargets();
+    if (add_and_sign_target) {
+      _uptane_repo.addTarget(targetname, hardware_id, serial, "");
+      _uptane_repo.signTargets();
+    }
 
     return getCurrentMetadata();
   }
@@ -198,75 +100,6 @@ class SecondaryUptaneVerificationTest : public ::testing::Test {
   AktualizrSecondaryWrapper _secondary;
   UptaneRepoWrapper _uptane_repo;
 };
-
-class OstreeSecondaryUptaneVerificationTest : public ::testing::Test {
- public:
-  static const char* curOstreeRootfsRev(OstreeDeployment* ostree_depl) {
-    (void)ostree_depl;
-    return _sysroot->getDeploymentRev();
-  }
-
-  static OstreeDeployment* curOstreeDeployment(OstreeSysroot* ostree_sysroot) {
-    (void)ostree_sysroot;
-    return _sysroot->getDeployment();
-  }
-
-  static void setOstreeRootfsTemplate(const std::string& ostree_rootfs_template) {
-    _ostree_rootfs_template = ostree_rootfs_template;
-  }
-
- protected:
-  static void SetUpTestSuite() {
-    _treehub = std::make_shared<Treehub>("tests/sota_tools/treehub_server.py");
-    _sysroot = std::make_shared<OstreeRootfs>(_ostree_rootfs_template);
-  }
-
-  static void TearDownTestSuite() {
-    _treehub.reset();
-    _sysroot.reset();
-  }
-
- protected:
-  OstreeSecondaryUptaneVerificationTest() {}
-
-  Metadata addDefaultTarget() { return addTarget(_treehub->curRev()); }
-
-  Metadata addTarget(const std::string& rev = "", const std::string& hardware_id = "", const std::string& serial = "") {
-    auto rev_to_apply = rev.empty() ? _treehub->curRev() : rev;
-    auto hw_id = hardware_id.empty() ? _secondary.hardwareID() : hardware_id;
-    auto serial_id = serial.empty() ? _secondary.serial() : serial;
-
-    _uptane_repo.addOstreeRev(rev, hw_id, serial_id);
-
-    return currentMetadata();
-  }
-
-  Metadata currentMetadata() const { return _uptane_repo.getCurrentMetadata(); }
-
-  std::shared_ptr<std::string> getCredsToSend() const {
-    std::map<std::string, std::string> creds_map = {
-        {"ca.pem", ""}, {"client.pem", ""}, {"pkey.pem", ""}, {"server.url", _treehub->url()}};
-
-    std::stringstream creads_strstream;
-    Utils::writeArchive(creds_map, creads_strstream);
-
-    return std::make_shared<std::string>(creads_strstream.str());
-  }
-
-  Uptane::Hash treehubCurRev() const { return Uptane::Hash(Uptane::Hash::Type::kSha256, _treehub->curRev()); }
-
- protected:
-  static std::shared_ptr<Treehub> _treehub;
-  static std::string _ostree_rootfs_template;
-  static std::shared_ptr<OstreeRootfs> _sysroot;
-
-  AktualizrSecondaryWrapper _secondary{*_sysroot, *_treehub};
-  UptaneRepoWrapper _uptane_repo;
-};
-
-std::shared_ptr<Treehub> OstreeSecondaryUptaneVerificationTest::_treehub{nullptr};
-std::string OstreeSecondaryUptaneVerificationTest::_ostree_rootfs_template{"./build/ostree_repo"};
-std::shared_ptr<OstreeRootfs> OstreeSecondaryUptaneVerificationTest::_sysroot{nullptr};
 
 class SecondaryUptaneVerificationTestNegative
     : public SecondaryUptaneVerificationTest,
@@ -321,29 +154,17 @@ INSTANTIATE_TEST_SUITE_P(SecondaryUptaneVerificationMalformedMetadata, Secondary
                                            std::make_pair(Uptane::RepositoryType::Image(), Uptane::Role::Snapshot()),
                                            std::make_pair(Uptane::RepositoryType::Image(), Uptane::Role::Targets())));
 
-TEST_F(OstreeSecondaryUptaneVerificationTest, fullUptaneVerificationPositive) {
-  EXPECT_TRUE(_secondary->putMetadataResp(addDefaultTarget()));
-  EXPECT_TRUE(_secondary->sendFirmwareResp(getCredsToSend()));
-  EXPECT_TRUE(_secondary.getPendingVersion().MatchHash(treehubCurRev()));
-  // TODO: emulate reboot and check installed version once ostree update finalization is supported by secondary
-}
-
-TEST_F(OstreeSecondaryUptaneVerificationTest, fullUptaneVerificationInvalidRevision) {
-  EXPECT_TRUE(_secondary->putMetadataResp(addTarget("invalid-revision")));
-  EXPECT_FALSE(_secondary->sendFirmwareResp(getCredsToSend()));
-}
-
-TEST_F(OstreeSecondaryUptaneVerificationTest, fullUptaneVerificationInvalidHwID) {
-  EXPECT_FALSE(_secondary->putMetadataResp(addTarget("", "invalid-hardware-id", "")));
-}
-
-TEST_F(OstreeSecondaryUptaneVerificationTest, fullUptaneVerificationInvalidSerial) {
-  EXPECT_FALSE(_secondary->putMetadataResp(addTarget("", "", "invalid-serial-id")));
-}
-
 TEST_F(SecondaryUptaneVerificationTest, fullUptaneVerificationPositive) {
   EXPECT_TRUE(_secondary->putMetadataResp(_uptane_repo.getCurrentMetadata()));
   EXPECT_TRUE(_secondary->sendFirmwareResp(getImageData()));
+}
+
+TEST_F(SecondaryUptaneVerificationTest, TwoImagesAndOneTarget) {
+  // two images for the same ECU, just one of them is added as a target and signed
+  // default image and corresponding target has been already added, just add another image
+  _uptane_repo.addImageFile("second_image_00", _secondary->getHwIdResp().ToString(),
+                            _secondary->getSerialResp().ToString(), false);
+  EXPECT_TRUE(_secondary->putMetadataResp(_uptane_repo.getCurrentMetadata()));
 }
 
 TEST_F(SecondaryUptaneVerificationTest, IncorrectTargetQuantity) {
@@ -390,24 +211,9 @@ TEST_F(SecondaryUptaneVerificationTest, InvalidImageData) {
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
 
-  if (argc != 2) {
-    std::cerr << "Error: " << argv[0] << " <ostree rootfs path>\n";
-    return EXIT_FAILURE;
-  }
-
-  OstreeSecondaryUptaneVerificationTest::setOstreeRootfsTemplate(argv[1]);
-
   logger_init();
   logger_set_threshold(boost::log::trivial::info);
 
   return RUN_ALL_TESTS();
 }
 #endif
-
-extern "C" OstreeDeployment* ostree_sysroot_get_booted_deployment(OstreeSysroot* ostree_sysroot) {
-  return OstreeSecondaryUptaneVerificationTest::curOstreeDeployment(ostree_sysroot);
-}
-
-extern "C" const char* ostree_deployment_get_csum(OstreeDeployment* ostree_deployment) {
-  return OstreeSecondaryUptaneVerificationTest::curOstreeRootfsRev(ostree_deployment);
-}

--- a/src/libaktualizr-posix/ipuptanesecondary.cc
+++ b/src/libaktualizr-posix/ipuptanesecondary.cc
@@ -104,7 +104,7 @@ bool IpUptaneSecondary::sendFirmware(const std::shared_ptr<std::string>& data) {
 }
 
 Json::Value IpUptaneSecondary::getManifest() {
-  LOG_INFO << "Getting the manifest key of a secondary";
+  LOG_DEBUG << "Getting the manifest from secondary with serial " << getSerial();
   Asn1Message::Ptr req(Asn1Message::Empty());
 
   req->present(AKIpUptaneMes_PR_manifestReq);

--- a/src/libaktualizr/uptane/directorrepository.cc
+++ b/src/libaktualizr/uptane/directorrepository.cc
@@ -139,4 +139,24 @@ void DirectorRepository::dropTargets(INvStorage& storage) {
   resetMeta();
 }
 
+bool DirectorRepository::matchTargetsWithImageTargets(const Uptane::Targets& image_targets) const {
+  // step 10 of https://uptane.github.io/papers/ieee-isto-6100.1.0.0.uptane-standard.html#rfc.section.5.4.4.2
+  // TBD: no delegation support, consider reusing of findTargetInDelegationTree()
+  // that needs to be moved into a common place to be resued by Primary and Secondary
+  const auto& image_target_array = image_targets.targets;
+  const auto& director_target_array = targets.targets;
+
+  for (const auto& director_target : director_target_array) {
+    auto found_it = std::find_if(
+        image_target_array.begin(), image_target_array.end(),
+        [&director_target](const Target& image_target) { return director_target.MatchTarget(image_target); });
+
+    if (found_it == image_target_array.end()) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 }  // namespace Uptane

--- a/src/libaktualizr/uptane/directorrepository.h
+++ b/src/libaktualizr/uptane/directorrepository.h
@@ -21,16 +21,18 @@ class DirectorRepository : public RepositoryCommon {
     return targets.getTargets(ecu_id, hw_id);
   }
   const std::string& getCorrelationId() const { return targets.correlation_id(); }
-  bool targetsExpired() const;
+
   bool checkMetaOffline(INvStorage& storage);
   void dropTargets(INvStorage& storage);
 
   Exception getLastException() const { return last_exception; }
   bool updateMeta(INvStorage& storage, const IMetadataFetcher& fetcher) override;
+  bool matchTargetsWithImageTargets(const Uptane::Targets& image_targets) const;
 
  private:
   void resetMeta();
   bool usePreviousTargets() const;
+  bool targetsExpired() const;
 
  private:
   FRIEND_TEST(Director, EmptyTargets);

--- a/src/libaktualizr/uptane/imagesrepository.h
+++ b/src/libaktualizr/uptane/imagesrepository.h
@@ -1,9 +1,6 @@
 #ifndef IMAGES_REPOSITORY_H_
 #define IMAGES_REPOSITORY_H_
 
-#include <map>
-#include <vector>
-
 #include "uptanerepository.h"
 
 namespace Uptane {
@@ -14,34 +11,29 @@ class ImagesRepository : public RepositoryCommon {
  public:
   ImagesRepository() : RepositoryCommon(RepositoryType::Image()) {}
 
-  void resetMeta();
-
-  bool verifyTargets(const std::string& targets_raw);
-  bool targetsExpired() { return targets->isExpired(TimeStamp::Now()); }
-
-  bool verifyTimestamp(const std::string& timestamp_raw);
-  bool timestampExpired() { return timestamp.isExpired(TimeStamp::Now()); }
-
-  bool verifySnapshot(const std::string& snapshot_raw);
-  bool snapshotExpired() { return snapshot.isExpired(TimeStamp::Now()); }
-  int64_t snapshotSize() { return timestamp.snapshot_size(); }
-
   Exception getLastException() const { return last_exception; }
-
-  static std::shared_ptr<Uptane::Targets> verifyDelegation(const std::string& delegation_raw, const Uptane::Role& role,
-                                                           const Targets& parent_target);
   std::shared_ptr<const Uptane::Targets> getTargets() const { return targets; }
 
   bool verifyRoleHashes(const std::string& role_data, const Uptane::Role& role) const;
   int getRoleVersion(const Uptane::Role& role) const;
   int64_t getRoleSize(const Uptane::Role& role) const;
-
-  bool checkMetaOffline(INvStorage& storage);
+  static std::shared_ptr<Uptane::Targets> verifyDelegation(const std::string& delegation_raw, const Uptane::Role& role,
+                                                           const Targets& parent_target);
   bool updateMeta(INvStorage& storage, const IMetadataFetcher& fetcher) override;
+  bool checkMetaOffline(INvStorage& storage);
 
  private:
+  bool targetsExpired() { return targets->isExpired(TimeStamp::Now()); }
+  bool timestampExpired() { return timestamp.isExpired(TimeStamp::Now()); }
+  bool snapshotExpired() { return snapshot.isExpired(TimeStamp::Now()); }
+  int64_t snapshotSize() { return timestamp.snapshot_size(); }
+
+  void resetMeta();
+  bool verifyTimestamp(const std::string& timestamp_raw);
   bool fetchSnapshot(INvStorage& storage, const IMetadataFetcher& fetcher, int local_version);
+  bool verifySnapshot(const std::string& snapshot_raw);
   bool fetchTargets(INvStorage& storage, const IMetadataFetcher& fetcher, int local_version);
+  bool verifyTargets(const std::string& targets_raw);
 
   std::shared_ptr<Uptane::Targets> targets;
   Uptane::TimestampMeta timestamp;


### PR DESCRIPTION
Cherry-pick of https://github.com/advancedtelematic/aktualizr/pull/1500/commits/fc6eafdf59fe040e676e4d91d42446fbc2a4e57b from https://github.com/advancedtelematic/aktualizr/pull/1500 to address a possible bug. Still requires some further investigation and review, but I think we might need this sooner than the rest of that PR.

- Each target listed in Director's target file should have corresponding match in ImageRepo's one
- Test for the use-case if IP Secondary Director's target file and ImageRepo's one have different number of targets
- Separate the ostree specific tests from non-ostree one in the IP Secondary Verification test suite