### PR TITLE
Check disk space before downloading files.

### DIFF
--- a/src/libaktualizr/package_manager/packagemanagerinterface.cc
+++ b/src/libaktualizr/package_manager/packagemanagerinterface.cc
@@ -110,6 +110,11 @@ bool PackageManagerInterface::fetchTarget(const Uptane::Target& target, Uptane::
       ds->fhandle = storage_->allocateTargetFile(false, target);
     }
 
+    const uint64_t required_bytes = target.length() - ds->downloaded_length;
+    if (!storage_->checkAvailableDiskSpace(required_bytes)) {
+      throw std::runtime_error("Insufficient disk space available to download target");
+    }
+
     std::string target_url = target.uri();
     if (target_url.empty()) {
       target_url = fetcher.getRepoServer() + "/targets/" + Utils::urlEncode(target.filename());

--- a/src/libaktualizr/storage/invstorage.h
+++ b/src/libaktualizr/storage/invstorage.h
@@ -184,6 +184,7 @@ class INvStorage {
   virtual void saveEcuReportCounter(const Uptane::EcuSerial& ecu_serial, int64_t counter) = 0;
   virtual bool loadEcuReportCounter(std::vector<std::pair<Uptane::EcuSerial, int64_t>>* results) = 0;
 
+  virtual bool checkAvailableDiskSpace(uint64_t required_bytes) const = 0;
   virtual boost::optional<std::pair<size_t, std::string>> checkTargetFile(const Uptane::Target& target) const = 0;
 
   // Incremental file API

--- a/src/libaktualizr/storage/sqlstorage.h
+++ b/src/libaktualizr/storage/sqlstorage.h
@@ -84,6 +84,8 @@ class SQLStorage : public SQLStorageBase, public INvStorage {
   bool loadEcuReportCounter(std::vector<std::pair<Uptane::EcuSerial, int64_t>>* results) override;
   void clearInstallationResults() override;
 
+  bool checkAvailableDiskSpace(uint64_t required_bytes) const override;
+
   std::unique_ptr<StorageTargetWHandle> allocateTargetFile(bool from_director, const Uptane::Target& target) override;
   std::unique_ptr<StorageTargetRHandle> openTargetFile(const Uptane::Target& target) override;
   boost::optional<std::pair<size_t, std::string>> checkTargetFile(const Uptane::Target& target) const override;


### PR DESCRIPTION
There is no reason to download a file that we don't have space for on disk. I've set 1MB as reserved so that we can still (hopefully) do the database operations to let libaktualizr send a manifest to the server.

This should help with the problems observed with non-OSTree images (see https://github.com/advancedtelematic/meta-updater/pull/637) when additional overhead isn't provided to the qemu image.