### PR TITLE
Remove clang-tidy's modernize-pass-by-value

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,8 +1,20 @@
 ---
-Checks:          'clang-analyzer-*, performance-*,readability-*,-readability-else-after-return,-readability-identifier-naming,-readability-container-size-empty,-readability-redundant-declaration,modernize-*,-modernize-avoid-bind,-modernize-loop-convert,-modernize-use-using,-modernize-deprecated-headers, llvm-namespace-comment,cppcoreguidelines-pro-*,-cppcoreguidelines-pro-type-reinterpret-cast,-cppcoreguidelines-pro-type-vararg,-cppcoreguidelines-pro-type-const-cast,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-cppcoreguidelines-pro-bounds-constant-array-index,cert-*,-cert-err58-cpp,-cert-env33-c,-cert-err09-cpp,-cert-err60-cpp,-cert-err61-cpp, -cert-err61-cpp, bugprone-*, google-*,-google-runtime-references,-google-runtime-member-string-references, -google-explicit-constructor, -google-readability-todo, misc-*, -misc-unused-parameters, -misc-macro-parentheses, -misc-throw-by-value-catch-by-reference, -misc-suspicious-enum-usage'
+Checks:          >-
+  clang-analyzer-*,
+  performance-*,
+  bugprone-*,
+  readability-*,-readability-else-after-return,-readability-identifier-naming,-readability-container-size-empty,-readability-redundant-declaration,
+  modernize-*,-modernize-avoid-bind,-modernize-loop-convert,-modernize-use-using,-modernize-deprecated-headers,
+  llvm-namespace-comment,
+  cppcoreguidelines-pro-*,-cppcoreguidelines-pro-type-reinterpret-cast,-cppcoreguidelines-pro-type-vararg,-cppcoreguidelines-pro-type-const-cast,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,-cppcoreguidelines-pro-bounds-constant-array-index,cert-*,
+  -cert-err58-cpp,-cert-env33-c,-cert-err09-cpp,-cert-err60-cpp,-cert-err61-cpp, -cert-err61-cpp,
+  google-*,-google-runtime-references,-google-runtime-member-string-references,-google-explicit-constructor,-google-readability-todo,
+  misc-*, -misc-unused-parameters, -misc-macro-parentheses, -misc-throw-by-value-catch-by-reference, -misc-suspicious-enum-usage
+
 WarningsAsErrors: '*'
 AnalyzeTemporaryDtors: false
-CheckOptions:    
+CheckOptions:
   - key:             cert-dcl59-cpp.HeaderFileExtensions
     value:           h,hh,hpp,hxx
   - key:             cert-err09-cpp.CheckThrowTemporaries

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,7 +4,7 @@ Checks:          >-
   performance-*,
   bugprone-*,
   readability-*,-readability-else-after-return,-readability-identifier-naming,-readability-container-size-empty,-readability-redundant-declaration,
-  modernize-*,-modernize-avoid-bind,-modernize-loop-convert,-modernize-use-using,-modernize-deprecated-headers,
+  modernize-*,-modernize-avoid-bind,-modernize-loop-convert,-modernize-use-using,-modernize-deprecated-headers,-modernize-pass-by-value,
   llvm-namespace-comment,
   cppcoreguidelines-pro-*,-cppcoreguidelines-pro-type-reinterpret-cast,-cppcoreguidelines-pro-type-vararg,-cppcoreguidelines-pro-type-const-cast,
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,-cppcoreguidelines-pro-bounds-constant-array-index,cert-*,


### PR DESCRIPTION
This lint has caused problems in the past and is going in the way of some refactors.