### PR TITLE
Creation of path for testing with root certificate

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/nav.adoc
+++ b/docs/ota-client-guide/modules/ROOT/nav.adoc
@@ -62,6 +62,11 @@ ifndef::env-github[:pageroot:]
 ** xref:{pageroot}hsm-provisioning-example.adoc[Generate a device certificate using an HSM]
 ** xref:{pageroot}enable-device-cred-provisioning.adoc[Enable and install device certificates]
 
+* xref:{pageroot}test-root-cert.adoc[Testing with a root certificate]
+** xref:{pageroot}provide-testroot-cert.adoc[Register your test root certificate]
+** xref:{pageroot}generatetest-devicecert.adoc[Generate a test device certificate]
+** xref:{pageroot}enable-device-cred-provtest.adoc[Enable and install test device certificates]
+
 * xref:{pageroot}secure-software-updates.adoc[Secure your software repository]
 ** xref:{pageroot}install-garage-sign-deploy.adoc[Install the garage-deploy tool]
 ** xref:{pageroot}rotating-signing-keys.adoc[Manage keys for software metadata]

--- a/docs/ota-client-guide/modules/ROOT/pages/generate-selfsigned-root.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/generate-selfsigned-root.adoc
@@ -10,6 +10,8 @@ endif::[]
 
 When you move to production, you'll need to register your fleet root certificate with OTA Connect server. This certificate needs to be signed by a trusted Certificate Authority (CA).
 
+If you already have your own CA certificate, you can proceed to xref:provide-root-cert.adoc[register your root certificate for your fleet with HERE OTA Connect].
+
 If you don't yet have your own CA certificate for signing device certificates, you can generate a self-signed certificate for testing.
 
 // tag::install-root-ca[]

--- a/docs/ota-client-guide/modules/ROOT/pages/test-root-cert.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/test-root-cert.adoc
@@ -1,0 +1,30 @@
+= Testing with a root certificate
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
+
+//MC: This is intended for the "test" use case of device credentials provisioning.
+
+If you would like to set up a test environment for device credentials provisioning, you should perform the following steps:
+
+. *xref:generate-selfsigned-root.adoc[Generate a self-signed root certificate for your test fleet]*
++
+You'll need a CA certificate to sign your device certificates for a production environment.
+
+. *xref:provide-testroot-cert.adoc[Register your test root certificate with your OTA Connect account]*
++
+Register the test root certificate you generated with your OTA Connect account, so that OTA Connect can validate your device certificates.
+
+. *xref:generatetest-devicecert.adoc[Generate a test device certificate]*
++
+You need a test device whose certifcate is to be signed by your test root. You can generate a test device certificate for this test.
+
+. *xref:enable-device-cred-provtest.adoc[Enable device credentials provisioning and install device certificates]*
++
+Finally, you can enable device credentials provisioning on a test device and install the test device certificate.
+


### PR DESCRIPTION
I created a path under "Integrate OTA Connect" and placed the pages for testing with a root certificate using device credentials, as I noticed they didn't have a path within the documentation and were a little difficult to locate.
