### PR TITLE
Docs/removing ecu events doc

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/nav.adoc
+++ b/docs/ota-client-guide/modules/ROOT/nav.adoc
@@ -89,7 +89,7 @@ ifndef::env-github[:pageroot:]
 * xref:{pageroot}provisioning-methods-and-credentialszip.adoc[Contents of the credentials file]
 * xref:{pageroot}useful-bitbake-commands.adoc[Bitbake commands]
 * xref:{pageroot}ostree-usage.adoc[OSTree commands]
-* xref:{pageroot}ecu_events.adoc[ECU events]
+// xref:{pageroot}ecu_events.adoc[ECU events]
 * xref:{pageroot}meta-updater-usage.adoc[Advanced usage of meta-updater]
 
 .Test and simulate OTA functions

--- a/docs/ota-client-guide/modules/ROOT/pages/ecu_events.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/ecu_events.adoc
@@ -7,7 +7,7 @@ We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}
 ====
 endif::[]
 
-// MC: This page is currently hidden in the developer guide portal and will be updated later to be connected to the API documentation.
+// AB: This page is currently out of date and will be temporarily hidden in the developer guide portal to be updated later and connected to the API documentation.
 
 :aktualizr-github-url: https://github.com/advancedtelematic/aktualizr/tree/master
 

--- a/docs/ota-client-guide/modules/ROOT/pages/ecu_events.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/ecu_events.adoc
@@ -7,6 +7,8 @@ We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}
 ====
 endif::[]
 
+// MC: This page is currently hidden in the developer guide portal and will be updated later to be connected to the API documentation.
+
 :aktualizr-github-url: https://github.com/advancedtelematic/aktualizr/tree/master
 
 This is a technical document describing the format of the events reported to the back-end by aktualizr during an ongoing update installation.


### PR DESCRIPTION
Hiding `ecu_events.adoc` page on the documentation portal. The page will be updated later and added to the API documentation in the doc portal, which is yet to be created.