### PR TITLE
Don't copy all CA certs to client cert

### DIFF
--- a/src/cert_provider/main.cc
+++ b/src/cert_provider/main.cc
@@ -484,7 +484,7 @@ int main(int argc, char* argv[]) {
 
       StructGuard<BIO> device_p12(BIO_new_mem_buf(response.body.c_str(), static_cast<int>(response.body.size())),
                                   BIO_vfree);
-      if (!Crypto::parseP12(device_p12.get(), "", &pkey, &cert, &ca)) {
+      if (!Crypto::parseP12(device_p12.get(), "", pkey, cert, ca)) {
         std::cout << "Unable to parse p12 file received from server.\n";
         return EXIT_FAILURE;
       }

--- a/src/libaktualizr/bootstrap/bootstrap.cc
+++ b/src/libaktualizr/bootstrap/bootstrap.cc
@@ -37,7 +37,7 @@ void Bootstrap::readTlsP12(const std::string& p12_str, const std::string& provis
     throw std::runtime_error("Unable to parse bootstrap credentials");
   }
 
-  if (!Crypto::parseP12(reg_p12.get(), provision_password, &pkey, &cert, &ca)) {
+  if (!Crypto::parseP12(reg_p12.get(), provision_password, pkey, cert, ca)) {
     LOG_ERROR << "Unable to parse P12 archive";
     throw std::runtime_error("Unable to parse bootstrap credentials");
   }

--- a/src/libaktualizr/config/config_test.cc
+++ b/src/libaktualizr/config/config_test.cc
@@ -89,7 +89,7 @@ TEST(config, ExtractCredentials) {
             "FBA3C8FAD16D8B3EC64F7D47CBDD8456A51A6399734A3F6B7E2D6E562072F264");
   std::cout << "Certificate: " << boot.getCert() << std::endl;
   EXPECT_EQ(boost::algorithm::hex(Crypto::sha256digest(boot.getCert())),
-            "02300CC9797556915D88CFA05644BFF22D8C458367A3636F7921585F828ECB81");
+            "97FEE312F1AC7BEDD9E0979CA8AE57C2824F39928AA9486C56467732B298893E");
   std::cout << "Pkey: " << boot.getPkey() << std::endl;
   EXPECT_EQ(boost::algorithm::hex(Crypto::sha256digest(boot.getPkey())),
             "D27E3E56BEF02AAA6D6FFEFDA5357458C477A8E891C5EADF4F04CE67BB5866A4");

--- a/src/libaktualizr/crypto/crypto.h
+++ b/src/libaktualizr/crypto/crypto.h
@@ -102,8 +102,10 @@ class Crypto {
   static std::string RSAPSSSign(ENGINE *engine, const std::string &private_key, const std::string &message);
   static std::string Sign(KeyType key_type, ENGINE *engine, const std::string &private_key, const std::string &message);
   static std::string ED25519Sign(const std::string &private_key, const std::string &message);
-  static bool parseP12(BIO *p12_bio, const std::string &p12_password, std::string *out_pkey, std::string *out_cert,
-                       std::string *out_ca);
+  static bool parseP12(BIO *p12_bio, const std::string &p12_password, std::string &out_pkey, std::string &out_cert,
+                       std::vector<std::string> &out_ca);
+  static bool parseP12(BIO *p12_bio, const std::string &p12_password, std::string &out_pkey, std::string &out_cert,
+                       std::string &out_ca);
   static bool extractSubjectCN(const std::string &cert, std::string *cn);
   static StructGuard<EVP_PKEY> generateRSAKeyPairEVP(KeyType key_type);
   static bool generateRSAKeyPair(KeyType key_type, std::string *public_key, std::string *private_key);
@@ -115,6 +117,7 @@ class Crypto {
 
   static bool IsRsaKeyType(KeyType type);
   static KeyType IdentifyRSAKeyType(const std::string &public_key_pem);
+  static std::string bioToString(BIO *b);
 };
 
 #endif  // CRYPTO_H_

--- a/src/libaktualizr/crypto/crypto_test.cc
+++ b/src/libaktualizr/crypto/crypto_test.cc
@@ -163,7 +163,7 @@ TEST(crypto, parsep12) {
   }
   StructGuard<BIO> p12src(BIO_new(BIO_s_file()), BIO_vfree);
   BIO_set_fp(p12src.get(), p12file, BIO_CLOSE);
-  Crypto::parseP12(p12src.get(), "", &pkey, &cert, &ca);
+  Crypto::parseP12(p12src.get(), "", pkey, cert, ca);
   EXPECT_EQ(pkey,
             "-----BEGIN PRIVATE KEY-----\n"
             "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgRoQ43D8dREwDpt69\n"
@@ -183,30 +183,6 @@ TEST(crypto, parsep12) {
             "JoIkY2MzNGY3ZjMtNDgxZC00NDNiLWJjZWItZTgzOGEzNmEyZDFmMAoGCCqGSM49\n"
             "BAMCA0cAMEQCIF7BH/kXuKD5f6f6ZNd2RLc1iwL2/nKq7FpaF6kunPV3AiA4pwZR\n"
             "p3GnzAJ1QAqaric/3lvcPSofSr5i0OiGi6wwwg==\n"
-            "-----END CERTIFICATE-----\n"
-            "-----BEGIN CERTIFICATE-----\n"
-            "MIIB0DCCAXagAwIBAgIUY9ZexzxoSQ2s9l7rzrdFtziAf04wCgYIKoZIzj0EAwIw\n"
-            "LjEsMCoGA1UEAwwjZ29vZ2xlLW9hdXRoMnwxMDMxMDYxMTkyNTE5NjkyODc1NzEw\n"
-            "HhcNMTcwMzAyMDkzMTI3WhcNMjcwMjI4MDkzMTU3WjAuMSwwKgYDVQQDDCNnb29n\n"
-            "bGUtb2F1dGgyfDEwMzEwNjExOTI1MTk2OTI4NzU3MTBZMBMGByqGSM49AgEGCCqG\n"
-            "SM49AwEHA0IABFjHD4kK3YBw7QTA1K659EMAYl5lxG5y5/4kWTr+bDuvYnYvpjFJ\n"
-            "x2P5CnoGmsffLvzgIjgrFV36cpHmXGalScCjcjBwMA4GA1UdDwEB/wQEAwIBBjAP\n"
-            "BgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTLWJBczmVpkZKtcNg+qusSz+YBSTAu\n"
-            "BgNVHREEJzAlgiNnb29nbGUtb2F1dGgyfDEwMzEwNjExOTI1MTk2OTI4NzU3MTAK\n"
-            "BggqhkjOPQQDAgNIADBFAiEAhoM17gakQxgEm/vkgV3RBo3oFgouzxP/qp2M4r4j\n"
-            "JqcCIBe+3Cgg9KjDGFaexf/T3sz0qjA5aT4/imsTS06NmbhW\n"
-            "-----END CERTIFICATE-----\n"
-            "-----BEGIN CERTIFICATE-----\n"
-            "MIIB0DCCAXagAwIBAgIUY9ZexzxoSQ2s9l7rzrdFtziAf04wCgYIKoZIzj0EAwIw\n"
-            "LjEsMCoGA1UEAwwjZ29vZ2xlLW9hdXRoMnwxMDMxMDYxMTkyNTE5NjkyODc1NzEw\n"
-            "HhcNMTcwMzAyMDkzMTI3WhcNMjcwMjI4MDkzMTU3WjAuMSwwKgYDVQQDDCNnb29n\n"
-            "bGUtb2F1dGgyfDEwMzEwNjExOTI1MTk2OTI4NzU3MTBZMBMGByqGSM49AgEGCCqG\n"
-            "SM49AwEHA0IABFjHD4kK3YBw7QTA1K659EMAYl5lxG5y5/4kWTr+bDuvYnYvpjFJ\n"
-            "x2P5CnoGmsffLvzgIjgrFV36cpHmXGalScCjcjBwMA4GA1UdDwEB/wQEAwIBBjAP\n"
-            "BgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTLWJBczmVpkZKtcNg+qusSz+YBSTAu\n"
-            "BgNVHREEJzAlgiNnb29nbGUtb2F1dGgyfDEwMzEwNjExOTI1MTk2OTI4NzU3MTAK\n"
-            "BggqhkjOPQQDAgNIADBFAiEAhoM17gakQxgEm/vkgV3RBo3oFgouzxP/qp2M4r4j\n"
-            "JqcCIBe+3Cgg9KjDGFaexf/T3sz0qjA5aT4/imsTS06NmbhW\n"
             "-----END CERTIFICATE-----\n");
   EXPECT_EQ(ca,
             "-----BEGIN CERTIFICATE-----\n"
@@ -246,7 +222,7 @@ TEST(crypto, parsep12_FAIL) {
   if (!bad_p12file) {
     EXPECT_TRUE(false) << " could not open tests/test_data/priv.key";
   }
-  bool result = Crypto::parseP12(p12src.get(), "", &pkey, &cert, &ca);
+  bool result = Crypto::parseP12(p12src.get(), "", pkey, cert, ca);
   EXPECT_EQ(result, false);
 }
 


### PR DESCRIPTION
We need to copy only the SubCA for device registration to support curl with GnuTLS backend, which expects us to provide a full client certificate chain.

There are also some unclear things about the certificates we get from the backend:
autoprov_credentials.p12 contains two identical copies of the server RootCA:
```
        Issuer: CN = e237937a-74ef-4d64-8d47-3df9c56eb79e
        Validity
            Not Before: Sep 13 09:04:13 2018 GMT
            Not After : Sep 10 09:04:43 2028 GMT
        Subject: CN = e237937a-74ef-4d64-8d47-3df9c56eb79e
```
Why do we need two of those?

P12 archive that we get after the device registration, again contains two copies of the server RootCA.
Why two? Do we even need to receive the same certificate we already use to establish connection to device gateway for registration?

P12 archive that we get after the device registration also contains the following RootCA:
```
        Issuer: C = IE, O = Baltimore, OU = CyberTrust, CN = Baltimore CyberTrust Root
        Validity
            Not Before: May 12 18:46:00 2000 GMT
            Not After : May 12 23:59:00 2025 GMT
        Subject: C = IE, O = Baltimore, OU = CyberTrust, CN = Baltimore CyberTrust Root
```
What is this certificate and where is it used?

Maybe somebody from the backend team can shed some light on this questions. @koshelev?