### PR TITLE
aktualizr-lite: Include primary ECU for target download

### DIFF
--- a/src/aktualizr_lite/helpers.cc
+++ b/src/aktualizr_lite/helpers.cc
@@ -53,7 +53,7 @@ LiteClient::LiteClient(Config &config_in)
   KeyManager keys(storage, config.keymanagerConfig());
   keys.copyCertsToCurl(*http_client);
 
-  primary = std::make_shared<SotaUptaneClient>(config, storage, http_client);
-  primary->initializePrimaryEcu();
+  primary =
+      std::make_shared<SotaUptaneClient>(config, storage, http_client, nullptr, primary_ecu.first, primary_ecu.second);
   finalizeIfNeeded(*storage, config.pacman);
 }

--- a/src/aktualizr_lite/helpers.h
+++ b/src/aktualizr_lite/helpers.h
@@ -20,6 +20,7 @@ struct LiteClient {
   Config config;
   std::shared_ptr<INvStorage> storage;
   std::shared_ptr<SotaUptaneClient> primary;
+  std::pair<Uptane::EcuSerial, Uptane::HardwareIdentifier> primary_ecu;
 };
 
 #endif  // AKTUALIZR_LITE_HELPERS

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -108,7 +108,7 @@ static std::unique_ptr<Uptane::Target> find_target(const std::shared_ptr<SotaUpt
 }
 
 static int do_update(LiteClient &client, Uptane::Target &target) {
-  target.InsertEcu(client.primary_ecu.first, client.primary_ecu.second);
+  target.InsertEcu(client.primary_ecu);
   if (!client.primary->downloadImage(target).first) {
     return 1;
   }

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -108,6 +108,7 @@ static std::unique_ptr<Uptane::Target> find_target(const std::shared_ptr<SotaUpt
 }
 
 static int do_update(LiteClient &client, Uptane::Target &target) {
+  target.InsertEcu(client.primary_ecu.first, client.primary_ecu.second);
   if (!client.primary->downloadImage(target).first) {
     return 1;
   }

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -266,16 +266,6 @@ Json::Value SotaUptaneClient::AssembleManifest() {
 
 bool SotaUptaneClient::hasPendingUpdates() const { return storage->hasPendingInstall(); }
 
-void SotaUptaneClient::initializePrimaryEcu() {
-  EcuSerials serials;
-  if (!storage->loadEcuSerials(&serials) || serials.size() == 0) {
-    throw std::runtime_error("Unable to load ECU serials after device registration.");
-  }
-
-  primary_ecu_serial_ = serials[0].first;
-  hw_ids.insert(serials[0]);
-}
-
 void SotaUptaneClient::initialize() {
   LOG_DEBUG << "Checking if device is provisioned...";
   auto keys = std::make_shared<KeyManager>(storage, config.keymanagerConfig());
@@ -285,8 +275,14 @@ void SotaUptaneClient::initialize() {
     throw std::runtime_error("Fatal error during provisioning or ECU device registration.");
   }
 
-  initializePrimaryEcu();
-  uptane_manifest = std::make_shared<Uptane::ManifestIssuer>(keys, primary_ecu_serial_);
+  EcuSerials serials;
+  if (!storage->loadEcuSerials(&serials) || serials.size() == 0) {
+    throw std::runtime_error("Unable to load ECU serials after device registration.");
+  }
+
+  uptane_manifest = std::make_shared<Uptane::ManifestIssuer>(keys, serials[0].first);
+  primary_ecu_serial_ = serials[0].first;
+  hw_ids.insert(serials[0]);
 
   verifySecondaries();
   LOG_DEBUG << "... provisioned OK";

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -72,7 +72,8 @@ class SotaUptaneClient {
   Uptane::LazyTargetsList allTargets() const;
   Uptane::Target getCurrent() const { return package_manager_->getCurrent(); }
 
-  bool updateImagesMeta();  // TODO: make private once aktualizr has a proper TUF API
+  bool updateImagesMeta();      // TODO: make private once aktualizr has a proper TUF API
+  void initializePrimaryEcu();  // TODO: make private once aktualizr has a proper TUF API
   bool checkImagesMetaOffline();
   data::InstallationResult PackageInstall(const Uptane::Target &target);
   TargetStatus VerifyTarget(const Uptane::Target &target) const { return package_manager_->verifyTarget(target); }

--- a/src/libaktualizr/uptane/tuf.h
+++ b/src/libaktualizr/uptane/tuf.h
@@ -262,6 +262,10 @@ class Target {
   void setUri(std::string uri) { uri_ = std::move(uri); };
   bool MatchHash(const Hash &hash) const;
 
+  void InsertEcu(const EcuSerial &ecuIdentifier, const HardwareIdentifier &hwid) {
+    ecus_.insert({ecuIdentifier, hwid});
+  }
+
   bool IsForEcu(const EcuSerial &ecuIdentifier) const {
     return (std::find_if(ecus_.cbegin(), ecus_.cend(), [&ecuIdentifier](std::pair<EcuSerial, HardwareIdentifier> pair) {
               return pair.first == ecuIdentifier;

--- a/src/libaktualizr/uptane/tuf.h
+++ b/src/libaktualizr/uptane/tuf.h
@@ -262,9 +262,7 @@ class Target {
   void setUri(std::string uri) { uri_ = std::move(uri); };
   bool MatchHash(const Hash &hash) const;
 
-  void InsertEcu(const EcuSerial &ecuIdentifier, const HardwareIdentifier &hwid) {
-    ecus_.insert({ecuIdentifier, hwid});
-  }
+  void InsertEcu(const std::pair<EcuSerial, HardwareIdentifier> &pair) { ecus_.insert(pair); }
 
   bool IsForEcu(const EcuSerial &ecuIdentifier) const {
     return (std::find_if(ecus_.cbegin(), ecus_.cend(), [&ecuIdentifier](std::pair<EcuSerial, HardwareIdentifier> pair) {


### PR DESCRIPTION
With the introduction of commit
 fead283be7813688f9f69037d2c879a9857157c5

SotaUptaneClient::downloadImage now requires the Target to have
EcuSerial information that would normally come from Uptane. When running
aktualizr-lite, the Target is taken directly from the TUF targets and
does not include this information.

This change allows aktualizr-lite to:

1) Set primary ECU information in the SotaUptaneClient
This change isn't too bad (splitting logic into smaller pieces).
However, it would make more sense if this was a private method.

2) Set Ecu information on the Uptane::Target object.

Signed-off-by: Andy Doan <andy@foundries.io>