### PR TITLE
aktualizr-lite: notify if not configured

### DIFF
--- a/src/aktualizr_lite/CMakeLists.txt
+++ b/src/aktualizr_lite/CMakeLists.txt
@@ -23,7 +23,8 @@ add_aktualizr_test(NAME lite-helpers SOURCES helpers.cc helpers_test.cc
                    ARGS ${PROJECT_BINARY_DIR}/ostree_repo)
 set_tests_properties(test_lite-helpers PROPERTIES
         ENVIRONMENT LD_PRELOAD=$<TARGET_FILE:t_lite-mock> LABELS "noptest")
-
+else(BUILD_OSTREE)
+	message(STATUS "aktualizr-lite not configured, skipping")
 endif(BUILD_OSTREE)
 
 aktualizr_source_file_checks(main.cc ${AKTUALIZR_LITE_SRC} ${AKTUALIZR_LITE_HEADERS} helpers_test.cc ostree_mock.cc)


### PR DESCRIPTION
notify the user if aktualizr-lite is not configured to be built.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>