### PR TITLE
OLPSUP-9046: Handle expired Director's target metadata

### DIFF
--- a/src/aktualizr_secondary/aktualizr_secondary.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary.cc
@@ -25,11 +25,12 @@ AktualizrSecondary::AktualizrSecondary(AktualizrSecondaryConfig config, std::sha
     std::vector<Uptane::Target> installed_versions;
     boost::optional<Uptane::Target> pending_target;
     storage_->loadInstalledVersions(ecu_serial_.ToString(), nullptr, &pending_target);
-    data::InstallationResult install_res =
-        data::InstallationResult(data::ResultCode::Numeric::kUnknown, "Unknown installation error");
-    LOG_INFO << "Pending update found; attempting to apply it. Target hash: " << pending_target->sha256Hash();
 
     if (!!pending_target) {
+      data::InstallationResult install_res =
+          data::InstallationResult(data::ResultCode::Numeric::kUnknown, "Unknown installation error");
+      LOG_INFO << "Pending update found; attempting to apply it. Target hash: " << pending_target->sha256Hash();
+
       install_res = update_agent_->applyPendingInstall(*pending_target);
 
       if (install_res.result_code != data::ResultCode::Numeric::kNeedCompletion) {

--- a/src/aktualizr_secondary/update_agent_ostree.cc
+++ b/src/aktualizr_secondary/update_agent_ostree.cc
@@ -78,18 +78,7 @@ data::ResultCode::Numeric OstreeUpdateAgent::install(const Uptane::Target& targe
 }
 
 data::InstallationResult OstreeUpdateAgent::applyPendingInstall(const Uptane::Target& target) {
-  if (!_ostreePackMan->rebootDetected()) {
-    // it should be removed from here, once we refactor the ostree package manager,
-    // e.g. _ostreePackMan->finalizeInstall() does this check/if
-    return data::InstallationResult(data::ResultCode::Numeric::kNeedCompletion,
-                                    "Reboot is required for the pending update application");
-  }
-
-  data::InstallationResult install_result = _ostreePackMan->finalizeInstall(target);
-  // it should be removed from here, once we refactor the ostree package manager,
-  // e.g. the pacman will reset/clear the flag by itself
-  _ostreePackMan->rebootFlagClear();
-  return install_result;
+  return _ostreePackMan->finalizeInstall(target);
 }
 
 void extractCredentialsArchive(const std::string& archive, std::string* ca, std::string* cert, std::string* pkey,

--- a/src/libaktualizr/package_manager/debianmanager.h
+++ b/src/libaktualizr/package_manager/debianmanager.h
@@ -17,7 +17,7 @@ class DebianManager : public PackageManagerInterface {
   Json::Value getInstalledPackages() const override;
   Uptane::Target getCurrent() const override;
   data::InstallationResult install(const Uptane::Target &target) const override;
-  data::InstallationResult finalizeInstall(const Uptane::Target &target) const override {
+  data::InstallationResult finalizeInstall(const Uptane::Target &target) override {
     (void)target;
     throw std::runtime_error("Unimplemented");
   }

--- a/src/libaktualizr/package_manager/ostreemanager.cc
+++ b/src/libaktualizr/package_manager/ostreemanager.cc
@@ -215,24 +215,20 @@ data::InstallationResult OstreeManager::finalizeInstall(const Uptane::Target &ta
                                     "Reboot is required for the pending update application");
   }
 
-  data::InstallationResult install_result = applyInstall(target);
-  // it should be removed from here, once we refactor the ostree package manager,
-  // e.g. the pacman will reset/clear the flag by itself
-  bootloader_->rebootFlagClear();
-  return install_result;
-}
-
-data::InstallationResult OstreeManager::applyInstall(const Uptane::Target &target) {
   LOG_INFO << "Checking installation of new OSTree sysroot";
   const std::string current_hash = getCurrentHash();
+
+  data::InstallationResult install_result =
+      data::InstallationResult(data::ResultCode::Numeric::kOk, "Successfully booted on new version");
 
   if (current_hash != target.sha256Hash()) {
     LOG_ERROR << "Expected to boot " << target.sha256Hash() << " but found " << current_hash
               << ". The system may have been rolled back.";
-    return data::InstallationResult(data::ResultCode::Numeric::kInstallFailed, "Wrong version booted");
+    install_result = data::InstallationResult(data::ResultCode::Numeric::kInstallFailed, "Wrong version booted");
   }
 
-  return data::InstallationResult(data::ResultCode::Numeric::kOk, "Successfully booted on new version");
+  bootloader_->rebootFlagClear();
+  return install_result;
 }
 
 OstreeManager::OstreeManager(PackageConfig pconfig, BootloaderConfig bconfig, std::shared_ptr<INvStorage> storage,

--- a/src/libaktualizr/package_manager/ostreemanager.h
+++ b/src/libaktualizr/package_manager/ostreemanager.h
@@ -65,7 +65,6 @@ class OstreeManager : public PackageManagerInterface {
 
  private:
   TargetStatus verifyTargetInternal(const Uptane::Target &target) const;
-  data::InstallationResult applyInstall(const Uptane::Target &target);
 };
 
 #endif  // OSTREE_H_

--- a/src/libaktualizr/package_manager/ostreemanager.h
+++ b/src/libaktualizr/package_manager/ostreemanager.h
@@ -49,7 +49,7 @@ class OstreeManager : public PackageManagerInterface {
   bool imageUpdated();
   data::InstallationResult install(const Uptane::Target &target) const override;
   void completeInstall() const override;
-  data::InstallationResult finalizeInstall(const Uptane::Target &target) const override;
+  data::InstallationResult finalizeInstall(const Uptane::Target &target) override;
   bool fetchTarget(const Uptane::Target &target, Uptane::Fetcher &fetcher, const KeyManager &keys,
                    FetcherProgressCb progress_cb, const api::FlowControlToken *token) override;
   TargetStatus verifyTarget(const Uptane::Target &target) const override;
@@ -65,6 +65,7 @@ class OstreeManager : public PackageManagerInterface {
 
  private:
   TargetStatus verifyTargetInternal(const Uptane::Target &target) const;
+  data::InstallationResult applyInstall(const Uptane::Target &target);
 };
 
 #endif  // OSTREE_H_

--- a/src/libaktualizr/package_manager/packagemanagerfake.h
+++ b/src/libaktualizr/package_manager/packagemanagerfake.h
@@ -19,7 +19,7 @@ class PackageManagerFake : public PackageManagerInterface {
 
   data::InstallationResult install(const Uptane::Target &target) const override;
   void completeInstall() const override;
-  data::InstallationResult finalizeInstall(const Uptane::Target &target) const override;
+  data::InstallationResult finalizeInstall(const Uptane::Target &target) override;
   bool fetchTarget(const Uptane::Target &target, Uptane::Fetcher &fetcher, const KeyManager &keys,
                    FetcherProgressCb progress_cb, const api::FlowControlToken *token) override;
 };

--- a/src/libaktualizr/package_manager/packagemanagerfake_test.cc
+++ b/src/libaktualizr/package_manager/packagemanagerfake_test.cc
@@ -87,6 +87,8 @@ TEST(PackageManagerFake, FinalizeAfterReboot) {
   EXPECT_EQ(result.result_code, data::ResultCode::Numeric::kNeedCompletion);
   storage->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kPending);
 
+  fakepm.completeInstall();
+
   result = fakepm.finalizeInstall(target);
   EXPECT_EQ(result.result_code, data::ResultCode::Numeric::kOk);
 }

--- a/src/libaktualizr/package_manager/packagemanagerinterface.h
+++ b/src/libaktualizr/package_manager/packagemanagerinterface.h
@@ -47,7 +47,7 @@ class PackageManagerInterface {
   virtual Uptane::Target getCurrent() const = 0;
   virtual data::InstallationResult install(const Uptane::Target& target) const = 0;
   virtual void completeInstall() const { throw std::runtime_error("Unimplemented"); };
-  virtual data::InstallationResult finalizeInstall(const Uptane::Target& target) const = 0;
+  virtual data::InstallationResult finalizeInstall(const Uptane::Target& target) = 0;
   virtual bool rebootDetected() { return bootloader_->rebootDetected(); };
   virtual void rebootFlagClear() { bootloader_->rebootFlagClear(); };
   virtual void updateNotify() { bootloader_->updateNotify(); };

--- a/src/libaktualizr/primary/CMakeLists.txt
+++ b/src/libaktualizr/primary/CMakeLists.txt
@@ -48,6 +48,10 @@ add_aktualizr_test(NAME metadata_fetch SOURCES metadata_fetch_test.cc PROJECT_WO
                    ARGS "$<TARGET_FILE:uptane-generator>" LIBRARIES uptane_generator_lib)
 target_link_libraries(t_metadata_fetch virtual_secondary)
 
+add_aktualizr_test(NAME metadata_expiration SOURCES metadata_expiration_test.cc PROJECT_WORKING_DIRECTORY
+                   ARGS "$<TARGET_FILE:uptane-generator>" LIBRARIES uptane_generator_lib)
+target_link_libraries(t_metadata_expiration virtual_secondary)
+
 add_aktualizr_test(NAME device_cred_prov SOURCES device_cred_prov_test.cc PROJECT_WORKING_DIRECTORY LIBRARIES PUBLIC uptane_generator_lib)
 set_tests_properties(test_device_cred_prov PROPERTIES LABELS "crypto")
 

--- a/src/libaktualizr/primary/metadata_expiration_test.cc
+++ b/src/libaktualizr/primary/metadata_expiration_test.cc
@@ -129,7 +129,9 @@ TEST_F(MetadataExpirationTest, MetadataExpirationAfterInstallationAndBeforeReboo
   result::UpdateCheck update_result = aktualizr_->CheckUpdates().get();
   EXPECT_EQ(update_result.status, result::UpdateStatus::kNoUpdatesAvailable);
 
-  addTargetToInstall(2);
+  const int expiration_in_sec = 5;
+  addTargetToInstall(expiration_in_sec);
+  auto target_init_time = std::chrono::system_clock::now();
 
   // run the uptane cycle to install the target
   aktualizr_->UptaneCycle();
@@ -140,7 +142,8 @@ TEST_F(MetadataExpirationTest, MetadataExpirationAfterInstallationAndBeforeReboo
   ASSERT_TRUE(client->isInstallCompletionRequired());
 
   // emulate the target metadata expiration while the uptane cycle is running
-  std::this_thread::sleep_for(std::chrono::seconds(3));
+  std::this_thread::sleep_for(std::chrono::seconds(expiration_in_sec) -
+                              (std::chrono::system_clock::now() - target_init_time));
   aktualizr_->UptaneCycle();
 
   // since the installation happenned before the metadata expiration we expect that
@@ -168,7 +171,9 @@ TEST_F(MetadataExpirationTest, MetadataExpirationAfterInstallationAndBeforeAppli
   result::UpdateCheck update_result = aktualizr_->CheckUpdates().get();
   EXPECT_EQ(update_result.status, result::UpdateStatus::kNoUpdatesAvailable);
 
-  addTargetToInstall(2);
+  const int expiration_in_sec = 5;
+  addTargetToInstall(expiration_in_sec);
+  auto target_init_time = std::chrono::system_clock::now();
 
   // run the uptane cycle to install the target
   aktualizr_->UptaneCycle();
@@ -179,7 +184,9 @@ TEST_F(MetadataExpirationTest, MetadataExpirationAfterInstallationAndBeforeAppli
   ASSERT_TRUE(client->isInstallCompletionRequired());
 
   // wait until the target metadata are expired
-  std::this_thread::sleep_for(std::chrono::seconds(3));
+  // emulate the target metadata expiration while the uptane cycle is running
+  std::this_thread::sleep_for(std::chrono::seconds(expiration_in_sec) -
+                              (std::chrono::system_clock::now() - target_init_time));
 
   // force reboot
   client->completeInstall();

--- a/src/libaktualizr/primary/metadata_expiration_test.cc
+++ b/src/libaktualizr/primary/metadata_expiration_test.cc
@@ -1,0 +1,212 @@
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "httpfake.h"
+#include "primary/aktualizr.h"
+#include "test_utils.h"
+#include "uptane_test_common.h"
+
+boost::filesystem::path uptane_generator_path;
+
+class MetadataExpirationTest : public ::testing::Test {
+ protected:
+  MetadataExpirationTest() : uptane_gen_(uptane_generator_path.string()) {
+    Process uptane_gen(uptane_generator_path.string());
+    uptane_gen.run({"generate", "--path", meta_dir_.PathString()});
+
+    auto http = std::make_shared<HttpFake>(temp_dir_.Path(), "", meta_dir_.Path() / "repo");
+    Config conf = UptaneTestCommon::makeTestConfig(temp_dir_, http->tls_server);
+    conf.pacman.fake_need_reboot = true;
+    conf.uptane.force_install_completion = true;
+    conf.bootloader.reboot_sentinel_dir = temp_dir_.Path();
+
+    logger_set_threshold(boost::log::trivial::trace);
+
+    storage_ = INvStorage::newStorage(conf.storage);
+    aktualizr_ = std::make_shared<UptaneTestCommon::TestAktualizr>(conf, storage_, http);
+  }
+
+  void addImage() {
+    uptane_gen_.run({"image", "--path", meta_dir_.PathString(), "--filename", "tests/test_data/firmware.txt",
+                     "--targetname", target_filename_, "--hwid", "primary_hw"});
+
+    target_image_hash_ = boost::algorithm::to_lower_copy(
+        boost::algorithm::hex(Crypto::sha256digest(Utils::readFile("tests/test_data/firmware.txt"))));
+  }
+
+  void addTarget(const std::string& target_filename, int expiration_delta = 0) {
+    if (expiration_delta != 0) {
+      time_t new_expiration_time;
+      std::time(&new_expiration_time);
+      new_expiration_time += expiration_delta;
+      struct tm new_expiration_time_str {};
+      gmtime_r(&new_expiration_time, &new_expiration_time_str);
+
+      uptane_gen_.run({"addtarget", "--path", meta_dir_.PathString(), "--targetname", target_filename, "--hwid",
+                       "primary_hw", "--serial", "CA:FE:A6:D2:84:9D", "--expires",
+                       TimeStamp(new_expiration_time_str).ToString()});
+
+    } else {
+      uptane_gen_.run({"addtarget", "--path", meta_dir_.PathString(), "--targetname", target_filename, "--hwid",
+                       "primary_hw", "--serial", "CA:FE:A6:D2:84:9D"});
+    }
+  }
+
+  void addTargetAndSign(const std::string& target_filename, int expiration_delta = 0) {
+    addTarget(target_filename, expiration_delta);
+    uptane_gen_.run({"signtargets", "--path", meta_dir_.PathString()});
+  }
+
+  void refreshTargetMetadata() {
+    // refresh the target metadata in the repo/Director
+    uptane_gen_.run({"refresh", "--path", meta_dir_.PathString(), "--repotype", "director", "--keyname", "targets"});
+  }
+
+  void addTargetToInstall(int expiration_delta = 0) {
+    addImage();
+    addTargetAndSign(target_filename_, expiration_delta);
+  }
+
+ protected:
+  Process uptane_gen_;
+  const std::string target_filename_ = "firmware.txt";
+  std::string target_image_hash_;
+
+  TemporaryDirectory meta_dir_;
+  TemporaryDirectory temp_dir_;
+  std::shared_ptr<INvStorage> storage_;
+  std::shared_ptr<UptaneTestCommon::TestAktualizr> aktualizr_;
+};
+
+TEST_F(MetadataExpirationTest, MetadataExpirationBeforeInstallation) {
+  aktualizr_->Initialize();
+  result::UpdateCheck update_result = aktualizr_->CheckUpdates().get();
+  EXPECT_EQ(update_result.status, result::UpdateStatus::kNoUpdatesAvailable);
+
+  addTargetToInstall(-1);
+
+  // run the uptane cycle an try to install the target
+  aktualizr_->UptaneCycle();
+
+  // check if the target has been installed and pending to be applied after a reboot
+  auto& client = aktualizr_->uptane_client();
+  ASSERT_FALSE(client->hasPendingUpdates());
+  ASSERT_FALSE(client->isInstallCompletionRequired());
+
+  auto currently_installed_target = client->getCurrent();
+
+  EXPECT_NE(target_image_hash_, currently_installed_target.sha256Hash());
+  EXPECT_NE(target_filename_, currently_installed_target.filename());
+
+  refreshTargetMetadata();
+
+  // run the uptane cycle an try to install the target
+  aktualizr_->UptaneCycle();
+
+  // check if the target has been installed and pending to be applied after a reboot
+  ASSERT_TRUE(client->hasPendingUpdates());
+  ASSERT_TRUE(client->isInstallCompletionRequired());
+
+  // force reboot
+  client->completeInstall();
+
+  // emulate aktualizr fresh start
+  aktualizr_->Initialize();
+  aktualizr_->UptaneCycle();
+
+  ASSERT_FALSE(client->hasPendingUpdates());
+  ASSERT_FALSE(client->isInstallCompletionRequired());
+
+  currently_installed_target = client->getCurrent();
+  EXPECT_EQ(target_image_hash_, currently_installed_target.sha256Hash());
+  EXPECT_EQ(target_filename_, currently_installed_target.filename());
+}
+
+TEST_F(MetadataExpirationTest, MetadataExpirationAfterInstallationAndBeforeReboot) {
+  aktualizr_->Initialize();
+
+  result::UpdateCheck update_result = aktualizr_->CheckUpdates().get();
+  EXPECT_EQ(update_result.status, result::UpdateStatus::kNoUpdatesAvailable);
+
+  addTargetToInstall(2);
+
+  // run the uptane cycle to install the target
+  aktualizr_->UptaneCycle();
+
+  // check if the target has been installed and pending to be applied after a reboot
+  auto& client = aktualizr_->uptane_client();
+  ASSERT_TRUE(client->hasPendingUpdates());
+  ASSERT_TRUE(client->isInstallCompletionRequired());
+
+  // emulate the target metadata expiration while the uptane cycle is running
+  std::this_thread::sleep_for(std::chrono::seconds(3));
+  aktualizr_->UptaneCycle();
+
+  // since the installation happenned before the metadata expiration we expect that
+  // the update is still pending and will be applied after a reboot
+  ASSERT_TRUE(client->hasPendingUpdates());
+  ASSERT_TRUE(client->isInstallCompletionRequired());
+
+  // force reboot
+  client->completeInstall();
+
+  // emulate aktualizr fresh start
+  aktualizr_->Initialize();
+  aktualizr_->UptaneCycle();
+
+  // check if the pending target has been applied. it should be applied in even if it's metadata are expired
+  // as long as it was installed at the moment when they were not expired
+  auto currently_installed_target = client->getCurrent();
+  EXPECT_EQ(target_image_hash_, currently_installed_target.sha256Hash());
+  EXPECT_EQ(target_filename_, currently_installed_target.filename());
+}
+
+TEST_F(MetadataExpirationTest, MetadataExpirationAfterInstallationAndBeforeApplication) {
+  aktualizr_->Initialize();
+
+  result::UpdateCheck update_result = aktualizr_->CheckUpdates().get();
+  EXPECT_EQ(update_result.status, result::UpdateStatus::kNoUpdatesAvailable);
+
+  addTargetToInstall(2);
+
+  // run the uptane cycle to install the target
+  aktualizr_->UptaneCycle();
+
+  // check if the target has been installed and pending to be applied after a reboot
+  auto& client = aktualizr_->uptane_client();
+  ASSERT_TRUE(client->hasPendingUpdates());
+  ASSERT_TRUE(client->isInstallCompletionRequired());
+
+  // wait until the target metadata are expired
+  std::this_thread::sleep_for(std::chrono::seconds(3));
+
+  // force reboot
+  client->completeInstall();
+
+  // emulate aktualizr fresh start
+  aktualizr_->Initialize();
+  aktualizr_->UptaneCycle();
+
+  // check if the pending target has been applied. it should be applied in even if it's metadta are expired
+  // as long as it was installed at the moment when they were not expired
+  auto currently_installed_target = client->getCurrent();
+  EXPECT_EQ(target_image_hash_, currently_installed_target.sha256Hash());
+  EXPECT_EQ(target_filename_, currently_installed_target.filename());
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  if (argc != 2) {
+    std::cerr << "Error: " << argv[0] << " requires the path to the uptane-generator utility\n";
+    return EXIT_FAILURE;
+  }
+  uptane_generator_path = argv[1];
+
+  logger_init();
+  logger_set_threshold(boost::log::trivial::trace);
+
+  return RUN_ALL_TESTS();
+}
+
+// vim: set tabstop=2 shiftwidth=2 expandtab:

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -76,54 +76,52 @@ data::InstallationResult SotaUptaneClient::PackageInstall(const Uptane::Target &
 }
 
 void SotaUptaneClient::finalizeAfterReboot() {
-  if (!package_manager_->rebootDetected()) {
-    // nothing to do
+  // TODO: consider bringing checkAndUpdatePendingSecondaries and the following functionality
+  // to the common denominator
+  if (!hasPendingUpdates()) {
+    LOG_INFO << "No any pending update, continue with initialization";
     return;
   }
 
-  LOG_INFO << "Device has been rebooted after an update";
+  LOG_INFO << "Checking for a pending update to apply for Primary ECU";
 
-  std::vector<Uptane::Target> updates;
-  unsigned int ecus_count = 0;
-  if (uptaneOfflineIteration(&updates, &ecus_count)) {
-    const Uptane::EcuSerial &primary_ecu_serial = primaryEcuSerial();
+  const Uptane::EcuSerial &primary_ecu_serial = primaryEcuSerial();
+  boost::optional<Uptane::Target> pending_target;
+  storage->loadInstalledVersions(primary_ecu_serial.ToString(), nullptr, &pending_target);
 
-    std::vector<Uptane::Target> installed_versions;
-    boost::optional<Uptane::Target> pending_target;
-    storage->loadInstalledVersions(primary_ecu_serial.ToString(), nullptr, &pending_target);
-
-    if (!!pending_target && pending_target->IsForEcu(primary_ecu_serial)) {
-      const std::string correlation_id = pending_target->correlation_id();
-
-      data::InstallationResult install_res = package_manager_->finalizeInstall(*pending_target);
-      storage->saveEcuInstallationResult(primary_ecu_serial, install_res);
-      if (install_res.success) {
-        storage->saveInstalledVersion(primary_ecu_serial.ToString(), *pending_target,
-                                      InstalledVersionUpdateMode::kCurrent);
-        report_queue->enqueue(
-            std_::make_unique<EcuInstallationCompletedReport>(primary_ecu_serial, correlation_id, true));
-      } else {
-        // finalize failed
-        // unset pending flag so that the rest of the uptane process can
-        // go forward again
-        storage->saveInstalledVersion(primary_ecu_serial.ToString(), *pending_target,
-                                      InstalledVersionUpdateMode::kNone);
-        report_queue->enqueue(
-            std_::make_unique<EcuInstallationCompletedReport>(primary_ecu_serial, correlation_id, false));
-        director_repo.dropTargets(*storage);  // fix for OTA-2587, listen to backend again after end of install
-      }
-
-      computeDeviceInstallationResult(nullptr, correlation_id);
-      putManifestSimple();
-    } else {
-      // nothing found on primary
-      LOG_ERROR << "No any pending update for Primary is found";
-    }
-  } else {
-    LOG_ERROR << "Invalid Uptane metadata in storage.";
+  if (!pending_target) {
+    LOG_ERROR << "No any pending update for Primary ECU is found, continue with initialization";
+    return;
   }
 
-  package_manager_->rebootFlagClear();
+  LOG_INFO << "Pending update for Primary ECU was found, trying to apply it...";
+
+  data::InstallationResult install_res = package_manager_->finalizeInstall(*pending_target);
+
+  if (install_res.result_code == data::ResultCode::Numeric::kNeedCompletion) {
+    LOG_INFO << "Pending update for Primary ECU was not applied because reboot was not detected, "
+                "continue with initialization";
+    return;
+  }
+
+  storage->saveEcuInstallationResult(primary_ecu_serial, install_res);
+
+  const std::string correlation_id = pending_target->correlation_id();
+  if (install_res.success) {
+    storage->saveInstalledVersion(primary_ecu_serial.ToString(), *pending_target, InstalledVersionUpdateMode::kCurrent);
+
+    report_queue->enqueue(std_::make_unique<EcuInstallationCompletedReport>(primary_ecu_serial, correlation_id, true));
+  } else {
+    // finalize failed, unset pending flag so that the rest of the uptane process can go forward again
+    storage->saveInstalledVersion(primary_ecu_serial.ToString(), *pending_target, InstalledVersionUpdateMode::kNone);
+    report_queue->enqueue(std_::make_unique<EcuInstallationCompletedReport>(primary_ecu_serial, correlation_id, false));
+  }
+
+  director_repo.dropTargets(*storage);  // fix for OTA-2587, listen to backend again after end of install
+  computeDeviceInstallationResult(nullptr, correlation_id);
+  // Do we really need to send a device manifest here at the initialization phase
+  // while we send it within the uptane cycle anyway
+  putManifestSimple();
 }
 
 data::InstallationResult SotaUptaneClient::PackageInstallSetResult(const Uptane::Target &target) {

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -119,8 +119,6 @@ void SotaUptaneClient::finalizeAfterReboot() {
 
   director_repo.dropTargets(*storage);  // fix for OTA-2587, listen to backend again after end of install
   computeDeviceInstallationResult(nullptr, correlation_id);
-  // Do we really need to send a device manifest here at the initialization phase
-  // while we send it within the uptane cycle anyway
   putManifestSimple();
 }
 

--- a/src/libaktualizr/uptane/directorrepository.cc
+++ b/src/libaktualizr/uptane/directorrepository.cc
@@ -63,6 +63,7 @@ bool DirectorRepository::checkMetaOffline(INvStorage& storage) {
     }
 
     if (targetsExpired()) {
+      last_exception = Uptane::ExpiredMetadata(type.toString(), Role::Targets().ToString());
       return false;
     }
   }

--- a/src/libaktualizr/uptane/directorrepository.cc
+++ b/src/libaktualizr/uptane/directorrepository.cc
@@ -128,6 +128,7 @@ bool DirectorRepository::updateMeta(INvStorage& storage, const IMetadataFetcher&
     }
 
     if (targetsExpired()) {
+      last_exception = Uptane::ExpiredMetadata(type.toString(), Role::Targets().ToString());
       return false;
     }
   }

--- a/src/libaktualizr/utilities/types.cc
+++ b/src/libaktualizr/utilities/types.cc
@@ -3,14 +3,21 @@
 #include <stdexcept>
 #include <utility>
 
-TimeStamp TimeStamp::Now() {
+std::string TimeToString(struct tm time) {
+  char formatted[22];
+  strftime(formatted, 22, "%Y-%m-%dT%H:%M:%SZ", &time);
+  return formatted;
+}
+
+TimeStamp TimeStamp::Now() { return TimeStamp(CurrentTime()); }
+
+struct tm TimeStamp::CurrentTime() {
   time_t raw_time;
   struct tm time_struct {};
   time(&raw_time);
   gmtime_r(&raw_time, &time_struct);
-  char formatted[22];
-  strftime(formatted, 22, "%Y-%m-%dT%H:%M:%SZ", &time_struct);
-  return TimeStamp(formatted);
+
+  return time_struct;
 }
 
 TimeStamp::TimeStamp(std::string rfc3339) {
@@ -19,6 +26,8 @@ TimeStamp::TimeStamp(std::string rfc3339) {
   }
   time_ = rfc3339;
 }
+
+TimeStamp::TimeStamp(struct tm time) : TimeStamp(TimeToString(time)) {}
 
 bool TimeStamp::IsValid() const { return time_.length() != 0; }
 

--- a/src/libaktualizr/utilities/types.h
+++ b/src/libaktualizr/utilities/types.h
@@ -85,9 +85,11 @@ inline std::ostream& operator<<(std::ostream& os, CryptoSource cs) {
 class TimeStamp {
  public:
   static TimeStamp Now();
+  static struct tm CurrentTime();
   /** An invalid TimeStamp */
   TimeStamp() { ; }
   explicit TimeStamp(std::string rfc3339);
+  explicit TimeStamp(struct tm time);
   bool IsExpiredAt(const TimeStamp& now) const;
   bool IsValid() const;
   std::string ToString() const { return time_; }

--- a/src/uptane_generator/director_repo.cc
+++ b/src/uptane_generator/director_repo.cc
@@ -1,7 +1,7 @@
 #include "director_repo.h"
 
 void DirectorRepo::addTarget(const std::string &target_name, const Json::Value &target, const std::string &hardware_id,
-                             const std::string &ecu_serial, const std::string &url) {
+                             const std::string &ecu_serial, const std::string &url, const std::string &expires) {
   const boost::filesystem::path current = path_ / DirectorRepo::dir / "targets.json";
   const boost::filesystem::path staging = path_ / DirectorRepo::dir / "staging/targets.json";
 
@@ -13,6 +13,9 @@ void DirectorRepo::addTarget(const std::string &target_name, const Json::Value &
   } else {
     throw std::runtime_error(std::string("targets.json not found at ") + staging.c_str() + " or " + current.c_str() +
                              "!");
+  }
+  if (!expires.empty()) {
+    director_targets["expires"] = expires;
   }
   director_targets["targets"][target_name] = target;
   director_targets["targets"][target_name]["custom"].removeMember("hardwareIds");

--- a/src/uptane_generator/director_repo.h
+++ b/src/uptane_generator/director_repo.h
@@ -8,7 +8,7 @@ class DirectorRepo : public Repo {
   DirectorRepo(boost::filesystem::path path, const std::string &expires, std::string correlation_id)
       : Repo(Uptane::RepositoryType::Director(), std::move(path), expires, std::move(correlation_id)) {}
   void addTarget(const std::string &target_name, const Json::Value &target, const std::string &hardware_id,
-                 const std::string &ecu_serial, const std::string &url);
+                 const std::string &ecu_serial, const std::string &url, const std::string &expires = "");
   void revokeTargets(const std::vector<std::string> &targets_to_remove);
   void signTargets();
   void emptyTargets();

--- a/src/uptane_generator/main.cc
+++ b/src/uptane_generator/main.cc
@@ -165,7 +165,7 @@ int main(int argc, char **argv) {
         if (vm.count("url") != 0) {
           url = vm["url"].as<std::string>();
         }
-        repo.addTarget(targetname, hwid, serial, url);
+        repo.addTarget(targetname, hwid, serial, url, expiration_time);
         std::cout << "Added target " << targetname << " to director targets metadata for ECU with serial " << serial
                   << " and hardware ID " << hwid << std::endl;
       } else if (command == "adddelegation") {

--- a/src/uptane_generator/uptane_repo.cc
+++ b/src/uptane_generator/uptane_repo.cc
@@ -11,12 +11,12 @@ void UptaneRepo::generateRepo(KeyType key_type) {
 }
 
 void UptaneRepo::addTarget(const std::string &target_name, const std::string &hardware_id,
-                           const std::string &ecu_serial, const std::string &url) {
+                           const std::string &ecu_serial, const std::string &url, const std::string &expires) {
   auto target = image_repo_.getTarget(target_name);
   if (target == Json::nullValue) {
     throw std::runtime_error("No such " + target_name + " target in the image repository");
   }
-  director_repo_.addTarget(target_name, target, hardware_id, ecu_serial, url);
+  director_repo_.addTarget(target_name, target, hardware_id, ecu_serial, url, expires);
 }
 
 void UptaneRepo::addDelegation(const Uptane::Role &name, const Uptane::Role &parent_role, const std::string &path,

--- a/src/uptane_generator/uptane_repo.h
+++ b/src/uptane_generator/uptane_repo.h
@@ -9,7 +9,7 @@ class UptaneRepo {
   UptaneRepo(const boost::filesystem::path &path, const std::string &expires, const std::string &correlation_id);
   void generateRepo(KeyType key_type = KeyType::kRSA2048);
   void addTarget(const std::string &target_name, const std::string &hardware_id, const std::string &ecu_serial,
-                 const std::string &url);
+                 const std::string &url, const std::string &expires = "");
   void addImage(const boost::filesystem::path &image_path, const boost::filesystem::path &targetname,
                 const std::string &hardware_id, const std::string &url, const Delegation &delegation);
   void addDelegation(const Uptane::Role &name, const Uptane::Role &parent_role, const std::string &path,

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import signal
 import socket
+import time
 
 from os import devnull
 from os import path
@@ -741,7 +742,7 @@ class UptaneTestRepo:
 
         return target_hash
 
-    def add_ostree_target(self, id, rev_hash, target_name=None):
+    def add_ostree_target(self, id, rev_hash, target_name=None, expires_within_sec=(60 * 5)):
         # emulate the backend behavior on defining a target name for OSTREE target format
         target_name = rev_hash if target_name is None else "{}-{}".format(target_name, rev_hash)
         image_creation_cmdline = [self._repo_manager_exe,
@@ -754,12 +755,16 @@ class UptaneTestRepo:
                                   '--hwid', id[0]]
         subprocess.run(image_creation_cmdline, check=True)
 
+        expiration_time = time.time() + expires_within_sec
+        expiration_time_str = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(expiration_time))
+
         subprocess.run([self._repo_manager_exe,
                         '--command', 'addtarget',
                         '--path', self.root_dir,
                         '--targetname', target_name,
                         '--hwid', id[0],
-                        '--serial', id[1]],
+                        '--serial', id[1],
+                        '--expires', expiration_time_str],
                        check=True)
 
         subprocess.run([self._repo_manager_exe, '--path', self.root_dir, '--command', 'signtargets'], check=True)

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -2,6 +2,7 @@
 
 import logging
 import argparse
+import time
 
 from os import getcwd, chdir
 
@@ -13,10 +14,11 @@ logger = logging.getLogger(__file__)
 
 
 """
- Test update of Primary and Secondary if their package manager differs, `ostree` and `fake` respectively
+ Test update of Primary and Secondary if their package manager differs, `ostree`
+ and binary (`none` or `fake`) respectively
 
  Aktualizr/Primary's package manager is set to `ostree`
- Secondary's package manager is set to `fake`
+ Secondary's package manager is set to `fake` which means a file/binary update
  Primary goal is to verify whether aktualizr succeeds with a binary/fake update of secondary
  while aktualizr/primary is configured with ostree package manager
 """
@@ -26,8 +28,8 @@ logger = logging.getLogger(__file__)
 @with_treehub()
 @with_sysroot()
 @with_aktualizr(start=False, run_mode='once', output_logs=True)
-def test_primary_ostree_secondary_fake_updates(uptane_repo, secondary, aktualizr, director,
-                                               uptane_server, sysroot, treehub):
+def test_primary_ostree_secondary_file_updates(uptane_repo, secondary, aktualizr, director, sysroot,
+                                               treehub, uptane_server):
     target_rev = treehub.revision
     # add an ostree update for Primary
     uptane_repo.add_ostree_target(aktualizr.id, target_rev)
@@ -62,6 +64,103 @@ def test_primary_ostree_secondary_fake_updates(uptane_repo, secondary, aktualizr
     return result
 
 
+"""
+ Test update of Secondary's ostree repo if an ostree target metadata are expired
+
+ Metadata are valid at the moment of a new ostree revision installation,
+ but are expired after that and before Secondary is rebooted,
+ we still expect that the installed update is applied in this case
+"""
+@with_treehub()
+@with_uptane_backend()
+@with_director()
+@with_sysroot()
+@with_secondary(start=False)
+@with_aktualizr(start=False, run_mode='once', output_logs=True)
+def test_secodary_ostree_update_if_metadata_expires(uptane_repo, secondary, aktualizr, treehub, sysroot, director, **kwargs):
+    target_rev = treehub.revision
+    expires_within_sec = 10
+
+    uptane_repo.add_ostree_target(secondary.id, target_rev, expires_within_sec=expires_within_sec)
+    start_time = time.time()
+
+    with secondary:
+        with aktualizr:
+            aktualizr.wait_for_completion()
+
+    pending_rev = aktualizr.get_current_pending_image_info(secondary.id)
+
+    if pending_rev != target_rev:
+        logger.error("Pending version {} != the target one {}".format(pending_rev, target_rev))
+        return False
+
+    # wait until the target metadata are expired
+    time.sleep(max(0, expires_within_sec - (time.time() - start_time)))
+
+    sysroot.update_revision(pending_rev)
+    secondary.emulate_reboot()
+
+    with secondary:
+        with aktualizr:
+            aktualizr.wait_for_completion()
+
+    if not director.get_install_result():
+        logger.error("Installation result is not successful")
+        return False
+
+    installed_rev = aktualizr.get_current_image_info(secondary.id)
+
+    if installed_rev != target_rev:
+        logger.error("Installed version {} != the target one {}".format(installed_rev, target_rev))
+        return False
+
+    return True
+
+
+"""
+ Test update of Primary's ostree repo if an ostree target metadata are expired
+
+ Metadata are valid at the moment of a new ostree revision installation,
+ but are expired after that and before Primary is rebooted,
+ we still expect that the installed update is applied in this case
+"""
+@with_uptane_backend(start_generic_server=True)
+@with_director()
+@with_treehub()
+@with_sysroot()
+@with_aktualizr(start=False, run_mode='once', output_logs=True)
+def test_primary_ostree_update_if_metadata_expires(uptane_repo, aktualizr, director, sysroot, treehub, uptane_server):
+    target_rev = treehub.revision
+    expires_within_sec = 10
+
+    # add an ostree update for Primary
+    uptane_repo.add_ostree_target(aktualizr.id, target_rev, expires_within_sec=expires_within_sec)
+    start_time = time.time()
+
+    with aktualizr:
+        aktualizr.wait_for_completion()
+
+    # check the Primary update, must be in pending state since it requires reboot
+    pending_rev = aktualizr.get_primary_pending_version()
+    if pending_rev != target_rev:
+        logger.error("Pending version {} != the target version {}".format(pending_rev, target_rev))
+        return False
+
+    # wait until the target metadata are expired
+    time.sleep(max(0, expires_within_sec - (time.time() - start_time)))
+
+    # emulate reboot and run aktualizr once more
+    sysroot.update_revision(pending_rev)
+    aktualizr.emulate_reboot()
+
+    with aktualizr:
+        aktualizr.wait_for_completion()
+
+    # check the Primary update after reboot
+    result = director.get_install_result() and (target_rev == aktualizr.get_current_primary_image_info())
+    return result
+
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
 
@@ -76,7 +175,9 @@ if __name__ == "__main__":
     chdir(input_params.build_dir)
 
     test_suite = [
-        test_primary_ostree_secondary_fake_updates
+        test_primary_ostree_secondary_file_updates,
+        test_secodary_ostree_update_if_metadata_expires,
+        test_primary_ostree_update_if_metadata_expires
     ]
 
     test_suite_run_result = True
@@ -88,4 +189,3 @@ if __name__ == "__main__":
 
     chdir(initial_cwd)
     exit(0 if test_suite_run_result else 1)
-


### PR DESCRIPTION
- Apply pending update even if its metadata are expired provided that it
was installed before the expiration
- Add tests for the target metadata expiration use-case

Signed-off-by: Mike Sul <ext-mykhaylo.sul@here.com>