### PR TITLE
Feat/better logging

### DIFF
--- a/src/aktualizr_primary/secondary.cc
+++ b/src/aktualizr_primary/secondary.cc
@@ -51,8 +51,8 @@ void initSecondaries(Aktualizr& aktualizr, const boost::filesystem::path& config
       Secondaries secondaries = createSecondaries(*config);
 
       for (const auto& secondary : secondaries) {
-        LOG_INFO << "Adding Secondary to Aktualizr."
-                 << "HW_ID: " << secondary->getHwId() << " Serial: " << secondary->getSerial();
+        LOG_INFO << "Adding Secondary with ECU serial: " << secondary->getSerial()
+                 << " with hardware ID: " << secondary->getHwId();
         aktualizr.AddSecondary(secondary);
       }
     } catch (const std::exception& exc) {

--- a/src/cert_provider/main.cc
+++ b/src/cert_provider/main.cc
@@ -249,7 +249,8 @@ bool generateAndSign(const std::string& cacert_path, const std::string& capkey_p
     std::cerr << "PEM_write_RSAPrivateKey" << std::endl;
     return false;
   }
-  auto privkey_len = BIO_get_mem_data(privkey_file.get(), &privkey_buf);  // NOLINT
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+  auto privkey_len = BIO_get_mem_data(privkey_file.get(), &privkey_buf);
   *pkey = std::string(privkey_buf, static_cast<size_t>(privkey_len));
 
   // serialize certificate
@@ -264,7 +265,8 @@ bool generateAndSign(const std::string& cacert_path, const std::string& capkey_p
     std::cerr << "PEM_write_X509" << std::endl;
     return false;
   }
-  auto cert_len = BIO_get_mem_data(cert_file.get(), &cert_buf);  // NOLINT
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+  auto cert_len = BIO_get_mem_data(cert_file.get(), &cert_buf);
   *cert = std::string(cert_buf, static_cast<size_t>(cert_len));
 
   return true;

--- a/src/libaktualizr/crypto/crypto.cc
+++ b/src/libaktualizr/crypto/crypto.cc
@@ -274,7 +274,7 @@ bool Crypto::parseP12(BIO *p12_bio, const std::string &p12_password, std::string
   PEM_write_bio_PrivateKey(pkey_pem_sink.get(), pkey.get(), nullptr, nullptr, 0, nullptr, nullptr);
 
   char *pkey_buf;
-  auto pkey_len = BIO_get_mem_data(pkey_pem_sink.get(), &pkey_buf);  // NOLINT
+  auto pkey_len = BIO_get_mem_data(pkey_pem_sink.get(), &pkey_buf);  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
   *out_pkey = std::string(pkey_buf, static_cast<size_t>(pkey_len));
 
   char *cert_buf;
@@ -299,10 +299,12 @@ bool Crypto::parseP12(BIO *p12_bio, const std::string &p12_password, std::string
     PEM_write_bio_X509(ca_sink.get(), ca_cert);
     PEM_write_bio_X509(cert_sink.get(), ca_cert);
   }
-  ca_len = static_cast<size_t>(BIO_get_mem_data(ca_sink.get(), &ca_buf));  // NOLINT
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+  ca_len = static_cast<size_t>(BIO_get_mem_data(ca_sink.get(), &ca_buf));
   *out_ca = std::string(ca_buf, ca_len);
 
-  cert_len = static_cast<size_t>(BIO_get_mem_data(cert_sink.get(), &cert_buf));  // NOLINT
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+  cert_len = static_cast<size_t>(BIO_get_mem_data(cert_sink.get(), &cert_buf));
   *out_cert = std::string(cert_buf, cert_len);
 
   return true;
@@ -394,7 +396,7 @@ bool Crypto::generateRSAKeyPair(KeyType key_type, std::string *public_key, std::
   if (ret != 1) {
     return false;
   }
-  auto pubkey_len = BIO_get_mem_data(pubkey_sink.get(), &pubkey_buf);  // NOLINT
+  auto pubkey_len = BIO_get_mem_data(pubkey_sink.get(), &pubkey_buf);  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
   *public_key = std::string(pubkey_buf, static_cast<size_t>(pubkey_len));
 
   char *privkey_buf;
@@ -408,7 +410,8 @@ bool Crypto::generateRSAKeyPair(KeyType key_type, std::string *public_key, std::
   if (ret != 1) {
     return false;
   }
-  auto privkey_len = BIO_get_mem_data(privkey_sink.get(), &privkey_buf);  // NOLINT
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+  auto privkey_len = BIO_get_mem_data(privkey_sink.get(), &privkey_buf);
   *private_key = std::string(privkey_buf, static_cast<size_t>(privkey_len));
   return true;
 }

--- a/src/libaktualizr/crypto/keymanager.h
+++ b/src/libaktualizr/crypto/keymanager.h
@@ -25,6 +25,7 @@ class KeyManager {
   std::string getCert() const;
   std::string getCa() const;
   std::string getCN() const;
+  void getCertInfo(std::string *subject, std::string *issuer, std::string *not_before, std::string *not_after) const;
   bool isOk() const { return ((getPkey().size() != 0u) && (getCert().size() != 0u) && (getCa().size() != 0u)); }
   std::string generateUptaneKeyPair();
   KeyType getUptaneKeyType() const { return config_.uptane_key_type; }

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -290,6 +290,15 @@ void SotaUptaneClient::initialize() {
   LOG_INFO << "Device ID: " << device_id;
   LOG_INFO << "Device Gateway URL: " << config.tls.server;
 
+  std::string subject;
+  std::string issuer;
+  std::string not_before;
+  std::string not_after;
+  keys->getCertInfo(&subject, &issuer, &not_before, &not_after);
+  LOG_INFO << "Certificate subject: " << subject;
+  LOG_INFO << "Certificate issuer: " << issuer;
+  LOG_INFO << "Certificate valid from: " << not_before << " until: " << not_after;
+
   LOG_DEBUG << "... provisioned OK";
   finalizeAfterReboot();
 }

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -79,7 +79,7 @@ void SotaUptaneClient::finalizeAfterReboot() {
   // TODO: consider bringing checkAndUpdatePendingSecondaries and the following functionality
   // to the common denominator
   if (!hasPendingUpdates()) {
-    LOG_INFO << "No any pending update, continue with initialization";
+    LOG_DEBUG << "No pending updates, continuing with initialization";
     return;
   }
 
@@ -90,7 +90,7 @@ void SotaUptaneClient::finalizeAfterReboot() {
   storage->loadInstalledVersions(primary_ecu_serial.ToString(), nullptr, &pending_target);
 
   if (!pending_target) {
-    LOG_ERROR << "No any pending update for Primary ECU is found, continue with initialization";
+    LOG_ERROR << "No pending update for Primary ECU found, continuing with initialization";
     return;
   }
 
@@ -100,7 +100,7 @@ void SotaUptaneClient::finalizeAfterReboot() {
 
   if (install_res.result_code == data::ResultCode::Numeric::kNeedCompletion) {
     LOG_INFO << "Pending update for Primary ECU was not applied because reboot was not detected, "
-                "continue with initialization";
+                "continuing with initialization";
     return;
   }
 
@@ -279,10 +279,18 @@ void SotaUptaneClient::initialize() {
   uptane_manifest = std::make_shared<Uptane::ManifestIssuer>(keys, serials[0].first);
   primary_ecu_serial_ = serials[0].first;
   hw_ids.insert(serials[0]);
+  LOG_INFO << "Primary ECU serial: " << primary_ecu_serial_ << " with hardware ID: " << serials[0].second;
 
   verifySecondaries();
-  LOG_DEBUG << "... provisioned OK";
 
+  std::string device_id;
+  if (!storage->loadDeviceId(&device_id)) {
+    throw std::runtime_error("Unable to load device ID after device registration.");
+  }
+  LOG_INFO << "Device ID: " << device_id;
+  LOG_INFO << "Device Gateway URL: " << config.tls.server;
+
+  LOG_DEBUG << "... provisioned OK";
   finalizeAfterReboot();
 }
 


### PR DESCRIPTION
Requested by @koshelev to speed up debugging, particularly when all we have is a log with the default loglevel. This is approximately how it will look:

```
Adding Secondary with ECU serial: 2c1644ed995acb07bebc4f0b1d0d3ad4865a7c3cb8eeb6de6f58bb543cd4c188 with hardware ID: virtualsec-demo
Primary ECU serial: 6d0a57cc949f6eaa1f0fb9e08984cdbc9a7328c66990290a7e5b5408061bce70 with hardware ID: local-fake
Device ID: grand-apfelkuchen-701
Device Gateway URL: https://3c877e1a-c969-4b71-9ba9-16b909a88c44.device-gateway.ota.api.here.com:443
Certificate subject: CN=grand-apfelkuchen-701, OU=Devices
Certificate issuer: CN=Device Registration
Certificate valid from: Jan  9 09:51:35 2020 GMT until Dec  4 09:38:36 2028 GMT
```