### PR TITLE
Store reports in the database

### DIFF
--- a/config/sql/migration/migrate.24.sql
+++ b/config/sql/migration/migrate.24.sql
@@ -1,0 +1,9 @@
+-- Don't modify this! Create a new migration instead--see docs/schema-migrations.adoc
+SAVEPOINT MIGRATION;
+
+CREATE TABLE report_events(id INTEGER PRIMARY KEY, json_string TEXT NOT NULL);
+
+DELETE FROM version;
+INSERT INTO version VALUES(24);
+
+RELEASE MIGRATION;

--- a/config/sql/rollback/rollback.24.sql
+++ b/config/sql/rollback/rollback.24.sql
@@ -1,0 +1,9 @@
+-- Don't modify this! Create a new migration instead--see docs/schema-migrations.adoc
+SAVEPOINT ROLLBACK_MIGRATION;
+
+DROP TABLE report_events;
+
+DELETE FROM version;
+INSERT INTO version VALUES(23);
+
+RELEASE ROLLBACK_MIGRATION;

--- a/config/sql/schema.sql
+++ b/config/sql/schema.sql
@@ -1,5 +1,5 @@
 CREATE TABLE version(version INTEGER);
-INSERT INTO version(rowid,version) VALUES(1,23);
+INSERT INTO version(rowid,version) VALUES(1,24);
 CREATE TABLE device_info(unique_mark INTEGER PRIMARY KEY CHECK (unique_mark = 0), device_id TEXT, is_registered INTEGER NOT NULL DEFAULT 0 CHECK (is_registered IN (0,1)));
 CREATE TABLE ecus(id INTEGER PRIMARY KEY, serial TEXT UNIQUE, hardware_id TEXT NOT NULL, is_primary INTEGER NOT NULL DEFAULT 0 CHECK (is_primary IN (0,1)));
 CREATE TABLE secondary_ecus(serial TEXT PRIMARY KEY, sec_type TEXT, public_key_type TEXT, public_key TEXT, extra TEXT, manifest TEXT);
@@ -25,3 +25,4 @@ CREATE TABLE need_reboot(unique_mark INTEGER PRIMARY KEY CHECK (unique_mark = 0)
 CREATE TABLE rollback_migrations(version_from INT PRIMARY KEY, migration TEXT NOT NULL);
 CREATE TABLE delegations(meta BLOB NOT NULL, role_name TEXT NOT NULL, UNIQUE(role_name));
 CREATE TABLE ecu_report_counter(ecu_serial TEXT NOT NULL PRIMARY KEY, counter INTEGER NOT NULL DEFAULT 0);
+CREATE TABLE report_events(id INTEGER PRIMARY KEY, json_string TEXT NOT NULL);

--- a/src/libaktualizr/primary/reportqueue.h
+++ b/src/libaktualizr/primary/reportqueue.h
@@ -12,6 +12,7 @@
 #include "config/config.h"
 #include "http/httpclient.h"
 #include "logging/logging.h"
+#include "storage/invstorage.h"
 #include "uptane/tuf.h"
 
 class ReportEvent {
@@ -84,7 +85,8 @@ class EcuInstallationCompletedReport : public ReportEvent {
 
 class ReportQueue {
  public:
-  ReportQueue(const Config& config_in, std::shared_ptr<HttpInterface> http_client);
+  ReportQueue(const Config& config_in, std::shared_ptr<HttpInterface> http_client,
+              std::shared_ptr<INvStorage> storage_in);
   ~ReportQueue();
   void run();
   void enqueue(std::unique_ptr<ReportEvent> event);
@@ -98,8 +100,8 @@ class ReportQueue {
   std::condition_variable cv_;
   std::mutex m_;
   std::queue<std::unique_ptr<ReportEvent>> report_queue_;
-  Json::Value report_array{Json::arrayValue};
   bool shutdown_{false};
+  std::shared_ptr<INvStorage> storage;
 };
 
 #endif  // REPORTQUEUE_H_

--- a/src/libaktualizr/primary/reportqueue_test.cc
+++ b/src/libaktualizr/primary/reportqueue_test.cc
@@ -10,6 +10,8 @@
 #include "config/config.h"
 #include "httpfake.h"
 #include "reportqueue.h"
+#include "storage/invstorage.h"
+#include "storage/sqlstorage.h"
 #include "utilities/types.h"  // TimeStamp
 #include "utilities/utils.h"
 
@@ -51,6 +53,15 @@ class HttpFakeRq : public HttpFake {
         }
         return HttpResponse("", 200, CURLE_OK, "");
       }
+    } else if (url.find("reportqueue/StoreEvents") == 0) {
+      for (int i = 0; i < static_cast<int>(data.size()); ++i) {
+        EXPECT_EQ(data[i]["eventType"]["id"], "EcuDownloadCompleted");
+        EXPECT_EQ(data[i]["event"]["ecu"], "StoreEvents" + std::to_string(events_seen++));
+      }
+      if (events_seen == expected_events_) {
+        expected_events_received.set_value(true);
+      }
+      return HttpResponse("", 200, CURLE_OK, "");
     }
     LOG_ERROR << "Unexpected event: " << data;
     return HttpResponse("", 400, CURLE_OK, "");
@@ -70,7 +81,8 @@ TEST(ReportQueue, SingleEvent) {
 
   size_t num_events = 1;
   auto http = std::make_shared<HttpFakeRq>(temp_dir.Path(), num_events);
-  ReportQueue report_queue(config, http);
+  auto sql_storage = std::make_shared<SQLStorage>(config.storage, false);
+  ReportQueue report_queue(config, http, sql_storage);
 
   report_queue.enqueue(std_::make_unique<EcuDownloadCompletedReport>(Uptane::EcuSerial("SingleEvent"), "", true));
 
@@ -88,7 +100,8 @@ TEST(ReportQueue, MultipleEvents) {
 
   size_t num_events = 10;
   auto http = std::make_shared<HttpFakeRq>(temp_dir.Path(), num_events);
-  ReportQueue report_queue(config, http);
+  auto sql_storage = std::make_shared<SQLStorage>(config.storage, false);
+  ReportQueue report_queue(config, http, sql_storage);
 
   for (int i = 0; i < 10; ++i) {
     report_queue.enqueue(std_::make_unique<EcuDownloadCompletedReport>(
@@ -110,16 +123,54 @@ TEST(ReportQueue, FailureRecovery) {
 
   size_t num_events = 10;
   auto http = std::make_shared<HttpFakeRq>(temp_dir.Path(), num_events);
-  ReportQueue report_queue(config, http);
+  auto sql_storage = std::make_shared<SQLStorage>(config.storage, false);
+  ReportQueue report_queue(config, http, sql_storage);
 
-  for (int i = 0; i < 10; ++i) {
+  for (size_t i = 0; i < num_events; ++i) {
     report_queue.enqueue(std_::make_unique<EcuDownloadCompletedReport>(
         Uptane::EcuSerial("FailureRecovery" + std::to_string(i)), "", true));
   }
 
-  // Wait at most 30 seconds for the messages to get processed.
+  // Wait at most 20 seconds for the messages to get processed.
   http->expected_events_received.get_future().wait_for(std::chrono::seconds(20));
   EXPECT_EQ(http->events_seen, num_events);
+}
+
+/* Test persistent storage of unsent events in the database across
+ * ReportQueue instantiations. */
+TEST(ReportQueue, StoreEvents) {
+  TemporaryDirectory temp_dir;
+  Config config;
+  config.storage.path = temp_dir.Path();
+  config.tls.server = "";
+
+  auto sql_storage = std::make_shared<SQLStorage>(config.storage, false);
+  size_t num_events = 10;
+  auto check_sql = [sql_storage](size_t count) {
+    int64_t max_id = 0;
+    Json::Value report_array{Json::arrayValue};
+    sql_storage->loadReportEvents(&report_array, &max_id);
+    EXPECT_EQ(max_id, count);
+  };
+
+  {
+    auto http = std::make_shared<HttpFakeRq>(temp_dir.Path(), num_events);
+    ReportQueue report_queue(config, http, sql_storage);
+    for (size_t i = 0; i < num_events; ++i) {
+      report_queue.enqueue(std_::make_unique<EcuDownloadCompletedReport>(
+          Uptane::EcuSerial("StoreEvents" + std::to_string(i)), "", true));
+    }
+    check_sql(num_events);
+  }
+
+  config.tls.server = "reportqueue/StoreEvents";
+  auto http = std::make_shared<HttpFakeRq>(temp_dir.Path(), num_events);
+  ReportQueue report_queue(config, http, sql_storage);
+  // Wait at most 20 seconds for the messages to get processed.
+  http->expected_events_received.get_future().wait_for(std::chrono::seconds(20));
+  EXPECT_EQ(http->events_seen, num_events);
+  sleep(1);
+  check_sql(0);
 }
 
 #ifndef __NO_MAIN__

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -39,10 +39,11 @@ class SotaUptaneClient {
         http(std::move(http_in)),
         package_manager_(PackageManagerFactory::makePackageManager(config.pacman, config.bootloader, storage, http)),
         uptane_fetcher(new Uptane::Fetcher(config, http)),
-        report_queue(new ReportQueue(config, http)),
         events_channel(std::move(events_channel_in)),
         primary_ecu_serial_(primary_serial),
-        primary_ecu_hw_id_(hwid) {}
+        primary_ecu_hw_id_(hwid) {
+    report_queue = std_::make_unique<ReportQueue>(config, http, storage);
+  }
 
   SotaUptaneClient(Config &config_in, const std::shared_ptr<INvStorage> &storage_in,
                    std::shared_ptr<HttpInterface> http_in)

--- a/src/libaktualizr/storage/invstorage.h
+++ b/src/libaktualizr/storage/invstorage.h
@@ -211,6 +211,10 @@ class INvStorage {
   virtual void saveEcuReportCounter(const Uptane::EcuSerial& ecu_serial, int64_t counter) = 0;
   virtual bool loadEcuReportCounter(std::vector<std::pair<Uptane::EcuSerial, int64_t>>* results) = 0;
 
+  virtual void saveReportEvent(const Json::Value& json_value) = 0;
+  virtual bool loadReportEvents(Json::Value* report_array, int64_t* id_max) = 0;
+  virtual void deleteReportEvents(int64_t id_max) = 0;
+
   virtual bool checkAvailableDiskSpace(uint64_t required_bytes) const = 0;
   virtual boost::optional<std::pair<uintmax_t, std::string>> checkTargetFile(const Uptane::Target& target) const = 0;
 

--- a/src/libaktualizr/storage/sqlstorage.h
+++ b/src/libaktualizr/storage/sqlstorage.h
@@ -91,6 +91,9 @@ class SQLStorage : public SQLStorageBase, public INvStorage {
                                     std::string* correlation_id) override;
   void saveEcuReportCounter(const Uptane::EcuSerial& ecu_serial, int64_t counter) override;
   bool loadEcuReportCounter(std::vector<std::pair<Uptane::EcuSerial, int64_t>>* results) override;
+  void saveReportEvent(const Json::Value& json_value) override;
+  bool loadReportEvents(Json::Value* report_array, int64_t* id_max) override;
+  void deleteReportEvents(int64_t id_max) override;
   void clearInstallationResults() override;
 
   bool checkAvailableDiskSpace(uint64_t required_bytes) const override;

--- a/src/libaktualizr/storage/sqlstorage_base.cc
+++ b/src/libaktualizr/storage/sqlstorage_base.cc
@@ -32,6 +32,7 @@ SQLStorageBase::SQLStorageBase(boost::filesystem::path sqldb_path, bool readonly
                                int current_schema_version)
     : sqldb_path_(std::move(sqldb_path)),
       readonly_(readonly),
+      mutex_(new std::mutex()),
       schema_migrations_(std::move(schema_migrations)),
       schema_rollback_migrations_(std::move(schema_rollback_migrations)),
       current_schema_(std::move(current_schema)),
@@ -72,7 +73,7 @@ SQLStorageBase::SQLStorageBase(boost::filesystem::path sqldb_path, bool readonly
 }
 
 SQLite3Guard SQLStorageBase::dbConnection() const {
-  SQLite3Guard db(dbPath(), readonly_);
+  SQLite3Guard db(dbPath(), readonly_, mutex_);
   if (db.get_rc() != SQLITE_OK) {
     throw SQLException(std::string("Can't open database: ") + db.errmsg());
   }

--- a/src/libaktualizr/storage/sqlstorage_base.h
+++ b/src/libaktualizr/storage/sqlstorage_base.h
@@ -48,6 +48,7 @@ class SQLStorageBase {
   bool readonly_{false};
 
   StorageLock lock;
+  std::shared_ptr<std::mutex> mutex_;
 
   const std::vector<std::string> schema_migrations_;
   std::vector<std::string> schema_rollback_migrations_;


### PR DESCRIPTION
It's for OTA-3637. Store reports in database when events generated
and delete them after sent them to server.

Signed-off-by: cheng.xiang <ext-cheng.xiang@here.com>