### PR TITLE
Give better names to shared libraries

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/pages/libaktualizr-getstarted.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/libaktualizr-getstarted.adoc
@@ -48,7 +48,7 @@ make
 
 NOTE: The `--recursive` flag in the `git clone` command is needed to recursively clone all the *git submodules*.
 
-After the build is finished, you'll find the client library at the following location: `$\{PROJECT_ROOT}/build/src/libaktualizr/libaktualizr_lib.so`.
+After the build is finished, you'll find the client library at the following location: `$\{PROJECT_ROOT}/build/src/libaktualizr/libaktualizr.so`.
 
 == Integrating libaktualizr into your application
 

--- a/src/aktualizr_secondary/CMakeLists.txt
+++ b/src/aktualizr_secondary/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(aktualizr_secondary_lib SHARED
     $<TARGET_OBJECTS:logging>
     $<TARGET_OBJECTS:uptane>
     $<TARGET_OBJECTS:campaign>)
+set_target_properties(aktualizr_secondary_lib PROPERTIES LIBRARY_OUTPUT_NAME aktualizr_secondary)
 target_link_libraries(aktualizr_secondary_lib aktualizr-posix ${AKTUALIZR_EXTERNAL_LIBS})
 
 if (BUILD_ISOTP)

--- a/src/libaktualizr/CMakeLists.txt
+++ b/src/libaktualizr/CMakeLists.txt
@@ -53,6 +53,7 @@ add_library(aktualizr_lib SHARED
     $<TARGET_OBJECTS:storage>
     $<TARGET_OBJECTS:uptane>)
 target_link_libraries(aktualizr_lib ${AKTUALIZR_EXTERNAL_LIBS})
+set_target_properties(aktualizr_lib PROPERTIES LIBRARY_OUTPUT_NAME aktualizr)
 install(TARGETS aktualizr_lib LIBRARY DESTINATION lib COMPONENT aktualizr)
 
 if (BUILD_ISOTP)

--- a/src/sota_tools/CMakeLists.txt
+++ b/src/sota_tools/CMakeLists.txt
@@ -34,6 +34,7 @@ if (BUILD_SOTA_TOOLS)
     set(GARAGE_TOOLS_VERSION "${AKTUALIZR_VERSION}")
     set_property(SOURCE garage_tools_version.cc PROPERTY COMPILE_DEFINITIONS GARAGE_TOOLS_VERSION="${GARAGE_TOOLS_VERSION}")
     add_library(sota_tools_lib SHARED ${SOTA_TOOLS_LIB_SRC})
+    set_target_properties(sota_tools_lib PROPERTIES LIBRARY_OUTPUT_NAME sota_tools)
     target_include_directories(sota_tools_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${PROJECT_SOURCE_DIR} ${GLIB2_INCLUDE_DIRS})
 
     # we link with aktualizr static lib here, to bundle everything in sota_tools_lib


### PR DESCRIPTION
Use set_target_properties so that we don't confuse the name of library
and executable targets.