### PR TITLE
Throw when trying to build a non-existing package manager

### DIFF
--- a/src/libaktualizr/package_manager/packagemanagerfactory.cc
+++ b/src/libaktualizr/package_manager/packagemanagerfactory.cc
@@ -40,5 +40,6 @@ std::shared_ptr<PackageManagerInterface> PackageManagerFactory::makePackageManag
     }
     return ss.str();
   }();
-  return nullptr;
+
+  throw std::runtime_error(std::string("Unsupported package manager: ") + pconfig.type);
 }

--- a/src/libaktualizr/package_manager/packagemanagerfactory_test.cc
+++ b/src/libaktualizr/package_manager/packagemanagerfactory_test.cc
@@ -11,7 +11,7 @@
 
 boost::filesystem::path sysroot;
 
-/* Support OSTree as a package manager. */
+#ifdef BUILD_OSTREE
 TEST(PackageManagerFactory, Ostree) {
   Config config;
   config.pacman.type = PACKAGE_MANAGER_OSTREE;
@@ -19,33 +19,24 @@ TEST(PackageManagerFactory, Ostree) {
   TemporaryDirectory dir;
   config.storage.path = dir.Path();
   std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
-#ifdef BUILD_OSTREE
   std::shared_ptr<PackageManagerInterface> pacman =
       PackageManagerFactory::makePackageManager(config.pacman, config.bootloader, storage, nullptr);
   EXPECT_TRUE(pacman);
-#else
-  EXPECT_THROW(std::shared_ptr<PackageManagerInterface> pacman =
-                   PackageManagerFactory::makePackageManager(config.pacman, config.bootloader, storage, nullptr),
-               std::runtime_error);
-#endif
 }
+#endif
 
+#ifdef BUILD_DEB
 TEST(PackageManagerFactory, Debian) {
   Config config;
   config.pacman.type = PACKAGE_MANAGER_DEBIAN;
   TemporaryDirectory dir;
   config.storage.path = dir.Path();
   std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
-#ifdef BUILD_DEB
   std::shared_ptr<PackageManagerInterface> pacman =
       PackageManagerFactory::makePackageManager(config.pacman, config.bootloader, storage, nullptr);
   EXPECT_TRUE(pacman);
-#else
-  EXPECT_THROW(std::shared_ptr<PackageManagerInterface> pacman =
-                   PackageManagerFactory::makePackageManager(config.pacman, config.bootloader, storage, nullptr),
-               std::runtime_error);
-#endif
 }
+#endif
 
 TEST(PackageManagerFactory, None) {
   Config config;
@@ -64,9 +55,8 @@ TEST(PackageManagerFactory, Bad) {
   config.storage.path = dir.Path();
   config.pacman.type = "bad";
   std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
-  std::shared_ptr<PackageManagerInterface> pacman =
-      PackageManagerFactory::makePackageManager(config.pacman, config.bootloader, storage, nullptr);
-  EXPECT_FALSE(pacman);
+  EXPECT_THROW(PackageManagerFactory::makePackageManager(config.pacman, config.bootloader, storage, nullptr),
+               std::runtime_error);
 }
 
 #include "package_manager/packagemanagerfake.h"


### PR DESCRIPTION
Also fix pacman factory tests when compiled without deb or ostree.

The old behaviour was different in the case of imaginary pacman names
and existing but not compiled pacman. Now, it throws an exception in any
case.