### PR TITLE
Fix for binary download resume

### DIFF
--- a/src/libaktualizr/package_manager/debianmanager_test.cc
+++ b/src/libaktualizr/package_manager/debianmanager_test.cc
@@ -32,7 +32,7 @@ TEST(PackageManagerFactory, Debian_Install_Good) {
   target_json_test["length"] = 2;
   Uptane::Target target_test("test.deb", target_json_test);
   storage->savePrimaryInstalledVersion(target_test, InstalledVersionUpdateMode::kCurrent);
-  std::unique_ptr<StorageTargetWHandle> fhandle = storage->allocateTargetFile(false, target);
+  std::unique_ptr<StorageTargetWHandle> fhandle = storage->allocateTargetFile(target);
   std::stringstream("ab") >> *fhandle;
   fhandle->wcommit();
 
@@ -55,7 +55,7 @@ TEST(PackageManagerFactory, Debian_Install_Bad) {
   target_json["custom"]["ecuIdentifiers"]["primary_serial"]["hardwareId"] = "primary_hwid";
   Uptane::Target target("bad.deb", target_json);
 
-  std::unique_ptr<StorageTargetWHandle> fhandle = storage->allocateTargetFile(false, target);
+  std::unique_ptr<StorageTargetWHandle> fhandle = storage->allocateTargetFile(target);
   std::stringstream("ab") >> *fhandle;
   fhandle->wcommit();
 

--- a/src/libaktualizr/package_manager/packagemanagerfake_test.cc
+++ b/src/libaktualizr/package_manager/packagemanagerfake_test.cc
@@ -43,7 +43,7 @@ TEST(PackageManagerFake, Verify) {
   EXPECT_EQ(fakepm.verifyTarget(target), TargetStatus::kNotFound);
 
   // Target has a bad hash.
-  auto whandle = storage->allocateTargetFile(false, target);
+  auto whandle = storage->allocateTargetFile(target);
   uint8_t content_bad[length + 1];
   memset(content_bad, 0, length + 1);
   EXPECT_EQ(whandle->wfeed(content_bad, length), length);
@@ -51,19 +51,19 @@ TEST(PackageManagerFake, Verify) {
   EXPECT_EQ(fakepm.verifyTarget(target), TargetStatus::kHashMismatch);
 
   // Target is oversized.
-  whandle = storage->allocateTargetFile(false, target);
+  whandle = storage->allocateTargetFile(target);
   EXPECT_EQ(whandle->wfeed(content_bad, length + 1), length + 1);
   whandle->wcommit();
   EXPECT_EQ(fakepm.verifyTarget(target), TargetStatus::kOversized);
 
   // Target is incomplete.
-  whandle = storage->allocateTargetFile(false, target);
+  whandle = storage->allocateTargetFile(target);
   EXPECT_EQ(whandle->wfeed(content, length - 1), length - 1);
   whandle->wcommit();
   EXPECT_EQ(fakepm.verifyTarget(target), TargetStatus::kIncomplete);
 
   // Target is good.
-  whandle = storage->allocateTargetFile(false, target);
+  whandle = storage->allocateTargetFile(target);
   EXPECT_EQ(whandle->wfeed(content, length), length);
   whandle->wcommit();
   EXPECT_EQ(fakepm.verifyTarget(target), TargetStatus::kGood);

--- a/src/libaktualizr/package_manager/packagemanagerinterface.cc
+++ b/src/libaktualizr/package_manager/packagemanagerinterface.cc
@@ -9,7 +9,7 @@ struct DownloadMetaStruct {
         target{std::move(target_in)},
         token{token_in},
         progress_cb{std::move(progress_cb_in)} {}
-  uint64_t downloaded_length{0};
+  uintmax_t downloaded_length{0};
   unsigned int last_progress{0};
   std::unique_ptr<StorageTargetWHandle> fhandle;
   const Uptane::Hash::Type hash_type;

--- a/src/libaktualizr/package_manager/packagemanagerinterface.cc
+++ b/src/libaktualizr/package_manager/packagemanagerinterface.cc
@@ -107,7 +107,7 @@ bool PackageManagerInterface::fetchTarget(const Uptane::Target& target, Uptane::
     } else {
       // If the target was found, but is oversized or the hash doesn't match,
       // just start over.
-      ds->fhandle = storage_->allocateTargetFile(false, target);
+      ds->fhandle = storage_->allocateTargetFile(target);
     }
 
     const uint64_t required_bytes = target.length() - ds->downloaded_length;
@@ -130,7 +130,7 @@ bool PackageManagerInterface::fetchTarget(const Uptane::Target& target, Uptane::
                        " try to download the image from the beginning: "
                     << target_url;
         ds = std_::make_unique<DownloadMetaStruct>(target, progress_cb, token);
-        ds->fhandle = storage_->allocateTargetFile(false, target);
+        ds->fhandle = storage_->allocateTargetFile(target);
         continue;
       }
 

--- a/src/libaktualizr/storage/invstorage.h
+++ b/src/libaktualizr/storage/invstorage.h
@@ -43,7 +43,7 @@ class StorageTargetWHandle {
   virtual size_t wfeed(const uint8_t* buf, size_t size) = 0;
   virtual void wcommit() = 0;
   virtual void wabort() = 0;
-  size_t getWrittenSize() { return written_size_; }
+  uintmax_t getWrittenSize() { return written_size_; }
 
   friend std::istream& operator>>(std::istream& is, StorageTargetWHandle& handle) {
     std::array<uint8_t, 256> arr{};
@@ -55,7 +55,7 @@ class StorageTargetWHandle {
   }
 
  protected:
-  size_t written_size_{0};
+  uintmax_t written_size_{0};
 };
 
 class StorageTargetRHandle {
@@ -68,13 +68,13 @@ class StorageTargetRHandle {
   virtual bool isPartial() const = 0;
   virtual std::unique_ptr<StorageTargetWHandle> toWriteHandle() = 0;
 
-  virtual size_t rsize() const = 0;
+  virtual uintmax_t rsize() const = 0;
   virtual size_t rread(uint8_t* buf, size_t size) = 0;
   virtual void rclose() = 0;
 
   void writeToFile(const boost::filesystem::path& path) {
     std::array<uint8_t, 1024> arr{};
-    size_t written = 0;
+    uintmax_t written = 0;
     std::ofstream file(path.c_str());
     if (!file.good()) {
       throw std::runtime_error(std::string("Error opening file ") + path.string());
@@ -89,7 +89,7 @@ class StorageTargetRHandle {
 
   friend std::ostream& operator<<(std::ostream& os, StorageTargetRHandle& handle) {
     std::array<uint8_t, 256> arr{};
-    size_t written = 0;
+    uintmax_t written = 0;
     while (written < handle.rsize()) {
       size_t nread = handle.rread(arr.data(), arr.size());
 
@@ -212,7 +212,7 @@ class INvStorage {
   virtual bool loadEcuReportCounter(std::vector<std::pair<Uptane::EcuSerial, int64_t>>* results) = 0;
 
   virtual bool checkAvailableDiskSpace(uint64_t required_bytes) const = 0;
-  virtual boost::optional<std::pair<size_t, std::string>> checkTargetFile(const Uptane::Target& target) const = 0;
+  virtual boost::optional<std::pair<uintmax_t, std::string>> checkTargetFile(const Uptane::Target& target) const = 0;
 
   // Incremental file API
   virtual std::unique_ptr<StorageTargetWHandle> allocateTargetFile(const Uptane::Target& target) = 0;

--- a/src/libaktualizr/storage/invstorage.h
+++ b/src/libaktualizr/storage/invstorage.h
@@ -215,8 +215,7 @@ class INvStorage {
   virtual boost::optional<std::pair<size_t, std::string>> checkTargetFile(const Uptane::Target& target) const = 0;
 
   // Incremental file API
-  virtual std::unique_ptr<StorageTargetWHandle> allocateTargetFile(bool from_director,
-                                                                   const Uptane::Target& target) = 0;
+  virtual std::unique_ptr<StorageTargetWHandle> allocateTargetFile(const Uptane::Target& target) = 0;
 
   virtual std::unique_ptr<StorageTargetRHandle> openTargetFile(const Uptane::Target& target) = 0;
   virtual std::vector<Uptane::Target> getTargetFiles() = 0;

--- a/src/libaktualizr/storage/sql_utils.h
+++ b/src/libaktualizr/storage/sql_utils.h
@@ -19,10 +19,6 @@ struct SQLBlob {
   explicit SQLBlob(const std::string& str) : content(str) {}
 };
 
-struct SQLZeroBlob {
-  size_t size;
-};
-
 class SQLException : public std::runtime_error {
  public:
   SQLException(const std::string& what = "SQL error") : std::runtime_error(what) {}
@@ -101,13 +97,6 @@ class SQLiteStatement {
 
     if (sqlite3_bind_blob(stmt_.get(), bind_cnt_, oe.c_str(), static_cast<int>(oe.size()), SQLITE_STATIC) !=
         SQLITE_OK) {
-      LOG_ERROR << "Could not bind: " << sqlite3_errmsg(db_);
-      throw std::runtime_error("SQLite bind error");
-    }
-  }
-
-  void bindArgument(const SQLZeroBlob& blob) {
-    if (sqlite3_bind_zeroblob(stmt_.get(), bind_cnt_, static_cast<int>(blob.size)) != SQLITE_OK) {
       LOG_ERROR << "Could not bind: " << sqlite3_errmsg(db_);
       throw std::runtime_error("SQLite bind error");
     }

--- a/src/libaktualizr/storage/sqlstorage.cc
+++ b/src/libaktualizr/storage/sqlstorage.cc
@@ -1796,8 +1796,7 @@ class SQLTargetWHandle : public StorageTargetWHandle {
   std::ofstream stream_;
 };
 
-std::unique_ptr<StorageTargetWHandle> SQLStorage::allocateTargetFile(bool from_director, const Uptane::Target& target) {
-  (void)from_director;
+std::unique_ptr<StorageTargetWHandle> SQLStorage::allocateTargetFile(const Uptane::Target& target) {
   return std::unique_ptr<StorageTargetWHandle>(new SQLTargetWHandle(*this, target));
 }
 

--- a/src/libaktualizr/storage/sqlstorage.cc
+++ b/src/libaktualizr/storage/sqlstorage.cc
@@ -1649,7 +1649,7 @@ bool SQLStorage::checkAvailableDiskSpace(const uint64_t required_bytes) const {
   }
 }
 
-boost::optional<std::pair<size_t, std::string>> SQLStorage::checkTargetFile(const Uptane::Target& target) const {
+boost::optional<std::pair<uintmax_t, std::string>> SQLStorage::checkTargetFile(const Uptane::Target& target) const {
   SQLite3Guard db = dbConnection();
 
   auto statement = db.prepareStatement<std::string>(
@@ -1777,7 +1777,7 @@ class SQLTargetWHandle : public StorageTargetWHandle {
 
  private:
   SQLTargetWHandle(const boost::filesystem::path& db_path, Uptane::Target target,
-                   const boost::filesystem::path& image_path, const size_t& start_from = 0)
+                   const boost::filesystem::path& image_path, const uintmax_t& start_from = 0)
       : db_(db_path), target_(std::move(target)) {
     if (db_.get_rc() != SQLITE_OK) {
       LOG_ERROR << "Can't open database: " << db_.errmsg();
@@ -1823,7 +1823,7 @@ class SQLTargetRHandle : public StorageTargetRHandle {
 
   ~SQLTargetRHandle() override { SQLTargetRHandle::rclose(); }
 
-  size_t rsize() const override { return size_; }
+  uintmax_t rsize() const override { return size_; }
 
   size_t rread(uint8_t* buf, size_t size) override {
     stream_.read(reinterpret_cast<char*>(buf), static_cast<std::streamsize>(size));
@@ -1845,7 +1845,7 @@ class SQLTargetRHandle : public StorageTargetRHandle {
   boost::filesystem::path db_path_;
   SQLite3Guard db_;
   Uptane::Target target_;
-  size_t size_;
+  uintmax_t size_;
   bool partial_{false};
   boost::filesystem::path image_path_;
   std::ifstream stream_;

--- a/src/libaktualizr/storage/sqlstorage.h
+++ b/src/libaktualizr/storage/sqlstorage.h
@@ -97,7 +97,7 @@ class SQLStorage : public SQLStorageBase, public INvStorage {
 
   std::unique_ptr<StorageTargetWHandle> allocateTargetFile(const Uptane::Target& target) override;
   std::unique_ptr<StorageTargetRHandle> openTargetFile(const Uptane::Target& target) override;
-  boost::optional<std::pair<size_t, std::string>> checkTargetFile(const Uptane::Target& target) const override;
+  boost::optional<std::pair<uintmax_t, std::string>> checkTargetFile(const Uptane::Target& target) const override;
   std::vector<Uptane::Target> getTargetFiles() override;
   void removeTargetFile(const std::string& target_name) override;
   void cleanUp() override;

--- a/src/libaktualizr/storage/sqlstorage.h
+++ b/src/libaktualizr/storage/sqlstorage.h
@@ -95,7 +95,7 @@ class SQLStorage : public SQLStorageBase, public INvStorage {
 
   bool checkAvailableDiskSpace(uint64_t required_bytes) const override;
 
-  std::unique_ptr<StorageTargetWHandle> allocateTargetFile(bool from_director, const Uptane::Target& target) override;
+  std::unique_ptr<StorageTargetWHandle> allocateTargetFile(const Uptane::Target& target) override;
   std::unique_ptr<StorageTargetRHandle> openTargetFile(const Uptane::Target& target) override;
   boost::optional<std::pair<size_t, std::string>> checkTargetFile(const Uptane::Target& target) const override;
   std::vector<Uptane::Target> getTargetFiles() override;

--- a/src/libaktualizr/storage/storage_common_test.cc
+++ b/src/libaktualizr/storage/storage_common_test.cc
@@ -472,7 +472,7 @@ TEST(storage, store_target) {
 
   // write
   {
-    std::unique_ptr<StorageTargetWHandle> fhandle = storage->allocateTargetFile(false, target);
+    std::unique_ptr<StorageTargetWHandle> fhandle = storage->allocateTargetFile(target);
     const uint8_t wb[] = "ab";
     fhandle->wfeed(wb, 1);
     fhandle->wfeed(wb + 1, 1);
@@ -492,7 +492,7 @@ TEST(storage, store_target) {
 
   // write again
   {
-    std::unique_ptr<StorageTargetWHandle> fhandle = storage->allocateTargetFile(false, target);
+    std::unique_ptr<StorageTargetWHandle> fhandle = storage->allocateTargetFile(target);
     const uint8_t wb[] = "ab";
     fhandle->wfeed(wb, 1);
     fhandle->wfeed(wb + 1, 1);
@@ -508,7 +508,7 @@ TEST(storage, store_target) {
 
   // write stream
   {
-    std::unique_ptr<StorageTargetWHandle> fhandle = storage->allocateTargetFile(false, target);
+    std::unique_ptr<StorageTargetWHandle> fhandle = storage->allocateTargetFile(target);
     std::stringstream("ab") >> *fhandle;
   }
 
@@ -539,7 +539,7 @@ TEST(storage, list_remove_targets) {
 
   // write
   {
-    std::unique_ptr<StorageTargetWHandle> fhandle = storage->allocateTargetFile(false, target);
+    std::unique_ptr<StorageTargetWHandle> fhandle = storage->allocateTargetFile(target);
     const uint8_t wb[] = "ab";
     fhandle->wfeed(wb, 1);
     fhandle->wfeed(wb + 1, 1);
@@ -623,7 +623,7 @@ TEST(storage, checksum) {
 
   // write target1
   {
-    std::unique_ptr<StorageTargetWHandle> fhandle = storage->allocateTargetFile(false, target1);
+    std::unique_ptr<StorageTargetWHandle> fhandle = storage->allocateTargetFile(target1);
     const uint8_t wb[] = "ab";
     fhandle->wfeed(wb, 2);
     fhandle->wcommit();
@@ -654,7 +654,7 @@ TEST(storage, partial) {
 
   // write partial target
   {
-    std::unique_ptr<StorageTargetWHandle> fhandle = storage->allocateTargetFile(false, target);
+    std::unique_ptr<StorageTargetWHandle> fhandle = storage->allocateTargetFile(target);
     const uint8_t wb[] = "a";
     fhandle->wfeed(wb, 1);
     fhandle->wcommit();

--- a/src/libaktualizr/uptane/uptane_test.cc
+++ b/src/libaktualizr/uptane/uptane_test.cc
@@ -440,7 +440,7 @@ TEST(Uptane, InstallFakeBad) {
   uint8_t content[length];
   EXPECT_EQ(rhandle->rread(content, length), length);
   rhandle->rclose();
-  auto whandle = storage->allocateTargetFile(false, download_result.updates[0]);
+  auto whandle = storage->allocateTargetFile(download_result.updates[0]);
   uint8_t content_bad[length + 1];
   memset(content_bad, 0, length + 1);
   EXPECT_EQ(whandle->wfeed(content_bad, 3), 3);
@@ -451,7 +451,7 @@ TEST(Uptane, InstallFakeBad) {
   EXPECT_EQ(install_result.dev_report.result_code, data::ResultCode::Numeric::kInternalError);
 
   // Try again with oversized data.
-  whandle = storage->allocateTargetFile(false, download_result.updates[0]);
+  whandle = storage->allocateTargetFile(download_result.updates[0]);
   EXPECT_EQ(whandle->wfeed(content_bad, length + 1), length + 1);
   whandle->wcommit();
 
@@ -461,7 +461,7 @@ TEST(Uptane, InstallFakeBad) {
 
   // Try again with equally long data to make sure the hash check actually gets
   // triggered.
-  whandle = storage->allocateTargetFile(false, download_result.updates[0]);
+  whandle = storage->allocateTargetFile(download_result.updates[0]);
   EXPECT_EQ(whandle->wfeed(content_bad, length), length);
   whandle->wcommit();
 
@@ -470,7 +470,7 @@ TEST(Uptane, InstallFakeBad) {
   EXPECT_EQ(install_result.dev_report.result_code, data::ResultCode::Numeric::kInternalError);
 
   // Try with the real data, but incomplete.
-  whandle = storage->allocateTargetFile(false, download_result.updates[0]);
+  whandle = storage->allocateTargetFile(download_result.updates[0]);
   EXPECT_EQ(whandle->wfeed(reinterpret_cast<uint8_t *>(content), length - 1), length - 1);
   whandle->wcommit();
 
@@ -479,7 +479,7 @@ TEST(Uptane, InstallFakeBad) {
   EXPECT_EQ(install_result.dev_report.result_code, data::ResultCode::Numeric::kInternalError);
 
   // Restore the original data to the file so that verification succeeds.
-  whandle = storage->allocateTargetFile(false, download_result.updates[0]);
+  whandle = storage->allocateTargetFile(download_result.updates[0]);
   EXPECT_EQ(whandle->wfeed(reinterpret_cast<uint8_t *>(content), length), length);
   whandle->wcommit();
 


### PR DESCRIPTION
This can be considered a hotfix for the issue with download resume after a nongraceful shutdown (OLPSUP-9401).
I plan to follow up this PR with another one, removing usage of target_images table for binary downloads and possibly moving this functionality to (Binary) package manager.