### PR TITLE
libaktualizr: Fix bug when building out-of-tree app

### DIFF
--- a/src/libaktualizr/utilities/types.cc
+++ b/src/libaktualizr/utilities/types.cc
@@ -1,5 +1,6 @@
 #include "utilities/types.h"
 
+#include <sstream>
 #include <stdexcept>
 #include <utility>
 


### PR DESCRIPTION
I've been experimenting with building aktualizr-lite out-of-tree with
aktualizr as a git submodule as described in the docs. I was getting the
following error without this fix:

../aktualizr/src/libaktualizr/utilities/types.cc:62:37: error: variable 'std::istringstream jsonss' has initializer but incomplete type
   62 |   std::istringstream jsonss(json_str);
      |                                     ^

Signed-off-by: Andy Doan <andy@foundries.io>