### PR TITLE
Add the Additional environments subsection

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/pages/account-setup.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/account-setup.adoc
@@ -8,12 +8,24 @@ We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}
 endif::[]
 
 
-In OTA Connect, all devices and software belong to one *user* login. However, you don't want to mix up test software and production software by creating them all under the same user.
+If you do not want to mix up test and production software, you may use separate user logins or create additional environments.
 
-In a proper production workflow, you'll need separate user logins to manage the different stages:
+== Separate user logins
 
-. A developer user such as "\dev@acme.com".
-. A QA user such as "\qa@acme.com".
-. A production user such as "\prod@acme.com".
+To manage the different stages of production workflow, you can create separate user logins:
 
-These logins provide you with a convenient way of clearly separating your development, QA and production resources.
+* A developer user such as _\dev@acme.com_
+* A QA user such as _\qa@acme.com_
+* A production user such as _\prod@acme.com_
+
+These logins provide you with a convenient way to separate your development, QA, and production resources.
+
+== Additional environments image:img::beta-icon.svg[Beta]
+
+NOTE: This feature is in beta and is only visible to users who are part of our beta program. If you would like to join the beta program, contact us at link:mailto:otaconnect.support@here.com[otaconnect.support@here.com] to request access.
+
+Instead of creating multiple accounts for each environment, you can now xref:ota-web::create-environment.adoc[create] additional environments using only one account. For example, you may need to have different environments for development, QA, and production.
+
+After you create an environment, you can xref:ota-web::manage-members.adoc[add] your colleagues to work together on device provisioning, device groups, software versions, software updates, and campaigns.
+
+To get more information on the environments feature, see the xref:ota-web::environments-intro.adoc[*Environments*] section in the OTA Connect User Guide.


### PR DESCRIPTION
In a separate section, describe that, instead of creating multiple
accounts, users can create up to 10 additional env using only
one account. Add a beta icon to that feature.

Relates-to: OTA-4601, OTA-4604

Signed-off-by: Halyna Dumych <ext-halyna.dumych@here.com>