### PR TITLE
fix: disable trying fetch target in case of abort or pause

### DIFF
--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -648,7 +648,7 @@ std::pair<bool, Uptane::Target> SotaUptaneClient::downloadImage(const Uptane::Ta
       success = package_manager_->fetchTarget(target, *uptane_fetcher, keys, prog_cb, token);
       // Skip trying to fetch the 'target' if control flow token transaction
       // was set to the 'abort' or 'pause' state, see the CommandQueue and FlowControlToken.
-      if (success || (token && !token->canContinue(false))) {
+      if (success || (token != nullptr && !token->canContinue(false))) {
         break;
       } else if (tries < max_tries - 1) {
         std::this_thread::sleep_for(wait);

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -646,7 +646,9 @@ std::pair<bool, Uptane::Target> SotaUptaneClient::downloadImage(const Uptane::Ta
 
     for (; tries < max_tries; tries++) {
       success = package_manager_->fetchTarget(target, *uptane_fetcher, keys, prog_cb, token);
-      if (success) {
+      // Skip trying to fetch the 'target' if control flow token transaction
+      // was set to the 'abort' or 'pause' state, see the CommandQueue and FlowControlToken.
+      if (success || (token && !token->canContinue(false))) {
         break;
       } else if (tries < max_tries - 1) {
         std::this_thread::sleep_for(wait);


### PR DESCRIPTION
Signed-off-by: Kostiantyn Bushko <kbushko@intellias.com>
Skip trying to fetch(download) target if the ```FlowControlToken``` state is set to ```pause``` or ```abort```.
So we try to fetch target against only in case if the ```PackageManagerInterface::fetchTarget(...)``` returns FALSE and the ```FlowControlToken STATE == running```.