### PR TITLE
Fix available space check for 32-bit systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,10 @@ unset(AKTUALIZR_CHECKED_SRCS CACHE)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+# To ensure better support of large files on 32-bit systems.
+# See https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html
+add_definitions("-D_FILE_OFFSET_BITS=64")
+
 if (CCACHE)
     find_program(CCACHE_PROGRAM ccache)
     if (CCACHE_PROGRAM)

--- a/src/libaktualizr/storage/sqlstorage.cc
+++ b/src/libaktualizr/storage/sqlstorage.cc
@@ -1637,7 +1637,7 @@ bool SQLStorage::checkAvailableDiskSpace(const uint64_t required_bytes) const {
     LOG_WARNING << "Unable to read filesystem statistics: error code " << stat_res;
     return true;
   }
-  const uint64_t available_bytes = (stvfsbuf.f_bsize * stvfsbuf.f_bavail);
+  const uint64_t available_bytes = (static_cast<uint64_t>(stvfsbuf.f_bsize) * stvfsbuf.f_bavail);
   const uint64_t reserved_bytes = 1 << 20;
 
   if (required_bytes + reserved_bytes < available_bytes) {


### PR DESCRIPTION
The issue was reported by a customer. This function:
https://github.com/advancedtelematic/aktualizr/blob/3c09519c97f8a40d9a84c62d02559dac18416c93/src/libaktualizr/storage/sqlstorage.cc#L1633
gives incorrect results on 32-bit systems.

The root cause is that both `f_bsize` and `f_bavail` members of statvfs struct are 4 bytes long. Hence, the result of this expression
https://github.com/advancedtelematic/aktualizr/blob/3c09519c97f8a40d9a84c62d02559dac18416c93/src/libaktualizr/storage/sqlstorage.cc#L1640
is also 4 byte long and overflows on 4GB.

This fix makes aktualizr use 64-bit filesystem interface. Member `f_bavail` becomes 8 bytes long and the expression evaluates correctly.
This has no effect on 64-bit architectures.