### PR TITLE
Only return hasPendingInstall() for primary

### DIFF
--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -1033,8 +1033,14 @@ void SotaUptaneClient::campaignPostpone(const std::string &campaign_id) {
 }
 
 bool SotaUptaneClient::isInstallCompletionRequired() const {
-  bool force_install_completion = (hasPendingUpdates() && config.uptane.force_install_completion);
-  return force_install_completion;
+  std::vector<std::pair<Uptane::EcuSerial, Uptane::Hash>> pending_ecus;
+  storage->getPendingEcus(&pending_ecus);
+  bool pending_for_ecu = std::find_if(pending_ecus.begin(), pending_ecus.end(),
+                                      [this](const std::pair<Uptane::EcuSerial, Uptane::Hash> &ecu) -> bool {
+                                        return ecu.first == primary_ecu_serial_;
+                                      }) != pending_ecus.end();
+
+  return pending_for_ecu && config.uptane.force_install_completion;
 }
 
 void SotaUptaneClient::completeInstall() const {

--- a/src/libaktualizr/storage/storage_common_test.cc
+++ b/src/libaktualizr/storage/storage_common_test.cc
@@ -321,6 +321,7 @@ TEST(storage, load_store_installed_versions) {
   {
     boost::optional<Uptane::Target> current;
     EXPECT_TRUE(storage->loadInstalledVersions("primary", &current, nullptr));
+    EXPECT_FALSE(storage->hasPendingInstall());
     EXPECT_TRUE(!!current);
     EXPECT_EQ(current->filename(), "update.bin");
     EXPECT_EQ(current->sha256Hash(), "2561");
@@ -340,6 +341,7 @@ TEST(storage, load_store_installed_versions) {
     boost::optional<Uptane::Target> pending;
     EXPECT_TRUE(storage->loadInstalledVersions("primary", nullptr, &pending));
     EXPECT_TRUE(!!pending);
+    EXPECT_TRUE(storage->hasPendingInstall());
     EXPECT_EQ(pending->filename(), "update2.bin");
   }
 
@@ -351,6 +353,7 @@ TEST(storage, load_store_installed_versions) {
     boost::optional<Uptane::Target> pending;
     EXPECT_TRUE(storage->loadInstalledVersions("primary", nullptr, &pending));
     EXPECT_TRUE(!!pending);
+    EXPECT_TRUE(storage->hasPendingInstall());
     EXPECT_EQ(pending->filename(), "update3.bin");
   }
 
@@ -364,6 +367,7 @@ TEST(storage, load_store_installed_versions) {
     EXPECT_TRUE(!!current);
     EXPECT_EQ(current->filename(), "update3.bin");
     EXPECT_FALSE(!!pending);
+    EXPECT_FALSE(storage->hasPendingInstall());
 
     std::vector<Uptane::Target> log;
     storage->loadInstallationLog("primary", &log, true);
@@ -378,6 +382,7 @@ TEST(storage, load_store_installed_versions) {
     storage->loadInstallationLog("primary", &log, true);
     EXPECT_EQ(log.size(), 3);
     EXPECT_EQ(log.back().filename(), "update.bin");
+    EXPECT_FALSE(storage->hasPendingInstall());
   }
 
   // Set t2 as the new pending and t3 as current afterwards: the pending flag
@@ -392,6 +397,7 @@ TEST(storage, load_store_installed_versions) {
     EXPECT_TRUE(!!current);
     EXPECT_EQ(current->filename(), "update3.bin");
     EXPECT_FALSE(!!pending);
+    EXPECT_FALSE(storage->hasPendingInstall());
 
     std::vector<Uptane::Target> log;
     storage->loadInstallationLog("primary", &log, true);


### PR DESCRIPTION
Because of this, primary was rebooting needlessly.

Bug found here: https://github.com/advancedtelematic/meta-updater/pull/696