### PR TITLE
fix: configurable number of attempts to connect to secondary

### DIFF
--- a/src/aktualizr_secondary/secondary_tcp_server.cc
+++ b/src/aktualizr_secondary/secondary_tcp_server.cc
@@ -20,7 +20,7 @@ SecondaryTcpServer::SecondaryTcpServer(Uptane::SecondaryInterface &secondary, co
     LOG_INFO << "Connected to Primary, sending info about this secondary...";
     HandleOneConnection(*conn_socket);
   } else {
-    LOG_INFO << "Failed to connect to Primary";
+    LOG_INFO << "Failed to connect to Primary: " << std::strerror(errno);
   }
 }
 

--- a/src/libaktualizr-posix/asn1/asn1_message.cc
+++ b/src/libaktualizr-posix/asn1/asn1_message.cc
@@ -84,10 +84,11 @@ Asn1Message::Ptr Asn1Rpc(const Asn1Message::Ptr& tx, int con_fd) {
   return msg;
 }
 
-Asn1Message::Ptr Asn1Rpc(const Asn1Message::Ptr& tx, const std::pair<std::string, uint16_t>& addr) {
+Asn1Message::Ptr Asn1Rpc(const Asn1Message::Ptr& tx, const std::pair<std::string, uint16_t>& addr,
+                         uint16_t max_attempt_number) {
   ConnectionSocket connection(addr.first, addr.second);
 
-  if (connection.connect() < 0) {
+  if (connection.connect(max_attempt_number) < 0) {
     LOG_ERROR << "Failed to connect to the secondary ( " << addr.first << ":" << addr.second
               << "): " << std::strerror(errno);
     return Asn1Message::Empty();

--- a/src/libaktualizr-posix/asn1/asn1_message.h
+++ b/src/libaktualizr-posix/asn1/asn1_message.h
@@ -123,5 +123,6 @@ void SetString(OCTET_STRING_t* dest, const std::string& str);
  * response.
  */
 Asn1Message::Ptr Asn1Rpc(const Asn1Message::Ptr& tx, int con_fd);
-Asn1Message::Ptr Asn1Rpc(const Asn1Message::Ptr& tx, const std::pair<std::string, uint16_t>& addr);
+Asn1Message::Ptr Asn1Rpc(const Asn1Message::Ptr& tx, const std::pair<std::string, uint16_t>& addr,
+                         uint16_t max_attempt_number = 1);
 #endif  // ASN1_MESSAGE_H_

--- a/src/libaktualizr-posix/ipuptanesecondary.cc
+++ b/src/libaktualizr-posix/ipuptanesecondary.cc
@@ -15,7 +15,7 @@ Uptane::SecondaryInterface::Ptr IpUptaneSecondary::connectAndCreate(const std::s
 
   ConnectionSocket con_sock{address, port};
 
-  if (con_sock.connect() == 0) {
+  if (con_sock.connect(3) == 0) {
     LOG_INFO << "Connected to IP Secondary: "
              << "(" << address << ":" << port << ")";
   } else {
@@ -169,7 +169,7 @@ Manifest IpUptaneSecondary::getManifest() const {
 
   req->present(AKIpUptaneMes_PR_manifestReq);
 
-  auto resp = Asn1Rpc(req, getAddr());
+  auto resp = Asn1Rpc(req, getAddr(), 3);
 
   if (resp->present() != AKIpUptaneMes_PR_manifestResp) {
     LOG_ERROR << "Failed to get public key response message from secondary";

--- a/src/libaktualizr/utilities/utils.cc
+++ b/src/libaktualizr/utilities/utils.cc
@@ -908,9 +908,16 @@ ConnectionSocket::ConnectionSocket(const std::string &ip, in_port_t port, in_por
 
 ConnectionSocket::~ConnectionSocket() { ::shutdown(socket_fd_, SHUT_RDWR); }
 
-int ConnectionSocket::connect() {
-  return ::connect(socket_fd_, reinterpret_cast<const struct sockaddr *>(&remote_sock_address_),
-                   sizeof(remote_sock_address_));
+int ConnectionSocket::connect(uint16_t max_attempt_number) {
+  uint16_t attempt_number = 1;
+  int connection_attempt_result = -1;
+
+  do {
+    connection_attempt_result = ::connect(socket_fd_, reinterpret_cast<const struct sockaddr *>(&remote_sock_address_),
+                                          sizeof(remote_sock_address_));
+  } while (connection_attempt_result < 0 && attempt_number++ < max_attempt_number);
+
+  return connection_attempt_result;
 }
 
 CurlEasyWrapper::CurlEasyWrapper() {

--- a/src/libaktualizr/utilities/utils.h
+++ b/src/libaktualizr/utilities/utils.h
@@ -149,7 +149,7 @@ class ConnectionSocket : public Socket {
   ~ConnectionSocket() override;
 
  public:
-  int connect();
+  int connect(uint16_t max_attempt_number = 1);
 
  private:
   struct sockaddr_in remote_sock_address_;


### PR DESCRIPTION
- parameterize a number of connection attempts to secondary
- try to connect to secondary for three times during manifest fetching
- try to connect to secondary for four times at provisioning state

Signed-off-by: Mike Sul <ext-mykhaylo.sul@here.com>