### PR TITLE
fix: run aktualizr in a full mode while waiting for a secondary reboot

### DIFF
--- a/src/libaktualizr-posix/ipuptanesecondary.cc
+++ b/src/libaktualizr-posix/ipuptanesecondary.cc
@@ -172,7 +172,7 @@ Manifest IpUptaneSecondary::getManifest() const {
   auto resp = Asn1Rpc(req, getAddr());
 
   if (resp->present() != AKIpUptaneMes_PR_manifestResp) {
-    LOG_ERROR << "Failed to get public key response message from secondary";
+    LOG_ERROR << "Failed to get a response to a get manifest request to secondary";
     return Json::Value();
   }
   auto r = resp->manifestResp();

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -1418,6 +1418,10 @@ void SotaUptaneClient::checkAndUpdatePendingSecondaries() {
     }
     auto &sec = secondaries[pending_ecu.first];
     const auto &manifest = sec->getManifest();
+    if (manifest == Json::nullValue) {
+      LOG_DEBUG << "Failed to get a manifest from Secondary: " << sec->getSerial();
+      continue;
+    }
     if (!manifest.verifySignature(sec->getPublicKey())) {
       LOG_ERROR << "Invalid signature of the manifest reported by secondary: "
                 << " serial: " << pending_ecu.first << " manifest: " << manifest;

--- a/tests/ipsecondary_test.py
+++ b/tests/ipsecondary_test.py
@@ -122,9 +122,10 @@ def test_secondary_ostree_update(uptane_repo, secondary, aktualizr, treehub, sys
     sysroot.update_revision(pending_rev)
     secondary.emulate_reboot()
 
-    with secondary:
-        with aktualizr:
-            aktualizr.wait_for_completion()
+    aktualizr.set_mode('full')
+    with aktualizr:
+        with secondary:
+            director.wait_for_install()
 
     if not director.get_install_result():
         logger.error("Installation result is not successful")
@@ -153,7 +154,7 @@ def test_secondary_ostree_update(uptane_repo, secondary, aktualizr, treehub, sys
 @with_aktualizr(start=False, run_mode='once', output_logs=True)
 def test_secondary_ostree_reboot(uptane_repo, secondary, aktualizr, treehub, sysroot, director, **kwargs):
     target_rev = treehub.revision
-    expected_targetname = uptane_repo.add_ostree_target(secondary.id, target_rev, "GARAGE_TARGET_NAME")
+    uptane_repo.add_ostree_target(secondary.id, target_rev, "GARAGE_TARGET_NAME")
 
     with secondary:
         with aktualizr:
@@ -168,9 +169,10 @@ def test_secondary_ostree_reboot(uptane_repo, secondary, aktualizr, treehub, sys
 
     sysroot.update_revision(pending_rev)
 
-    with secondary:
-        with aktualizr:
-            aktualizr.wait_for_completion()
+    aktualizr.set_mode('full')
+    with aktualizr:
+        with secondary:
+            director.wait_for_install()
 
     if not director.get_install_result():
         logger.error("Installation result is not successful")

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -128,6 +128,9 @@ class Aktualizr:
     }}
     '''
 
+    def set_mode(self, mode):
+        self._run_mode = mode
+
     def add_secondary(self, secondary):
         with open(self._secondary_config_file, "r+") as config_file:
             sec_cfg = json.load(config_file)


### PR DESCRIPTION
- run aktualizr in a full mode while waiting for a secondary reboot after its ostree rootfs update in the scope of ip secondary test;

- fix a minor issue with catching errors that might occur during fetching Secondary's manifest on Primary withing its UptaneCycle loop.

Signed-off-by: Mike Sul <ext-mykhaylo.sul@here.com>