### PR TITLE
libaktualizr: dockerapp: dont prune label aktualizr-no-prune

### DIFF
--- a/src/libaktualizr/package_manager/dockerapp_bundles.cc
+++ b/src/libaktualizr/package_manager/dockerapp_bundles.cc
@@ -140,7 +140,7 @@ data::InstallationResult DockerAppBundles::install(const Uptane::Target &target)
     LOG_INFO << "Pruning unused docker images";
     // Utils::shell which isn't interactive, we'll use std::system so that
     // stdout/stderr is streamed while docker sets things up.
-    if (std::system("docker image prune -a -f") != 0) {
+    if (std::system("docker image prune -a -f --filter=\"label!=aktualizr-no-prune\"") != 0) {
       LOG_WARNING << "Unable to prune unused docker images";
     }
   }

--- a/src/libaktualizr/package_manager/dockerapp_standalone.cc
+++ b/src/libaktualizr/package_manager/dockerapp_standalone.cc
@@ -174,7 +174,7 @@ data::InstallationResult DockerAppStandalone::install(const Uptane::Target &targ
     LOG_INFO << "Pruning unused docker images";
     // Utils::shell which isn't interactive, we'll use std::system so that
     // stdout/stderr is streamed while docker sets things up.
-    if (std::system("docker image prune -a -f") != 0) {
+    if (std::system("docker image prune -a -f --filter=\"label!=aktualizr-no-prune\"") != 0) {
       LOG_WARNING << "Unable to prune unused docker images";
     }
   }


### PR DESCRIPTION
Let's create a way of preserving images which are not currently
being used by marking them with the following label:
aktualizr-no-prune=1

An example use-case for this would be keeping around an image used
for manual debugging (it isn't always running).

Signed-off-by: Michael Scott <mike@foundries.io>