### PR TITLE
Move the default branch to zeus.

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/pages/aktualizr-config-options.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/aktualizr-config-options.adoc
@@ -38,7 +38,7 @@ For examples of configuration files, see the following resources:
 
 * link:{aktualizr-github-url}/config/[Config files used by unit tests]
 * link:{aktualizr-github-url}/tests/config/[Config files used by continuous integration tests]
-* link:https://github.com/advancedtelematic/meta-updater/tree/thud/recipes-sota/config/files[Configuration fragments used in meta-updater recipes].
+* link:https://github.com/advancedtelematic/meta-updater/tree/zeus/recipes-sota/config/files[Configuration fragments used in meta-updater recipes].
 
 All fields are optional, and most have reasonable defaults that should be used unless you have a particular need to do otherwise.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/build-raspberry.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-raspberry.adoc
@@ -61,7 +61,7 @@ First, clone a manifest file for the quickstart project:
 ----
 mkdir myproject
 cd myproject
-repo init -u https://github.com/advancedtelematic/updater-repo.git -m thud.xml
+repo init -u https://github.com/advancedtelematic/updater-repo.git -m zeus.xml
 repo sync
 ----
 


### PR DESCRIPTION
Thud in poky has been moved to community support only. We are still supporting it in our repos for now, but new users should use a newer release branch.

We should consider putting the branchname in a common place as a variable as we've done for some other things.