### PR TITLE
Improve logging in aktualizr-secondary

### DIFF
--- a/src/aktualizr_info/aktualizr_info_test.cc
+++ b/src/aktualizr_info/aktualizr_info_test.cc
@@ -393,9 +393,9 @@ TEST_F(AktualizrInfoTest, PrintPrimaryEcuCurrentAndPendingVersions) {
   aktualizr_info_process_.run();
   ASSERT_FALSE(aktualizr_info_output.empty());
 
-  EXPECT_NE(aktualizr_info_output.find("Current primary ecu running version: " + current_ecu_version),
+  EXPECT_NE(aktualizr_info_output.find("Current Primary ECU running version: " + current_ecu_version),
             std::string::npos);
-  EXPECT_NE(aktualizr_info_output.find("Pending primary ecu version: " + pending_ecu_version), std::string::npos);
+  EXPECT_NE(aktualizr_info_output.find("Pending Primary ECU version: " + pending_ecu_version), std::string::npos);
 }
 
 /**
@@ -418,8 +418,8 @@ TEST_F(AktualizrInfoTest, PrintPrimaryEcuCurrentAndPendingVersionsNegative) {
   EXPECT_NE(aktualizr_info_output.find(primary_ecu_serial.ToString()), std::string::npos);
   EXPECT_NE(aktualizr_info_output.find(primary_hw_id.ToString()), std::string::npos);
 
-  EXPECT_NE(aktualizr_info_output.find("No currently running version on primary ecu"), std::string::npos);
-  EXPECT_EQ(aktualizr_info_output.find("Pending primary ecu version:"), std::string::npos);
+  EXPECT_NE(aktualizr_info_output.find("No currently running version on Primary ECU"), std::string::npos);
+  EXPECT_EQ(aktualizr_info_output.find("Pending Primary ECU version:"), std::string::npos);
 
   Uptane::EcuMap ecu_map{{primary_ecu_serial, primary_hw_id}};
   db_storage_->savePrimaryInstalledVersion(
@@ -429,8 +429,8 @@ TEST_F(AktualizrInfoTest, PrintPrimaryEcuCurrentAndPendingVersionsNegative) {
   aktualizr_info_process_.run();
   ASSERT_FALSE(aktualizr_info_output.empty());
 
-  EXPECT_NE(aktualizr_info_output.find("No currently running version on primary ecu"), std::string::npos);
-  EXPECT_NE(aktualizr_info_output.find("Pending primary ecu version: " + pending_ecu_version), std::string::npos);
+  EXPECT_NE(aktualizr_info_output.find("No currently running version on Primary ECU"), std::string::npos);
+  EXPECT_NE(aktualizr_info_output.find("Pending Primary ECU version: " + pending_ecu_version), std::string::npos);
 
   db_storage_->savePrimaryInstalledVersion(
       {"update-01.bin", ecu_map, {{Uptane::Hash::Type::kSha256, pending_ecu_version}}, 1, "corrid-01"},
@@ -440,9 +440,9 @@ TEST_F(AktualizrInfoTest, PrintPrimaryEcuCurrentAndPendingVersionsNegative) {
   ASSERT_FALSE(aktualizr_info_output.empty());
 
   // pending ecu version became the current now
-  EXPECT_NE(aktualizr_info_output.find("Current primary ecu running version: " + pending_ecu_version),
+  EXPECT_NE(aktualizr_info_output.find("Current Primary ECU running version: " + pending_ecu_version),
             std::string::npos);
-  EXPECT_EQ(aktualizr_info_output.find("Pending primary ecu version:"), std::string::npos);
+  EXPECT_EQ(aktualizr_info_output.find("Pending Primary ECU version:"), std::string::npos);
 }
 
 /**

--- a/tests/prov_test_common.py
+++ b/tests/prov_test_common.py
@@ -8,7 +8,7 @@ def verify_provisioned(akt_info, conf):
     stdout, stderr, retcode = run_subprocess([str(akt_info), '--config', str(conf), '--wait-until-provisioned'])
     machine = platform.node()
     if (b'Device ID: ' not in stdout or
-            b'Primary ecu hardware ID: ' + machine.encode() not in stdout or
+            b'Primary ECU hardware ID: ' + machine.encode() not in stdout or
             b'Fetched metadata: yes' not in stdout):
         print('Provisioning failed: ' + stderr.decode() + stdout.decode())
         return 1

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -158,7 +158,7 @@ class Aktualizr:
                                           timeout=60, stdout=subprocess.PIPE, env=self._run_env)
             if info_exe_res.returncode == 0 and \
                     str(info_exe_res.stdout).find('Provisioned on server: yes') != -1 and \
-                    str(info_exe_res.stdout).find('Current primary ecu running version:') != -1:
+                    str(info_exe_res.stdout).find('Current Primary ECU running version:') != -1:
                 break
 
         if info_exe_res and info_exe_res.returncode == 0:
@@ -212,7 +212,7 @@ class Aktualizr:
     # ugly stuff that could be removed if Aktualizr had exposed API to check status
     # or aktializr-info had output status/info in a structured way (e.g. json)
     def get_current_primary_image_info(self):
-        primary_hash_field = 'Current primary ecu running version: '
+        primary_hash_field = 'Current Primary ECU running version: '
         aktualizr_status = self.get_info()
         if aktualizr_status:
             start = aktualizr_status.find(primary_hash_field)
@@ -225,7 +225,7 @@ class Aktualizr:
     # ugly stuff that could be removed if Aktualizr had exposed API to check status
     # or aktializr-info had output status/info in a structured way (e.g. json)
     def get_primary_pending_version(self):
-        primary_hash_field = 'Pending primary ecu version: '
+        primary_hash_field = 'Pending Primary ECU version: '
         aktualizr_status = self.get_info()
         start = aktualizr_status.find(primary_hash_field)
         end = aktualizr_status.find('\\n', start)


### PR DESCRIPTION
Changed log in aktualizr-secondary and aktualizr-info

In aktualizr-secondary, print manifest, meta, and status like download success/fail,
installation success/fail.
Added a parameter "--secondary" for aktualizr-info to make the log for secondary
database looks better.

Signed-off-by: cheng.xiang <ext-cheng.xiang@here.com>