### PR TITLE
Editing mulltiple accounts page with environment info

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/nav.adoc
+++ b/docs/ota-client-guide/modules/ROOT/nav.adoc
@@ -44,7 +44,7 @@ ifndef::env-github[:pageroot:]
 .Integrate OTA Connect
 * xref:{pageroot}intro-prep.adoc[Recommended steps]
 * xref:{pageroot}recommended-clientconfig.adoc[Recommended configurations]
-* xref:{pageroot}account-setup.adoc[Set up additional environments]
+* xref:{pageroot}add-environments.adoc[Set up additional environments]
 
 * xref:{pageroot}libaktualizr-why-use.adoc[Integrate libaktualizr into your solution]
 ** xref:{pageroot}libaktualizr-getstarted.adoc[Get started with libaktualizr]

--- a/docs/ota-client-guide/modules/ROOT/nav.adoc
+++ b/docs/ota-client-guide/modules/ROOT/nav.adoc
@@ -44,7 +44,7 @@ ifndef::env-github[:pageroot:]
 .Integrate OTA Connect
 * xref:{pageroot}intro-prep.adoc[Recommended steps]
 * xref:{pageroot}recommended-clientconfig.adoc[Recommended configurations]
-* xref:{pageroot}account-setup.adoc[Set up multiple accounts]
+* xref:{pageroot}account-setup.adoc[Set up additional environments]
 
 * xref:{pageroot}libaktualizr-why-use.adoc[Integrate libaktualizr into your solution]
 ** xref:{pageroot}libaktualizr-getstarted.adoc[Get started with libaktualizr]

--- a/docs/ota-client-guide/modules/ROOT/pages/_partials/recommended-steps.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/_partials/recommended-steps.adoc
@@ -31,7 +31,7 @@ We support a couple of demo boards "out of the box". You don't need to worry abo
 
 * *Set up different environments*
 +
-When you first create an account on the https://connect.ota.here.com[OTA Connect Portal], you get a home xref:ota-web::environments-intro.adoc[environment]--where you can create and manage software update projects. You become the owner of your home environment and can create up to 10 additional environments within your OTA Connect account. This helps because you don't want to mix up test software and production software.
+When you first create an account on the https://connect.ota.here.com[OTA Connect Portal], you get a home xref:ota-web::environments-intro.adoc[environment]--where you can create and manage software update projects. You can also create up to 10 additional environments within your OTA Connect account. This helps because you don't want to mix up test software and production software.
 +
 In a proper production workflow, you'll need separate environments to manage the different stages:
 +
@@ -39,9 +39,9 @@ In a proper production workflow, you'll need separate environments to manage the
 . A QA environment.
 . A production environment.
 +
-With one login to your OTA Connect account, you can easily switch between the different environments and also add your colleagues as members in each of the environments. Please refer to xref:ota-web::manage-members.adoc[managing members in an environment] to know how to achieve this.
+In your OTA Connect account, you can easily switch between the different environments and also add your colleagues as members in each of the environments. For instructions on how to manage members, see the xref:ota-web::manage-members.adoc[related] section in the User Guide.
 +
-Creating seperate environments provides you with a convenient way of separating your development, QA and production resources.
+Seperate environments provide you with a convenient way of separating your development, QA, and production resources.
 
 
 ////

--- a/docs/ota-client-guide/modules/ROOT/pages/_partials/recommended-steps.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/_partials/recommended-steps.adoc
@@ -29,17 +29,20 @@ We support a couple of demo boards "out of the box". You don't need to worry abo
 
 //  tag::integrate-steps[]
 
-* *Set up different user logins*
+* *Set up different environments*
 +
-In OTA Connect, each user account gets its own personal software repositories and device inventory. However, you don't want to mix up test software and production software by putting all of your builds and devices on the same account.
+When you first create an account on the https://connect.ota.here.com[OTA Connect Portal], you get a home xref:ota-web::environments-intro.adoc[environment]--where you can create and manage software update projects. You become the owner of your home environment and can create up to 10 additional environments within your OTA Connect account. This helps because you don't want to mix up test software and production software.
 +
-A better strategy for production is to create separate user logins to manage the different stages. For example, you might want a three-step process:
+In a proper production workflow, you'll need separate environments to manage the different stages:
 +
-. A developer user such as "\dev@acme.com".
-. A QA user such as "\qa@acme.com".
-. A production user such as "\prod@acme.com".
+. A developer environment.
+. A QA environment.
+. A production environment.
 +
-These logins provide you with a way of clearly separating your development, QA and production resources.
+With one login to your OTA Connect account, you can easily switch between the different environments and also add your colleagues as members in each of the environments. Please refer to xref:ota-web::manage-members.adoc[managing members in an environment] to know how to achieve this.
++
+Creating seperate environments provides you with a convenient way of separating your development, QA and production resources.
+
 
 ////
 COMMENTING OUT UNTIL ORGANIZATIONS STOPS BEING "ALPHA"

--- a/docs/ota-client-guide/modules/ROOT/pages/account-setup.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/account-setup.adoc
@@ -1,4 +1,4 @@
-= Set up multiple accounts
+= Set up additional environments
 ifdef::env-github[]
 
 [NOTE]
@@ -8,24 +8,25 @@ We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}
 endif::[]
 
 
-If you do not want to mix up test and production software, you may use separate user logins or create additional environments.
+An environment is your working space in your https://connect.ota.here.com[OTA Connect account], where you can create and manage software update projects.
 
-== Separate user logins
+If you do not want to mix up test and production software xref:evaluation-to-prod.adoc#_integrate_ota_connect[during integration with OTA Connect], you may create additional environments. You can xref:ota-web::create-environment.adoc[create] up to 10 additional environments in one https://connect.ota.here.com[OTA Connect account].
 
-To manage the different stages of production workflow, you can create separate user logins:
+For example, you may need to have different environments for development, QA, and production.
+
+IMPORTANT: The limit of 10 additional environments applies even if you leave the environments that you have created. There is currently no way to delete environments.
+
+== Additional environments
+
+To manage the different stages of production workflow, you can create additional environments for the following:
 
 * A developer user such as _\dev@acme.com_
 * A QA user such as _\qa@acme.com_
 * A production user such as _\prod@acme.com_
 
-These logins provide you with a convenient way to separate your development, QA, and production resources.
+These environments provide you with a convenient way to separate your development, QA, and production resources.
 
-== Additional environments image:img::beta-icon.svg[Beta]
-
-NOTE: This feature is in beta and is only visible to users who are part of our beta program. If you would like to join the beta program, contact us at link:mailto:otaconnect.support@here.com[otaconnect.support@here.com] to request access.
-
-Instead of creating multiple accounts for each environment, you can now xref:ota-web::create-environment.adoc[create] additional environments using only one account. For example, you may need to have different environments for development, QA, and production.
 
 After you create an environment, you can xref:ota-web::manage-members.adoc[add] your colleagues to work together on device provisioning, device groups, software versions, software updates, and campaigns.
 
-To get more information on the environments feature, see the xref:ota-web::environments-intro.adoc[*Environments*] section in the OTA Connect User Guide.
+To get more information on the *Environments* feature, see the xref:ota-web::environments-intro.adoc[Environments] section in the OTA Connect User Guide.

--- a/docs/ota-client-guide/modules/ROOT/pages/add-environments.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/add-environments.adoc
@@ -1,4 +1,5 @@
 = Set up additional environments
+:page-aliases: account-setup.adoc
 ifdef::env-github[]
 
 [NOTE]
@@ -8,21 +9,21 @@ We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}
 endif::[]
 
 
-An environment is your working space in your https://connect.ota.here.com[OTA Connect account], where you can create and manage software update projects.
+An xref:ota-web::environments-intro.adoc[environment] is your working space in your https://connect.ota.here.com[OTA Connect account], where you can create and manage software update projects.
 
-If you do not want to mix up test and production software xref:evaluation-to-prod.adoc#_integrate_ota_connect[during integration with OTA Connect], you may create additional environments. You can xref:ota-web::create-environment.adoc[create] up to 10 additional environments in one https://connect.ota.here.com[OTA Connect account].
+If you do not want to mix up test and production software during xref:evaluation-to-prod.adoc#_integrate_ota_connect[integration with OTA Connect], you may create additional environments. You can xref:ota-web::create-environment.adoc[create] up to 10 additional environments in one OTA Connect account.
 
 For example, you may need to have different environments for development, QA, and production.
 
 IMPORTANT: The limit of 10 additional environments applies even if you leave the environments that you have created. There is currently no way to delete environments.
 
-== Additional environments
+== Environments for production workflow
 
-To manage the different stages of production workflow, you can create additional environments for the following:
+To manage the different stages of production workflow, you should create the following additional environments:
 
-* A developer user such as _\dev@acme.com_
-* A QA user such as _\qa@acme.com_
-* A production user such as _\prod@acme.com_
+* A developer environment
+* A QA environment
+* A production environment
 
 These environments provide you with a convenient way to separate your development, QA, and production resources.
 
@@ -30,3 +31,4 @@ These environments provide you with a convenient way to separate your developmen
 After you create an environment, you can xref:ota-web::manage-members.adoc[add] your colleagues to work together on device provisioning, device groups, software versions, software updates, and campaigns.
 
 To get more information on the *Environments* feature, see the xref:ota-web::environments-intro.adoc[Environments] section in the OTA Connect User Guide.
+

--- a/docs/ota-client-guide/modules/ROOT/pages/client-provisioning-methods.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/client-provisioning-methods.adoc
@@ -80,12 +80,12 @@ image::img::device-cred-provisioning.png[width=100%]
 
 If you want to use "shared credential" provisioning, you don't have to do anything at all. When your account was created, we already generated a Fleet Root CA and keypair for you, and stored them on the OTA Connect server. We take the security of these keys extremely seriously: following industry best practices, they are kept in a Vault instance and only taken out when you request them.
 
-If you want to use "device credential" provisioning, you'll need to provide us with your own Fleet Root CA so that the OTA Connect server can verify devices.
+If you want to use "device credential" provisioning, provide us with your Fleet Root CA so that the OTA Connect server can verify devices.
 Of course, you can use both methods, but in that case, we recommend that you maintain separate xref:ota-web::environments-intro.adoc[environments]:
 
-* one environment for testing with "shared credential" provisioning
-* one environment for production with "device credential" provisioning
+* one for testing with "shared credential" provisioning
+* one for production with "device credential" provisioning
 
-It is not possible to migrate from a test environment to a production environment. Therefore we recommend that you test with devices that will not go into production or devices that can be completely wiped and reset once they are ready to deploy.
+It is not possible to migrate from a test environment to a production environment. Therefore, we recommend that you test with devices that do not go into production or devices that can be completely wiped and reset once they are ready to deploy.
 Once you are ready for production, you should use your production environment, your own Fleet Root certificate, and production devices that have their device certificates preinstalled.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/client-provisioning-methods.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/client-provisioning-methods.adoc
@@ -81,10 +81,11 @@ image::img::device-cred-provisioning.png[width=100%]
 If you want to use "shared credential" provisioning, you don't have to do anything at all. When your account was created, we already generated a Fleet Root CA and keypair for you, and stored them on the OTA Connect server. We take the security of these keys extremely seriously: following industry best practices, they are kept in a Vault instance and only taken out when you request them.
 
 If you want to use "device credential" provisioning, you'll need to provide us with your own Fleet Root CA so that the OTA Connect server can verify devices.
-Of course, you can use both methods, but in that case, we recommend that you maintain separate user accounts:
+Of course, you can use both methods, but in that case, we recommend that you maintain separate xref:ota-web::environments-intro.adoc[environments]:
 
-* one account for testing with "shared credential" provisioning
-* one account for production with "device credential" provisioning
+* one environment for testing with "shared credential" provisioning
+* one environment for production with "device credential" provisioning
 
-Migrating devices from a test account to a production account is an extremely complex process and should be avoided.  Instead, we recommend that you test with devices that will not go into production or devices that can be completely wiped and reset once they are ready to deploy.
-Once you are ready for production, you should use your production account, your own Fleet Root certificate, and production devices that have their device certificates preinstalled.
+It is not possible to migrate from a test environment to a production environment. Therefore we recommend that you test with devices that will not go into production or devices that can be completely wiped and reset once they are ready to deploy.
+Once you are ready for production, you should use your production environment, your own Fleet Root certificate, and production devices that have their device certificates preinstalled.
+

--- a/docs/ota-client-guide/modules/ROOT/pages/cross-deploy-images.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/cross-deploy-images.adoc
@@ -23,11 +23,11 @@ To transfer disk images to a different environment, follow these steps: ::
 +
 We'll assume that you named them `source-credentials.zip` and `dest-credentials.zip`.
 +
-. Select an image and commit ID to deploy, and the hardware ID(s) to deploy it to
+. Select an image and commit ID to deploy, and the hardware ID(s) to deploy them to.
 +
-The image name is the one that appears in your {product-name} account--it will be the same as the `MACHINE` setting in Yocto by default, or the `OSTREE_BRANCHNAME` option if you set it. The commit ID is the hash of the OSTree commit, visible in the package details. The hardware IDs are for the destination environment, and are equivalent to the `MACHINE` setting in your Yocto build.
+The image name is the one that appears in your {product-name} account--it is the same as the `MACHINE` setting in Yocto by default, or the `OSTREE_BRANCHNAME` option if you set it. The commit ID is the hash of the OSTree commit, visible in the package details. The hardware IDs are for the destination environment, and are equivalent to the `MACHINE` setting in your Yocto build.
 +
-. Run `garage-deploy`
+. Run `garage-deploy`.
 +
 You can see the available options with `--help`:
 +
@@ -48,11 +48,11 @@ garage-deploy command line options:
                                  same format as curl --cacert
 ----
 +
-For example, to deploy an image called `acme-modelB` with SHA `001ee11a28e3e08f3e93e31425f0721a7fb44946919284b629ca85a1cc3073cb` and make it installable on all Raspberry Pi devices on your target environment, the command would be:
+For example, to deploy an image called `acme-modelB` with SHA `001ee11a28e3e08f3e93e31425f0721a7fb44946919284b629ca85a1cc3073cb` and make it installable on all Raspberry Pi devices in your target environment, use the following command:
 +
 ----
 garage-deploy --commit 001ee11a28e3e08f3e93e31425f0721a7fb44946919284b629ca85a1cc3073cb \
   --name acme-modelB -f source-credentials.zip -p dest-credentials.zip -h raspberrypi3
 ----
 +
-. Go to your destination environment, and verify that your image has been deployed.
+. Go to your destination environment and verify that your image is deployed.

--- a/docs/ota-client-guide/modules/ROOT/pages/cross-deploy-images.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/cross-deploy-images.adoc
@@ -1,4 +1,4 @@
-= Transfer disk images to a software repository in another account
+= Transfer disk images to a software repository in another environment
 ifdef::env-github[]
 
 [NOTE]
@@ -14,18 +14,18 @@ endif::[]
 :icons: font
 :sectnums:
 
-For our recommended production workflow, you will need to move disk images from one account to another from time to time. For example, you might want to send a development build that you're happy with to the QA team, or send that build to the deployment team once it's passed QA. You can do this with our `garage-deploy` tool.
+For our recommended production workflow, you will need to move disk images from one environment to another from time to time. For example, you might want to send a development build that you're happy with to the QA team, or send that build to the deployment team once it's passed QA. You can do this with our `garage-deploy` tool.
 
 Before you start, make sure that you've installed the xref:install-garage-sign-deploy.adoc[`garage-deploy`] tool first.
 
-To transfer disk images to a different account, follow these steps: ::
+To transfer disk images to a different environment, follow these steps: ::
 . xref:getstarted::generating-provisioning-credentials.adoc[Download provisioning keys] for both accounts.
 +
 We'll assume that you named them `source-credentials.zip` and `dest-credentials.zip`.
 +
 . Select an image and commit ID to deploy, and the hardware ID(s) to deploy it to
 +
-The image name is the one that appears in your {product-name} account--it will be the same as the `MACHINE` setting in Yocto by default, or the `OSTREE_BRANCHNAME` option if you set it. The commit ID is the hash of the OSTree commit, visible in the package details. The hardware IDs are for the destination account, and are equivalent to the `MACHINE` setting in your Yocto build.
+The image name is the one that appears in your {product-name} account--it will be the same as the `MACHINE` setting in Yocto by default, or the `OSTREE_BRANCHNAME` option if you set it. The commit ID is the hash of the OSTree commit, visible in the package details. The hardware IDs are for the destination environment, and are equivalent to the `MACHINE` setting in your Yocto build.
 +
 . Run `garage-deploy`
 +
@@ -48,11 +48,11 @@ garage-deploy command line options:
                                  same format as curl --cacert
 ----
 +
-For example, to deploy an image called `acme-modelB` with SHA `001ee11a28e3e08f3e93e31425f0721a7fb44946919284b629ca85a1cc3073cb` and make it installable on all Raspberry Pi devices on your target account, the command would be:
+For example, to deploy an image called `acme-modelB` with SHA `001ee11a28e3e08f3e93e31425f0721a7fb44946919284b629ca85a1cc3073cb` and make it installable on all Raspberry Pi devices on your target environment, the command would be:
 +
 ----
 garage-deploy --commit 001ee11a28e3e08f3e93e31425f0721a7fb44946919284b629ca85a1cc3073cb \
   --name acme-modelB -f source-credentials.zip -p dest-credentials.zip -h raspberrypi3
 ----
 +
-. Log into the destination account, and verify that your image has been deployed
+. Go to your destination environment, and verify that your image has been deployed.

--- a/docs/ota-client-guide/modules/ROOT/pages/deploy-checklist.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/deploy-checklist.adoc
@@ -35,11 +35,11 @@ You can then automate the process of either generating the device certificates o
 * xref:generate-devicecert.adoc[Generate a device certificate]
 * xref:enable-device-cred-provisioning.adoc[Enable device-credential provisioning and install device certificates]
 |**Rotate production keys**  |
-* In line with our security concept, we recommend that you sign software version with secure, offline keys.
+* In line with our security concept, we recommend that you sign the software version with secure, offline keys.
 
-* Even if you've done this already in a test environment, you need to do it again with a `credentials.zip` from your production environment.
+* Even if you've done this already in a test environment, you need to do it again with a `credentials.zip` file from your production environment.
 
-* You should keep these keys on a secure storage medium such as a link:https://www.yubico.com/[YubiKey]. You would only plug in your YubiKey when you need to sign metadata on your local computer.|  xref:rotating-signing-keys.adoc[Manage keys for software metadata]
+* You should keep these keys on a secure storage medium such as a link:https://www.yubico.com/[YubiKey]. Only plug in your YubiKey when you need to sign metadata on your local computer.|  xref:rotating-signing-keys.adoc[Manage keys for software metadata]
 
 |**Transfer disk images to your production repository**  |
 * When you're ready to deploy your software to production, you'll need to move all approved disk images from the software repository in your testing environment to the one in your production environment.  |  xref:cross-deploy-images.adoc[Transfer software to another repository]

--- a/docs/ota-client-guide/modules/ROOT/pages/deploy-checklist.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/deploy-checklist.adoc
@@ -16,12 +16,12 @@ Here is a checklist for all the tasks you should consider when moving to product
 |====================
 | Task  | Summary | Documentation
 |**Register the root certificate for your fleet ** |
-* If you followed our recommendations, you should have accounts for development, testing and production.
-** If you also followed our recommendation to use device-credential provisioning, you need to register your Fleet Root certificate with your production account
+* If you followed our recommendations, you should have separate environments for development, testing, and production.
+** If you also followed our recommendation to use device-credential provisioning, you need to register your Fleet Root certificate with your production environment.
 
-* You might have already registered a self-signed root certificate with your test account.
+* You might have already registered a self-signed root certificate with your test environment.
 +
-However, regardless of the type of certficate that you use, you'll need to register a new certificate with your *production* account. |
+However, regardless of the type of certficate that you use, you'll need to register a new certificate with your *production* environment. |
 * xref:client-provisioning-methods.adoc[Device provisioning methods]
 * xref:provide-root-cert.adoc[Register the Root Certificate for your Fleet]
 
@@ -37,12 +37,12 @@ You can then automate the process of either generating the device certificates o
 |**Rotate production keys**  |
 * In line with our security concept, we recommend that you sign software version with secure, offline keys.
 
-* Even if you've done this already for with a test account, you need to do it again with a `credentials.zip` from your production account.
+* Even if you've done this already in a test environment, you need to do it again with a `credentials.zip` from your production environment.
 
 * You should keep these keys on a secure storage medium such as a link:https://www.yubico.com/[YubiKey]. You would only plug in your YubiKey when you need to sign metadata on your local computer.|  xref:rotating-signing-keys.adoc[Manage keys for software metadata]
 
 |**Transfer disk images to your production repository**  |
-* When you're ready to deploy your software to production, you'll need to move all approved disk images from the software repository in your testing account to the one in your production account.  |  xref:cross-deploy-images.adoc[Transfer software to another repository]
+* When you're ready to deploy your software to production, you'll need to move all approved disk images from the software repository in your testing environment to the one in your production environment.  |  xref:cross-deploy-images.adoc[Transfer software to another repository]
 |**Create production-ready client configuration**  |
 * You'll need to update the configuration for aktualizr or libaktualizr.
 +

--- a/docs/ota-client-guide/modules/ROOT/pages/evaluation-to-prod.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/evaluation-to-prod.adoc
@@ -18,10 +18,10 @@ That's why it's better to work in phases when setting up OTA Connect in your org
 
 No matter which phase you're in, there are 4 basic tasks you'll need to do:
 
-. Build device images with an aktualizr-based client on it
-. Sign and upload the device images
-. Provision devices with authentication credentials for your account
-. Send updated images to some or all of your devices
+. Build device images with an aktualizr-based client on it.
+. Sign and upload the device images.
+. Provision devices with authentication credentials for your account.
+. Send updated images to some or all of your devices.
 
 This guide contains chapters to guide you through each phase. The sections below give you an introduction to the phased approach.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/evaluation-to-prod.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/evaluation-to-prod.adoc
@@ -18,12 +18,12 @@ That's why it's better to work in phases when setting up OTA Connect in your org
 
 No matter which phase you're in, there are 4 basic tasks you'll need to do:
 
-* Build device images with an aktualizr-based client on it
-* Sign and upload the device images
-* Provision devices with authentication credentials for your account
-* Send updated images to some or all of your devices
+. Build device images with an aktualizr-based client on it
+. Sign and upload the device images
+. Provision devices with authentication credentials for your account
+. Send updated images to some or all of your devices
 
-This guide contains chapters to guide you through each phase, and the following sections give you an introduction to the phased approach:
+This guide contains chapters to guide you through each phase. The sections below give you an introduction to the phased approach.
 
 == Evaluate OTA Connect
 

--- a/docs/ota-client-guide/modules/ROOT/pages/evaluation-to-prod.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/evaluation-to-prod.adoc
@@ -23,11 +23,11 @@ No matter which phase you're in, there are 4 basic tasks you'll need to do:
 * Provision devices with authentication credentials for your account
 * Send updated images to some or all of your devices
 
-This guide contains chapters to guide you through each phase and the following sections give you an introduction the phased approach:
+This guide contains chapters to guide you through each phase, and the following sections give you an introduction to the phased approach:
 
 == Evaluate OTA Connect
 
-During evaluation, you should focus on testing the basic update functionality to make sure that you understand how it works. At this stage you don't need to think about customization or production-level security. You'll use basic, minimal device images for test boards, or even just simulate devices, and OTA Connect will handle the software signing on the server. For provisioning, you'll use a shared registration key for all your devices.
+During the evaluation phase, you should focus on testing the basic update functionality to make sure that you understand how it works. At this stage, you don't need to think about customization or production-level security. You'll use basic, minimal device images for test boards, or even just simulate devices, and OTA Connect will handle the software signing on the server. For provisioning, you'll use a shared registration key for all your devices.
 
 === Recommendations
 

--- a/docs/ota-client-guide/modules/ROOT/pages/install-garage-sign-deploy.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/install-garage-sign-deploy.adoc
@@ -79,11 +79,11 @@ The executable will be available in `build/src/sota_tools/garage-deploy`.
 
 == Usage
 
-Once you've installed `garage-deploy` tool, you're ready to perform the following tasks:
+Once you've installed the `garage-deploy` tool, you're ready to perform the following tasks:
 
-* Move device images from one account to another--for example, to send a development build to the QA team, or to send a release candidate to the deployment team.
+* Move device images from one environment to another--for example, to send a development build to the QA team, or to send a release candidate to the deployment team.
 +
-For more information, see "xref:cross-deploy-images.adoc[Cross-deploy device images to a different account]".
+For more information, see "xref:cross-deploy-images.adoc[Cross-deploy device images to a different environment]".
 
 * Create offline signing keys that you manage yourself and rotate out the installed online keys.
 +

--- a/docs/ota-client-guide/modules/ROOT/pages/install-garage-sign-deploy.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/install-garage-sign-deploy.adoc
@@ -81,7 +81,7 @@ The executable will be available in `build/src/sota_tools/garage-deploy`.
 
 Once you've installed the `garage-deploy` tool, you're ready to perform the following tasks:
 
-* Move device images from one environment to another--for example, to send a development build to the QA team, or to send a release candidate to the deployment team.
+* Move device images from one environment to another. For example, you may need to send a development build to the QA team, or to send a release candidate to the deployment team.
 +
 For more information, see "xref:cross-deploy-images.adoc[Cross-deploy device images to a different environment]".
 

--- a/docs/ota-client-guide/modules/ROOT/pages/install-garage-sign-deploy.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/install-garage-sign-deploy.adoc
@@ -81,7 +81,7 @@ The executable will be available in `build/src/sota_tools/garage-deploy`.
 
 Once you've installed the `garage-deploy` tool, you're ready to perform the following tasks:
 
-* Move device images from one environment to another. For example, you may need to send a development build to the QA team, or to send a release candidate to the deployment team.
+* Move device images from one environment to another. For example, you may need to send a development build to the QA team or a release candidate to the deployment team.
 +
 For more information, see "xref:cross-deploy-images.adoc[Cross-deploy device images to a different environment]".
 

--- a/docs/ota-client-guide/modules/ROOT/pages/intro-prep.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/intro-prep.adoc
@@ -14,9 +14,9 @@ You will also start thinking about production-ready security, making sure that y
 
 Here are our recommended steps for integration:
 
-* xref:account-setup.adoc[*Set up different user accounts*]
+* xref:add-environments.adoc[*Set up different environments*]
 +
-Avoid mixing up test software and production software by uploading software under different user accounts.
+Avoid mixing up test software and production software by uploading the software under different environments.
 
 * xref:libaktualizr-why-use.adoc[*Integrate libaktualizr with the client software on your board*]
 +
@@ -28,7 +28,7 @@ Once have a working version of your integration, you'll want to build a disk ima
 
 * xref:cross-deploy-images.adoc[*Transfer disk images to a QA repository*]
 +
-After you've build your images, you'll want to hand them over to your QA team, who are ideally testing the software under a QA account with its own software repository.
+After you've built your images, you'll want to hand them over to your QA team, who are ideally testing the software in a QA environment with its own software repository.
 
 * xref:device-cred-prov-steps.adoc[*Set up provisioning with device credentials*]
 +

--- a/docs/ota-client-guide/modules/ROOT/pages/intro-prep.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/intro-prep.adoc
@@ -16,7 +16,7 @@ Here are our recommended steps for integration:
 
 * xref:add-environments.adoc[*Set up different environments*]
 +
-Avoid mixing up test software and production software by uploading the software under different environments.
+To avoid mixing up test software and production software upload the software to different environments.
 
 * xref:libaktualizr-why-use.adoc[*Integrate libaktualizr with the client software on your board*]
 +


### PR DESCRIPTION
Removed the beta icon next to the title "Additional Environments" and updated the page to only recommend creating multiple environments instead of multiple accounts.

Information added about the number of environments that can be created.

Signed-off-by: amma <awuraaamma.okyere-boateng@here.com>