### PR TITLE
antora.yml: Set version now that 2020.5 is out.

### DIFF
--- a/docs/ota-client-guide/antora.yml
+++ b/docs/ota-client-guide/antora.yml
@@ -1,6 +1,6 @@
 name: ota-client
 title: OTA Connect Developer Guide
-version: latest
-display_version: 2020.4 (latest)
+version: 2020.4
+display_version: 2020.4
 nav:
 - modules/ROOT/nav.adoc


### PR DESCRIPTION
Following the directions in https://docs.ota.here.com/ota-client/latest/release-process.html#_update_version_strings_in_antora_yml_for_old_and_new_branch.