### PR TITLE
clean the cached aktualizr repo before brewing

### DIFF
--- a/ci/gitlab/.gitlab-ci.yml
+++ b/ci/gitlab/.gitlab-ci.yml
@@ -461,6 +461,6 @@ build-osx-release:
     - if: $CI_COMMIT_TAG =~ /^20\d\d\.\d\d?-docs$/
       when: never
     - if: $OSX_RELEASE && $CI_COMMIT_TAG =~ /^\d\d\d\d\.\d+(-\w+)?$/
-      when: always
+      when: on_success
   tags:
   - osx

--- a/ci/gitlab/.gitlab-ci.yml
+++ b/ci/gitlab/.gitlab-ci.yml
@@ -434,6 +434,7 @@ build-osx-release:
   before_script:
     - brew uninstall -f aktualizr
     - brew untap advancedtelematic/otaconnect
+    - rm -rf $(brew --cache)/aktualizr--git
     - brew install ghr
   script:
     # clone a repo that contains the aktualizr formula


### PR DESCRIPTION
At first run, this release job https://main.gitlab.in.here.com/olp/edge/ota/connect/client/aktualizr/-/jobs/2203603 has failed because I left some changes (2020.5 tag) in the locally cached aktualizr repo what led to the repo update failure (the local tag and the new remote tag pointed to different revisions/commits).
So, I added an additional step to the CI job - remove the locally caches aktualizr repo to make sure that we have "clean" repo before starting the brewing process.

Signed-off-by: Mike Sul <ext-mykhaylo.sul@here.com>