### PR TITLE
Update the Antora docs to keep track of the latest version.

### DIFF
--- a/docs/ota-client-guide/antora.yml
+++ b/docs/ota-client-guide/antora.yml
@@ -1,6 +1,6 @@
 name: ota-client
 title: OTA Connect Developer Guide
-version: latest
-display_version: 2020.4 (latest)
+version: '2020.4'
+display_version: '2020.4'
 nav:
 - modules/ROOT/nav.adoc


### PR DESCRIPTION
The docs can't be published because of the conflicting versions between `2020.4-docs` and `2020.5-docs` branches. Since the latter seems to now be the latest version, the former needs to be "downgraded".