### PR TITLE
Added API to direct update raw_roport in the installation result

### DIFF
--- a/src/libaktualizr/primary/aktualizr.cc
+++ b/src/libaktualizr/primary/aktualizr.cc
@@ -156,8 +156,8 @@ std::future<result::Install> Aktualizr::Install(const std::vector<Uptane::Target
   return api_queue_.enqueue(task);
 }
 
-bool Aktualizr::SetInstallationRawReport(const Json::Value &custom_raw_report) {
-  return storage_->storeDeviceInstallationRawReport(custom_raw_report.toStyledString());
+bool Aktualizr::SetInstallationRawReport(const std::string &custom_raw_report) {
+  return storage_->storeDeviceInstallationRawReport(custom_raw_report);
 }
 
 std::future<bool> Aktualizr::SendManifest(const Json::Value &custom) {

--- a/src/libaktualizr/primary/aktualizr.cc
+++ b/src/libaktualizr/primary/aktualizr.cc
@@ -156,6 +156,10 @@ std::future<result::Install> Aktualizr::Install(const std::vector<Uptane::Target
   return api_queue_.enqueue(task);
 }
 
+bool Aktualizr::SetInstallationRawReport(const Json::Value &custom_raw_report) {
+  return storage_->storeDeviceInstallationRawReport(custom_raw_report.toStyledString());
+}
+
 std::future<bool> Aktualizr::SendManifest(const Json::Value &custom) {
   std::function<bool()> task([this, custom]() { return uptane_client_->putManifest(custom); });
   return api_queue_.enqueue(task);

--- a/src/libaktualizr/primary/aktualizr.h
+++ b/src/libaktualizr/primary/aktualizr.h
@@ -135,9 +135,21 @@ class Aktualizr {
   std::future<result::Install> Install(const std::vector<Uptane::Target>& updates);
 
   /**
+   * SetInstallationRawReport allows setting a custom raw report field in the device installation result.
+   *
+   * @note An invocation of this method will have effect only after call of  Aktualizr::Install and before calling
+   * Aktualizr::SendManifest member function.
+   * @param custom_raw_report is an arbitrary json object which is intended to replace a default value in the device
+   * installation report.
+   * @return true if the custom raw report was successfully applied to the device installation result.
+   * If there is no installation report in the storage the function will always return false.
+   */
+  bool SetInstallationRawReport(const Json::Value& custom_raw_report);
+
+  /**
    * Send installation report to the backend.
    *
-   * Note that the device manifest is also sent as a part of CheckUpdates and
+   * @note The device manifest is also sent as a part of CheckUpdates and
    * SendDeviceData calls, as well as after a reboot if it was initiated
    * by Aktualizr as a part of an installation process.
    * All these manifests will not include the custom data provided in this call.

--- a/src/libaktualizr/primary/aktualizr.h
+++ b/src/libaktualizr/primary/aktualizr.h
@@ -139,12 +139,11 @@ class Aktualizr {
    *
    * @note An invocation of this method will have effect only after call of  Aktualizr::Install and before calling
    * Aktualizr::SendManifest member function.
-   * @param custom_raw_report is an arbitrary json object which is intended to replace a default value in the device
-   * installation report.
+   * @param custom_raw_report is intended to replace a default value in the device installation report.
    * @return true if the custom raw report was successfully applied to the device installation result.
    * If there is no installation report in the storage the function will always return false.
    */
-  bool SetInstallationRawReport(const Json::Value& custom_raw_report);
+  bool SetInstallationRawReport(const std::string& custom_raw_report);
 
   /**
    * Send installation report to the backend.

--- a/src/libaktualizr/storage/invstorage.h
+++ b/src/libaktualizr/storage/invstorage.h
@@ -139,6 +139,7 @@ class INvStorage {
       std::vector<std::pair<Uptane::EcuSerial, data::InstallationResult>>* results) const = 0;
   virtual void storeDeviceInstallationResult(const data::InstallationResult& result, const std::string& raw_report,
                                              const std::string& correlation_id) = 0;
+  virtual bool storeDeviceInstallationRawReport(const std::string& raw_report) = 0;
   virtual bool loadDeviceInstallationResult(data::InstallationResult* result, std::string* raw_report,
                                             std::string* correlation_id) const = 0;
   virtual void clearInstallationResults() = 0;

--- a/src/libaktualizr/storage/sqlstorage.cc
+++ b/src/libaktualizr/storage/sqlstorage.cc
@@ -1456,6 +1456,16 @@ void SQLStorage::storeDeviceInstallationResult(const data::InstallationResult& r
   }
 }
 
+bool SQLStorage::storeDeviceInstallationRawReport(const std::string& raw_report) {
+  SQLite3Guard db = dbConnection();
+  auto statement = db.prepareStatement<std::string>("UPDATE device_installation_result SET raw_report=?;", raw_report);
+  if (statement.step() != SQLITE_DONE || sqlite3_changes(db.get()) != 1) {
+    LOG_ERROR << "Can't set device raw report result: " << db.errmsg();
+    return false;
+  }
+  return true;
+}
+
 bool SQLStorage::loadDeviceInstallationResult(data::InstallationResult* result, std::string* raw_report,
                                               std::string* correlation_id) const {
   SQLite3Guard db = dbConnection();

--- a/src/libaktualizr/storage/sqlstorage.h
+++ b/src/libaktualizr/storage/sqlstorage.h
@@ -87,6 +87,7 @@ class SQLStorage : public SQLStorageBase, public INvStorage {
       std::vector<std::pair<Uptane::EcuSerial, data::InstallationResult>>* results) const override;
   void storeDeviceInstallationResult(const data::InstallationResult& result, const std::string& raw_report,
                                      const std::string& correlation_id) override;
+  bool storeDeviceInstallationRawReport(const std::string& raw_report) override;
   bool loadDeviceInstallationResult(data::InstallationResult* result, std::string* raw_report,
                                     std::string* correlation_id) const override;
   void saveEcuReportCounter(const Uptane::EcuSerial& ecu_serial, int64_t counter) override;

--- a/src/libaktualizr/storage/storage_common_test.cc
+++ b/src/libaktualizr/storage/storage_common_test.cc
@@ -455,12 +455,15 @@ TEST(storage, load_store_installation_results) {
   EXPECT_EQ(dev_res.result_code.num_code, data::ResultCode::Numeric::kGeneralError);
   EXPECT_EQ(report, "raw");
   EXPECT_EQ(correlation_id, "corrid");
+  EXPECT_TRUE(storage->storeDeviceInstallationRawReport("user's raw report"));
 
   storage->clearInstallationResults();
   res.clear();
   EXPECT_FALSE(storage->loadEcuInstallationResults(&res));
   EXPECT_EQ(res.size(), 0);
   EXPECT_FALSE(storage->loadDeviceInstallationResult(&dev_res, &report, &correlation_id));
+  EXPECT_FALSE(storage->storeDeviceInstallationRawReport(
+      "This call will return a negative value since the installation report was cleaned!"));
 }
 
 TEST(storage, downloaded_files_info) {


### PR DESCRIPTION
Signed-off-by: Kostiantyn Bushko <kbushko@intellias.com>

This API call should be used after installation complete and before clear of installation result ```clearInstallationResults``` in the storage.
If the device installation result does not exist in the storage the invocation of this API won't have any negative effect it just returns a negative result of the execution.