### PR TITLE
Fix broken yocto link

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/pages/build-qemu.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-qemu.adoc
@@ -8,6 +8,7 @@ We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}
 ====
 endif::[]
 
+include::_partials/aktualizr-version.adoc[]
 
 :page-layout: page
 :page-categories: [quickstarts]


### PR DESCRIPTION
Normally I wouldn't bother with a PR for a minor fix like this, but I wanted to ping @ammaboateng and @HalynaDumych because this was caused by an asciidoc behaviour that might not be obvious: this page included content from another page that had the `{yocto-version}` attribute substitution in it, but didn't include the definition of the attribute, causing a broken link.

Note that this will be fixable in a cleaner way when Antora 2.3 is released, because support for component-scoped attributes was added: https://gitlab.com/antora/antora/issues/251