### PR TITLE
Docs: List dunfell as a supported Yocto branch.

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/pages/yocto-release-branches.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/yocto-release-branches.adoc
@@ -12,6 +12,7 @@ endif::[]
 
 Yocto has a number of release branches. Their details are documented in the https://wiki.yoctoproject.org/wiki/Releases[Yocto wiki]. HERE OTA Connect currently actively supports the following branches:
 
+* dunfell
 * zeus
 * warrior
 * thud


### PR DESCRIPTION
~~Depends on https://github.com/advancedtelematic/updater-repo/pull/38~~.