### PR TITLE
Fix include syntax for partials

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/pages/add-meta-updater-to-vendors-sdk.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/add-meta-updater-to-vendors-sdk.adoc
@@ -7,7 +7,7 @@ We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}
 ====
 endif::[]
 
-include::_partials/aktualizr-version.adoc[]
+include::partial$aktualizr-version.adoc[]
 
 To avoid conflicts and certain classes of bugs, we require the use of `usrmerge`, even on systems that do not use systemd. In the https://www.yoctoproject.org/docs/{yocto-version}/mega-manual/mega-manual.html[Yocto] ecosystem, it is a general best practice to write `do_install()` functions that install to the variable `\{bindir}`, but some recipes still hard-code the location of `/bin`.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/add-ota-functonality-existing-yocto-project.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/add-ota-functonality-existing-yocto-project.adoc
@@ -7,7 +7,7 @@ We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}
 ====
 endif::[]
 
-include::_partials/aktualizr-version.adoc[]
+include::partial$aktualizr-version.adoc[]
 
 :page-layout: page
 :page-categories: [quickstarts]

--- a/docs/ota-client-guide/modules/ROOT/pages/aktualizr-config-options.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/aktualizr-config-options.adoc
@@ -7,7 +7,7 @@ We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}
 ====
 endif::[]
 
-include::_partials/aktualizr-version.adoc[]
+include::partial$aktualizr-version.adoc[]
 
 :page-layout: page
 :page-categories: [client-config]
@@ -23,9 +23,9 @@ Here, we provide reference documentation on aktualizr's usage and configuration.
 
 == How .toml files are processed
 
-Aktualizr is configured via `.toml` config files. One or more files or directories can be passed to the application via the `--config` flag (one per file or directory). 
+Aktualizr is configured via `.toml` config files. One or more files or directories can be passed to the application via the `--config` flag (one per file or directory).
 
-* If `--config` is not specified on the command line, aktualizr searches the following directories for files with a `.toml` extension: 
+* If `--config` is not specified on the command line, aktualizr searches the following directories for files with a `.toml` extension:
 ** `/usr/lib/sota/conf.d`
 ** `/etc/sota/conf.d/`
 
@@ -33,7 +33,7 @@ Aktualizr searches for and processes these config files in systemd style using t
 
 * If multiple files are found with the same name, the last detected file overrules and hides the others.
 * Files are then processed in alphabetical order with the following conditions:
-** If a config option is specified in multiple files, the last entry **overrules** the previous entries. 
+** If a config option is specified in multiple files, the last entry **overrules** the previous entries.
 ** But if a config option is specified in the first file but *unspecified* in the last file, the last entry **does not** overrule the previous entry.
 
 For examples of configuration files, see the following resources:

--- a/docs/ota-client-guide/modules/ROOT/pages/build-agl.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-agl.adoc
@@ -8,7 +8,7 @@ We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}
 ====
 endif::[]
 
-include::_partials/aktualizr-version.adoc[]
+include::ota-client::partial$aktualizr-version.adoc[]
 
 
 :page-layout: page
@@ -24,7 +24,7 @@ include::_partials/aktualizr-version.adoc[]
 
 // Most of the content here is the same as the Raspberry Pi instructions, so we re-use the chunks we can.
 
-include::build-raspberry.adoc[tags=prereqs]
+include::ota-client::page$build-raspberry.adoc[tags=prereqs]
 
 == Create your AGL Yocto build environment
 
@@ -74,7 +74,7 @@ By default, AGL for QEMU boots into an initrd before loading the root filesystem
 AGL_DEFAULT_INITRAMFS_FSTYPES = "cpio.gz"
 ----
 
-include::build-raspberry.adoc[tags=config]
+include::ota-client::page$build-raspberry.adoc[tags=config]
 
 == Bitbake
 
@@ -107,4 +107,4 @@ TIP: You can also write the image using `dd`, but since the wrong kind of typo i
 
 You can now run the image in QEMU using the same method as described for a xref:build-qemu.adoc#_run_the_built_image_with_qemu[regular QEMU build]. However, the exact image you'll need will vary depending on the architecture you're building forfootnote:[For example, building the `agl-image-minimal` target for QEMU creates an image at `build/tmp/deploy/images/qemux86-64/agl-image-minimal-qemux86-64.ota-ext4`.], but it will be located in the `/tmp/deploy/images` directory under your build directory.
 
-include::partial$recommended-steps.adoc[tags=firstbuild-nextstep]
+include::ota-client::partial$recommended-steps.adoc[tags=firstbuild-nextstep]

--- a/docs/ota-client-guide/modules/ROOT/pages/build-qemu.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-qemu.adoc
@@ -8,7 +8,7 @@ We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}
 ====
 endif::[]
 
-include::_partials/aktualizr-version.adoc[]
+include::ota-client::partial$aktualizr-version.adoc[]
 
 :page-layout: page
 :page-categories: [quickstarts]

--- a/docs/ota-client-guide/modules/ROOT/pages/build-raspberry.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/build-raspberry.adoc
@@ -8,7 +8,7 @@ We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}
 ====
 endif::[]
 
-include::_partials/aktualizr-version.adoc[]
+include::partial$aktualizr-version.adoc[]
 
 :page-layout: page
 :page-categories: [quickstarts]

--- a/docs/ota-client-guide/modules/ROOT/pages/customise-targets-metadata.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/customise-targets-metadata.adoc
@@ -7,7 +7,7 @@ We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}
 ====
 endif::[]
 
-include::_partials/aktualizr-version.adoc[]
+include::partial$aktualizr-version.adoc[]
 
 In some cases, you might find it useful to include extra metadata about your software inside the signed Uptane metadata that OTA Connect delivers to your device. Some reasons you might want to do this include:
 

--- a/docs/ota-client-guide/modules/ROOT/pages/pushing-updates.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/pushing-updates.adoc
@@ -8,7 +8,7 @@ We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}
 ====
 endif::[]
 
-include::_partials/aktualizr-version.adoc[]
+include::partial$aktualizr-version.adoc[]
 
 Every time you bitbake a new image, it is automatically pushed to {product-name}. You can then send the updated image out to any of your devices. In this guide, you learn a few ways to push updated system images from your build machine or workstation to {product-name-short}.
 

--- a/docs/ota-client-guide/modules/ROOT/pages/setup-boot-image-for-ostree.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/setup-boot-image-for-ostree.adoc
@@ -7,7 +7,7 @@ We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}
 ====
 endif::[]
 
-include::_partials/aktualizr-version.adoc[]
+include::partial$aktualizr-version.adoc[]
 
 This is the second step in getting a new board running after xref:add-board-class.adoc[adding a new board class for the new target board in meta-updater].
 

--- a/docs/ota-client-guide/modules/ROOT/pages/troubleshooting-bsp-integration.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/troubleshooting-bsp-integration.adoc
@@ -7,7 +7,7 @@ We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}
 ====
 endif::[]
 
-include::_partials/aktualizr-version.adoc[]
+include::partial$aktualizr-version.adoc[]
 
 == U-Boot loading the wrong config file
 

--- a/docs/ota-client-guide/modules/ROOT/pages/troubleshooting.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/troubleshooting.adoc
@@ -7,7 +7,7 @@ We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}
 ====
 endif::[]
 
-include::_partials/aktualizr-version.adoc[]
+include::partial$aktualizr-version.adoc[]
 
 :page-layout: page
 :page-categories: [tips]


### PR DESCRIPTION
This was a tricky one, even though the actual fix is fairly small. I've been troubleshooting it for most of the day, though, so I want to make sure it's explained in a PR (and again, I'm tagging @ammaboateng and @HalynaDumych).

It's possible to include content in Antora using the asciidoc `include::[]` directive in two different ways: by [resource ID](https://docs.antora.org/antora/2.1/page/resource-id/), or by (relative) path. In general, we should always be including by resource ID, because inheriting by resource ID means that we retain the context from the page where the include occurs.

To include a page via resource ID, there's a small syntax difference from the xref syntax: for disambiguation purposes, you need to include the **family**--includes could be pages, partials, examples, etc., whereas xrefs can only be pages. This is what it looks like in practice:
```
include::page$build-raspberry.adoc[] // for a page
include::ota-client::page$build-raspberry.adoc[] // for a page, but specifying the component explicitly
include::partial$aktualizr-version.adoc[] // for a partial
include::example$sota-local.toml[] // for an example
```

There were several places where we weren't using resource IDs, and that caused some unexpected bugginess. Most of them were actually quite subtle: the include would work, but would grab a version from the wrong branch, for example. This was never caught because the only places it cause incorrect rendering was in older branches; include-by-relative-path happened to generate correct docs for the latest branch in all the places it was used (as far as I can tell).

My initial (erroneous) fix for the problem (#1629) actually ended up surfacing those bugs by causing broken links, which the link-checker CI job caught. Figuring out why that happened is what led to this fix. I'm also pushing similar fix commits to all previous docs branches, but won't be opening a PR for every one of those.