### PR TITLE
Skip test_ip_secondary test in ptest.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -192,6 +192,7 @@ endif ()
 add_test(NAME test_ip_secondary
          COMMAND ${PROJECT_SOURCE_DIR}/tests/ipsecondary_test.py
          --build-dir ${PROJECT_BINARY_DIR} --src-dir ${PROJECT_SOURCE_DIR} ${TEST_IPSEC_ARGS})
+set_tests_properties(test_ip_secondary PROPERTIES LABELS "noptest")
 
 add_test(NAME test_director_failure
         COMMAND ${PROJECT_SOURCE_DIR}/tests/test_director_failure.py


### PR DESCRIPTION
It's long and slow and isn't really something we necessarily *need* to cover in ptest.