### PR TITLE
Docs: Remove softlinks and slightly clean up the docs README.

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -1,12 +1,12 @@
 = OTA Connect Developer Guide
 
-This directory contains the source of our **OTA Connect Developer Guide** which is published to our https://docs.ota.here.com[documentation portal].
+The `ota-client-guide` subdirectory contains the source of our **OTA Connect Developer Guide** which is published to our https://docs.ota.here.com[documentation portal].
 
 You can also read the source files for this guide. To read this guide locally or in GitHub, start with the xref:ota-client-guide/modules/ROOT/nav.adoc[table of contents].
 
 [NOTE]
 ====
-Content includes, such as code snippets or reused text snippets will not render correctly in Github.
+Some elements, such as code snippets or reused text snippets, will not render correctly in Github.
 ====
 
 == Reference documentation

--- a/docs/client-provisioning-methods.adoc
+++ b/docs/client-provisioning-methods.adoc
@@ -1,1 +1,0 @@
-./ota-client-guide/modules/ROOT/pages/client-provisioning-methods.adoc

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -1,1 +1,0 @@
-./ota-client-guide/modules/ROOT/pages/aktualizr-config-options.adoc

--- a/docs/deb-package-install.adoc
+++ b/docs/deb-package-install.adoc
@@ -1,1 +1,0 @@
-./ota-client-guide/modules/ROOT/pages/deb-package-install.adoc

--- a/docs/debugging-tips.adoc
+++ b/docs/debugging-tips.adoc
@@ -1,1 +1,0 @@
-./ota-client-guide/modules/ROOT/pages/debugging-tips.adoc

--- a/docs/ecu_events.adoc
+++ b/docs/ecu_events.adoc
@@ -1,1 +1,0 @@
-./ota-client-guide/modules/ROOT/pages/ecu_events.adoc

--- a/docs/fault-injection.adoc
+++ b/docs/fault-injection.adoc
@@ -1,1 +1,0 @@
-./ota-client-guide/modules/ROOT/pages/fault-injection.adoc

--- a/docs/integrate-libaktualizr.adoc
+++ b/docs/integrate-libaktualizr.adoc
@@ -1,1 +1,0 @@
-./ota-client-guide/modules/ROOT/pages/libaktualizr-why-use.adoc

--- a/docs/posix-secondaries-bitbaking.adoc
+++ b/docs/posix-secondaries-bitbaking.adoc
@@ -1,1 +1,0 @@
-./ota-client-guide/modules/ROOT/pages/posix-secondaries-bitbaking.adoc

--- a/docs/posix-secondaries.adoc
+++ b/docs/posix-secondaries.adoc
@@ -1,1 +1,0 @@
-./ota-client-guide/modules/ROOT/pages/posix-secondaries.adoc

--- a/docs/provision-with-device-credentials.adoc
+++ b/docs/provision-with-device-credentials.adoc
@@ -1,1 +1,0 @@
-./ota-client-guide/modules/ROOT/pages/enable-device-cred-provisioning.adoc

--- a/docs/provisioning-methods-and-credentialszip.adoc
+++ b/docs/provisioning-methods-and-credentialszip.adoc
@@ -1,1 +1,0 @@
-ota-client-guide/modules/ROOT/pages/provisioning-methods-and-credentialszip.adoc

--- a/docs/rollback.adoc
+++ b/docs/rollback.adoc
@@ -1,1 +1,0 @@
-./ota-client-guide/modules/ROOT/pages/rollback.adoc

--- a/docs/schema-migrations.adoc
+++ b/docs/schema-migrations.adoc
@@ -1,1 +1,0 @@
-./ota-client-guide/modules/ROOT/pages/schema-migrations.adoc

--- a/docs/security.adoc
+++ b/docs/security.adoc
@@ -1,1 +1,0 @@
-./ota-client-guide/modules/ROOT/pages/security.adoc

--- a/docs/selectively-triggering-aktualizr.adoc
+++ b/docs/selectively-triggering-aktualizr.adoc
@@ -1,1 +1,0 @@
-./ota-client-guide/modules/ROOT/pages/aktualizr-runningmodes-finegrained-commandline-control.adoc

--- a/docs/uptane-generator.adoc
+++ b/docs/uptane-generator.adoc
@@ -1,1 +1,0 @@
-ota-client-guide/modules/ROOT/pages/uptane-generator.adoc


### PR DESCRIPTION
I think these softlinks are no longer necessary. I haven't used them in ages and they mostly just get in the way at this point.