### PR TITLE
garage-deploy: Add statistics.

### DIFF
--- a/src/sota_tools/deploy.cc
+++ b/src/sota_tools/deploy.cc
@@ -50,7 +50,9 @@ bool UploadToTreehub(const OSTreeRepo::ptr &src_repo, TreehubServer &push_server
 
   if (root_object->is_on_server() == PresenceOnServer::kObjectPresent) {
     if (mode == RunMode::kDefault || mode == RunMode::kPushTree) {
-      LOG_INFO << "Upload to Treehub complete after " << request_pool.total_requests_made() << " requests";
+      LOG_INFO << "Upload to Treehub complete after " << request_pool.head_requests_made() << " HEAD requests and "
+               << request_pool.put_requests_made() << " PUT requests.";
+      LOG_INFO << "Total size of uploaded objects: " << request_pool.total_object_size() << " bytes.";
     } else {
       LOG_INFO << "Dry run. No objects uploaded.";
     }

--- a/src/sota_tools/garage_deploy.cc
+++ b/src/sota_tools/garage_deploy.cc
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <string>
 
 #include <boost/filesystem.hpp>
@@ -16,6 +17,8 @@ namespace po = boost::program_options;
 
 int main(int argc, char **argv) {
   logger_init();
+
+  auto start_time = std::chrono::system_clock::now();
 
   int verbosity;
   std::string ostree_commit;
@@ -137,6 +140,10 @@ int main(int argc, char **argv) {
     LOG_FATAL << e.what();
     return EXIT_FAILURE;
   }
+
+  auto end_time = std::chrono::system_clock::now();
+  std::chrono::duration<double> diff_time = end_time - start_time;
+  LOG_INFO << "Total runtime: " << diff_time.count() << " seconds.";
 
   return EXIT_SUCCESS;
 }

--- a/src/sota_tools/ostree_object.cc
+++ b/src/sota_tools/ostree_object.cc
@@ -24,7 +24,7 @@ OSTreeObject::OSTreeObject(const OSTreeRepo &repo, const std::string &object_nam
       curl_handle_(nullptr),
       fd_(nullptr) {
   if (!boost::filesystem::is_regular_file(file_path_)) {
-    throw std::runtime_error(file_path_.native() + " is not a valid OSTree repo.");
+    throw std::runtime_error(file_path_.native() + " is not a valid OSTree object.");
   }
 }
 

--- a/src/sota_tools/ostree_object.h
+++ b/src/sota_tools/ostree_object.h
@@ -50,6 +50,8 @@ class OSTreeObject {
   /* Process a completed curl transaction (presence check or upload). */
   void CurlDone(CURLM* curl_multi_handle, RequestPool& pool);
 
+  uintmax_t GetSize() { return boost::filesystem::file_size(file_path_); }
+
   PresenceOnServer is_on_server() const { return is_on_server_; }
   CurrentOp operation() const { return current_operation_; }
   bool children_ready() { return children_.empty(); }

--- a/src/sota_tools/request_pool.cc
+++ b/src/sota_tools/request_pool.cc
@@ -56,7 +56,8 @@ void RequestPool::LoopLaunch() {
       cur = upload_queue_.front();
       upload_queue_.pop_front();
       cur->Upload(server_, multi_, mode_);
-      total_requests_made_++;
+      put_requests_made_++;
+      total_object_size_ += cur->GetSize();
       if (mode_ == RunMode::kDryRun || mode_ == RunMode::kWalkTree) {
         // Don't send an actual upload message, just skip to the part where we
         // acknowledge that the object has been uploaded.
@@ -66,7 +67,7 @@ void RequestPool::LoopLaunch() {
       cur = query_queue_.front();
       query_queue_.pop_front();
       cur->MakeTestRequest(server_, multi_);
-      total_requests_made_++;
+      head_requests_made_++;
     }
 
     running_requests_++;

--- a/src/sota_tools/request_pool.h
+++ b/src/sota_tools/request_pool.h
@@ -33,7 +33,9 @@ class RequestPool {
    * The number of HEAD + PUT requests that have been sent to curl. This
    * includes requests that eventually returned 500 and get retried.
    */
-  int total_requests_made() { return total_requests_made_; }
+  int put_requests_made() { return put_requests_made_; }
+  int head_requests_made() { return head_requests_made_; }
+  uintmax_t total_object_size() { return total_object_size_; }
 
  private:
   void LoopLaunch();  // launches multiple requests from the queues
@@ -41,7 +43,9 @@ class RequestPool {
 
   RateController rate_controller_;
   int running_requests_;
-  int total_requests_made_{0};
+  int head_requests_made_{0};
+  int put_requests_made_{0};
+  uintmax_t total_object_size_{0};
   TreehubServer& server_;
   CURLM* multi_;
   std::list<OSTreeObject::ptr> query_queue_;


### PR DESCRIPTION
Now prints out runtime, total number of HEAD and PUT requests, and total amount of data uploaded.

We can't improve it if we can't measure it. :)