### PR TITLE
Fix/ota 4814/secondary unknown msg support

### DIFF
--- a/src/aktualizr_secondary/msg_dispatcher.cc
+++ b/src/aktualizr_secondary/msg_dispatcher.cc
@@ -10,15 +10,15 @@ void MsgDispatcher::registerHandler(AKIpUptaneMes_PR msg_id, Handler handler) {
 }
 
 MsgDispatcher::HandleStatusCode MsgDispatcher::handleMsg(const Asn1Message::Ptr& in_msg, Asn1Message::Ptr& out_msg) {
-  LOG_INFO << "Got a request message from Primary: " << in_msg->toStr();
+  LOG_TRACE << "Got a request message from Primary: " << in_msg->toStr();
 
   auto find_res_it = handler_map_.find(in_msg->present());
   if (find_res_it == handler_map_.end()) {
     return MsgDispatcher::HandleStatusCode::kUnkownMsg;
   }
-  LOG_INFO << "Found a handler for the request message, processing it...";
+  LOG_TRACE << "Found a handler for the request message, processing it...";
   auto handle_status_code = find_res_it->second(*in_msg, *out_msg);
-  LOG_INFO << "Got a response message from a handler: " << out_msg->toStr();
+  LOG_TRACE << "Got a response message from a handler: " << out_msg->toStr();
 
   return handle_status_code;
 }

--- a/src/aktualizr_secondary/secondary_tcp_server.cc
+++ b/src/aktualizr_secondary/secondary_tcp_server.cc
@@ -143,6 +143,7 @@ bool SecondaryTcpServer::HandleOneConnection(int socket) {
       case MsgDispatcher::HandleStatusCode::kUnkownMsg:
       default: {
         // TODO: consider sending NOT_SUPPORTED/Unknown message and closing connection socket
+        keep_running_current_session = false;
         LOG_INFO << "Unknown message received from Primary!";
       }
     }  // switch


### PR DESCRIPTION
close a connection if an unsupported/unknown message is received otherwise a client(IpUptaneSecondary) get stuck at recv() in Asn1Rpc().
As a matter of fact, this issue was introduced by this commit https://github.com/advancedtelematic/aktualizr/commit/3c1b3c868fe1b13f782336fb27adcb7337935e54 and the given fix makes the secondary behaves exactly as it did before the commit was merged.