### PR TITLE
Refactor/ota 4814/restore send firmware

### DIFF
--- a/src/aktualizr_secondary/secondary_rpc_test.cc
+++ b/src/aktualizr_secondary/secondary_rpc_test.cc
@@ -315,13 +315,23 @@ class SecondaryRpcTest : public ::testing::Test, public ::testing::WithParamInte
   data::ResultCode::Numeric sendAndInstallBinaryImage() {
     Json::Value target_json;
     target_json["custom"]["targetFormat"] = "BINARY";
-    return ip_secondary_->install(Uptane::Target(image_file_.path(), target_json));
+    Uptane::Target target = Uptane::Target(image_file_.path(), target_json);
+    data::ResultCode::Numeric result = ip_secondary_->sendFirmware(target);
+    if (result != data::ResultCode::Numeric::kOk) {
+      return result;
+    }
+    return ip_secondary_->install(target);
   }
 
   data::ResultCode::Numeric installOstreeRev() {
     Json::Value target_json;
     target_json["custom"]["targetFormat"] = "OSTREE";
-    return ip_secondary_->install(Uptane::Target("OSTREE", target_json));
+    Uptane::Target target = Uptane::Target("OSTREE", target_json);
+    data::ResultCode::Numeric result = ip_secondary_->sendFirmware(target);
+    if (result != data::ResultCode::Numeric::kOk) {
+      return result;
+    }
+    return ip_secondary_->install(target);
   }
 
  protected:
@@ -393,7 +403,9 @@ TEST(SecondaryTcpServer, TestIpSecondaryIfSecondaryIsNotRunning) {
   EXPECT_FALSE(ip_secondary->putMetadata(meta_pack));
   Json::Value target_json;
   target_json["custom"]["targetFormat"] = "BINARY";
-  EXPECT_NE(ip_secondary->install(Uptane::Target(target_file.path(), target_json)), data::ResultCode::Numeric::kOk);
+  Uptane::Target target = Uptane::Target(target_file.path(), target_json);
+  EXPECT_NE(ip_secondary->sendFirmware(target), data::ResultCode::Numeric::kOk);
+  EXPECT_NE(ip_secondary->install(target), data::ResultCode::Numeric::kOk);
 }
 
 class SecondaryRpcTestNegative : public ::testing::Test, public MsgHandler {

--- a/src/libaktualizr-isotp/isotpsecondary.cc
+++ b/src/libaktualizr-isotp/isotpsecondary.cc
@@ -140,6 +140,11 @@ bool IsoTpSecondary::putMetadata(const RawMetaPack& meta_pack) {
   return conn.Send(out);
 }
 
+data::ResultCode::Numeric IsoTpSecondary::sendFirmware(const Target& target) {
+  (void)target;
+  return data::ResultCode::Numeric::kOk;
+}
+
 data::ResultCode::Numeric IsoTpSecondary::install(const Target& target) {
   auto result = data::ResultCode::Numeric::kOk;
 

--- a/src/libaktualizr-isotp/isotpsecondary.h
+++ b/src/libaktualizr-isotp/isotpsecondary.h
@@ -17,6 +17,7 @@ class IsoTpSecondary : public SecondaryInterface {
   bool putMetadata(const RawMetaPack& meta_pack) override;
   int getRootVersion(bool director) const override;
   bool putRoot(const std::string& root, bool director) override;
+  data::ResultCode::Numeric sendFirmware(const Target& target) override;
   data::ResultCode::Numeric install(const Target& target) override;
   Uptane::Manifest getManifest() const override;
 

--- a/src/libaktualizr-posix/ipuptanesecondary.cc
+++ b/src/libaktualizr-posix/ipuptanesecondary.cc
@@ -167,6 +167,11 @@ bool IpUptaneSecondary::ping() const {
   return resp->present() == AKIpUptaneMes_PR_getInfoResp;
 }
 
+data::ResultCode::Numeric IpUptaneSecondary::sendFirmware(const Uptane::Target& target) {
+  (void)target;
+  return data::ResultCode::Numeric::kOk;
+}
+
 data::ResultCode::Numeric IpUptaneSecondary::install(const Uptane::Target& target) {
   std::lock_guard<std::mutex> l(install_mutex);
   auto install_result = install_v2(target);

--- a/src/libaktualizr-posix/ipuptanesecondary.h
+++ b/src/libaktualizr-posix/ipuptanesecondary.h
@@ -36,6 +36,7 @@ class IpUptaneSecondary : public SecondaryInterface {
   bool putRoot(const std::string& /* root */, bool /* director */) override { return true; }
   Manifest getManifest() const override;
   bool ping() const override;
+  data::ResultCode::Numeric sendFirmware(const Uptane::Target& target) override;
   data::ResultCode::Numeric install(const Uptane::Target& target) override;
 
  private:

--- a/src/libaktualizr-posix/ipuptanesecondary.h
+++ b/src/libaktualizr-posix/ipuptanesecondary.h
@@ -41,11 +41,11 @@ class IpUptaneSecondary : public SecondaryInterface {
 
  private:
   const std::pair<std::string, uint16_t>& getAddr() const { return addr_; }
+  data::ResultCode::Numeric sendFirmware_v1(const Uptane::Target& target);
+  data::ResultCode::Numeric sendFirmware_v2(const Uptane::Target& target);
   data::ResultCode::Numeric install_v1(const Uptane::Target& target);
-  bool sendFirmware(const std::string& data);
-  data::ResultCode::Numeric invokeInstallOnSecondary(const Uptane::Target& target);
-
   data::ResultCode::Numeric install_v2(const Uptane::Target& target);
+  data::ResultCode::Numeric invokeInstallOnSecondary(const Uptane::Target& target);
   data::ResultCode::Numeric downloadOstreeRev(const Uptane::Target& target);
   data::ResultCode::Numeric uploadFirmware(const Uptane::Target& target);
   data::ResultCode::Numeric uploadFirmwareData(const uint8_t* data, size_t size);

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -1292,7 +1292,11 @@ std::future<data::ResultCode::Numeric> SotaUptaneClient::sendFirmwareAsync(Uptan
     sendEvent<event::InstallStarted>(secondary.getSerial());
     report_queue->enqueue(std_::make_unique<EcuInstallationStartedReport>(secondary.getSerial(), correlation_id));
 
-    data::ResultCode::Numeric result = secondary.install(target);
+    data::ResultCode::Numeric result = secondary.sendFirmware(target);
+
+    if (result == data::ResultCode::Numeric::kOk) {
+      result = secondary.install(target);
+    }
 
     if (result == data::ResultCode::Numeric::kNeedCompletion) {
       report_queue->enqueue(std_::make_unique<EcuInstallationAppliedReport>(secondary.getSerial(), correlation_id));

--- a/src/libaktualizr/uptane/secondaryinterface.h
+++ b/src/libaktualizr/uptane/secondaryinterface.h
@@ -33,6 +33,7 @@ class SecondaryInterface {
   virtual int32_t getRootVersion(bool director) const = 0;
   virtual bool putRoot(const std::string& root, bool director) = 0;
 
+  virtual data::ResultCode::Numeric sendFirmware(const Target& target) = 0;
   virtual data::ResultCode::Numeric install(const Target& target) = 0;
 
   virtual ~SecondaryInterface() = default;

--- a/src/libaktualizr/uptane/uptane_test.cc
+++ b/src/libaktualizr/uptane/uptane_test.cc
@@ -548,6 +548,9 @@ class SecondaryInterfaceMock : public Uptane::SecondaryInterface {
   int32_t getRootVersion(bool director) const override { return getRootVersionMock(director); }
 
   bool putRoot(const std::string &, bool) override { return true; }
+  virtual data::ResultCode::Numeric sendFirmware(const Uptane::Target &) override {
+    return data::ResultCode::Numeric::kOk;
+  }
   virtual data::ResultCode::Numeric install(const Uptane::Target &) override { return data::ResultCode::Numeric::kOk; }
 
   PublicKey public_key_;

--- a/src/virtual_secondary/managedsecondary.cc
+++ b/src/virtual_secondary/managedsecondary.cc
@@ -142,7 +142,12 @@ bool ManagedSecondary::putRoot(const std::string &root, const bool director) {
   return true;
 }
 
-data::ResultCode::Numeric ManagedSecondary::install(const Uptane::Target &target_name) {
+data::ResultCode::Numeric ManagedSecondary::sendFirmware(const Uptane::Target &target) {
+  (void)target;
+  return data::ResultCode::Numeric::kOk;
+}
+
+data::ResultCode::Numeric ManagedSecondary::install(const Uptane::Target &target) {
   if (fiu_fail((std::string("secondary_install_") + getSerial().ToString()).c_str()) != 0) {
     // consider changing this approach of the fault injection, since the current approach impacts the non-test code flow
     // here as well as it doesn't test the installation failure on secondary from an end-to-end perspective as it
@@ -153,7 +158,7 @@ data::ResultCode::Numeric ManagedSecondary::install(const Uptane::Target &target
     return data::ResultCode::Numeric::kInstallFailed;
   }
 
-  image_reader(target_name)->writeToFile(sconfig.firmware_path);
+  image_reader(target)->writeToFile(sconfig.firmware_path);
   Utils::writeFile(sconfig.target_name_path, expected_target_name);
   sync();
   return data::ResultCode::Numeric::kOk;

--- a/src/virtual_secondary/managedsecondary.cc
+++ b/src/virtual_secondary/managedsecondary.cc
@@ -160,7 +160,6 @@ data::ResultCode::Numeric ManagedSecondary::install(const Uptane::Target &target
 
   image_reader(target)->writeToFile(sconfig.firmware_path);
   Utils::writeFile(sconfig.target_name_path, expected_target_name);
-  sync();
   return data::ResultCode::Numeric::kOk;
 }
 

--- a/src/virtual_secondary/managedsecondary.h
+++ b/src/virtual_secondary/managedsecondary.h
@@ -72,7 +72,6 @@ class ManagedSecondary : public Uptane::SecondaryInterface {
   std::mutex install_mutex;
   ImageReaderProvider image_reader;
 
-  virtual bool storeFirmware(const std::string& target_name, const std::string& content) = 0;
   virtual bool getFirmwareInfo(Uptane::InstalledImageInfo& firmware_info) const = 0;
 
  private:

--- a/src/virtual_secondary/managedsecondary.h
+++ b/src/virtual_secondary/managedsecondary.h
@@ -57,7 +57,8 @@ class ManagedSecondary : public Uptane::SecondaryInterface {
   int getRootVersion(bool director) const override;
   bool putRoot(const std::string& root, bool director) override;
 
-  data::ResultCode::Numeric install(const Uptane::Target& target_name) override;
+  data::ResultCode::Numeric sendFirmware(const Uptane::Target& target) override;
+  data::ResultCode::Numeric install(const Uptane::Target& target) override;
 
   Uptane::Manifest getManifest() const override;
 

--- a/src/virtual_secondary/partialverificationsecondary.cc
+++ b/src/virtual_secondary/partialverificationsecondary.cc
@@ -76,8 +76,13 @@ bool PartialVerificationSecondary::putRoot(const std::string &root, bool directo
   return false;
 }
 
-data::ResultCode::Numeric PartialVerificationSecondary::install(const Uptane::Target &target_name) {
-  (void)target_name;
+data::ResultCode::Numeric PartialVerificationSecondary::sendFirmware(const Uptane::Target &target) {
+  (void)target;
+  throw NotImplementedException();
+}
+
+data::ResultCode::Numeric PartialVerificationSecondary::install(const Uptane::Target &target) {
+  (void)target;
   throw NotImplementedException();
 }
 

--- a/src/virtual_secondary/partialverificationsecondary.h
+++ b/src/virtual_secondary/partialverificationsecondary.h
@@ -44,7 +44,8 @@ class PartialVerificationSecondary : public SecondaryInterface {
   int getRootVersion(bool director) const override;
   bool putRoot(const std::string& root, bool director) override;
 
-  data::ResultCode::Numeric install(const Uptane::Target& target_name) override;
+  data::ResultCode::Numeric sendFirmware(const Uptane::Target& target) override;
+  data::ResultCode::Numeric install(const Uptane::Target& target) override;
   Uptane::Manifest getManifest() const override;
   bool ping() const override { return true; }
 

--- a/src/virtual_secondary/virtualsecondary.cc
+++ b/src/virtual_secondary/virtualsecondary.cc
@@ -68,27 +68,6 @@ void VirtualSecondaryConfig::dump(const boost::filesystem::path& file_full_path)
 VirtualSecondary::VirtualSecondary(Primary::VirtualSecondaryConfig sconfig_in, ImageReaderProvider image_reader_in)
     : ManagedSecondary(std::move(sconfig_in), std::move(image_reader_in)) {}
 
-bool VirtualSecondary::storeFirmware(const std::string& target_name, const std::string& content) {
-  if (fiu_fail((std::string("secondary_install_") + getSerial().ToString()).c_str()) != 0) {
-    // consider changing this approach of the fault injection, since the current approach impacts the non-test code flow
-    // here as well as it doesn't test the installation failure on secondary from an end-to-end perspective as it
-    // injects an error on the middle of the control flow that would have happened if an installation error had happened
-    // in case of the virtual or the ip-secondary or any other secondary, e.g. add a mock secondary that returns an
-    // error to sendFirmware/install request we might consider passing the installation description message from
-    // Secondary, not just bool and/or data::ResultCode::Numeric
-    return false;
-  }
-
-  // TODO: it does not make much sense to read, pass via a function parameter to Virtual secondary
-  // and store the file that has been already downloaded by Primary
-  // Primary should apply ECU (Primary, virtual, Secondary) specific verification, download and installation logic in
-  // the first place
-  Utils::writeFile(sconfig.target_name_path, target_name);
-  Utils::writeFile(sconfig.firmware_path, content);
-  sync();
-  return true;
-}
-
 bool VirtualSecondary::getFirmwareInfo(Uptane::InstalledImageInfo& firmware_info) const {
   std::string content;
 

--- a/src/virtual_secondary/virtualsecondary.h
+++ b/src/virtual_secondary/virtualsecondary.h
@@ -31,7 +31,6 @@ class VirtualSecondary : public ManagedSecondary {
   bool ping() const override { return true; }
 
  private:
-  bool storeFirmware(const std::string& target_name, const std::string& content) override;
   bool getFirmwareInfo(Uptane::InstalledImageInfo& firmware_info) const override;
 };
 


### PR DESCRIPTION
Note that this is based on https://github.com/advancedtelematic/aktualizr/pull/1642. We are treating that as a feature branch for the moment and this should be merged into that. I originally tried to do this by skipping the original removal of sendFirmware and rebasing, but it was too much of a mess. This was much easier and ultimately rather straightforward.