### PR TITLE
Fix installation of 0-byte files.

### DIFF
--- a/src/libaktualizr/package_manager/packagemanagerinterface.cc
+++ b/src/libaktualizr/package_manager/packagemanagerinterface.cc
@@ -92,11 +92,12 @@ bool PackageManagerInterface::fetchTarget(const Uptane::Target& target, Uptane::
       LOG_INFO << "Image already downloaded; skipping download";
       return true;
     }
+    std::unique_ptr<DownloadMetaStruct> ds = std_::make_unique<DownloadMetaStruct>(target, progress_cb, token);
     if (target.length() == 0) {
-      LOG_WARNING << "Skipping download of target with length 0";
+      LOG_INFO << "Skipping download of target with length 0";
+      ds->fhandle = storage_->allocateTargetFile(target);
       return true;
     }
-    std::unique_ptr<DownloadMetaStruct> ds = std_::make_unique<DownloadMetaStruct>(target, progress_cb, token);
     if (exists == TargetStatus::kIncomplete) {
       LOG_INFO << "Continuing incomplete download of file " << target.filename();
       auto target_check = storage_->checkTargetFile(target);

--- a/tests/httpfake.h
+++ b/tests/httpfake.h
@@ -136,7 +136,7 @@ class HttpFake : public HttpInterface {
     auto resp_future = resp_promise.get_future();
     std::thread(
         [path, write_cb, progress_cb, userp, url](std::promise<HttpResponse> promise) {
-          std::string content = Utils::readFile(path.string());
+          const std::string content = Utils::readFile(path.string());
           for (unsigned int i = 0; i < content.size(); ++i) {
             write_cb(const_cast<char *>(&content[i]), 1, 1, userp);
             progress_cb(userp, 0, 0, 0, 0);


### PR DESCRIPTION
We now create the file and leave it empty during download, which sort of makes sense, and then we can successfully "install" it. Previously this failed because verifyTarget failed.