### PR TITLE
Refuse to download OSTree targets with the fake/binary package manager.

### DIFF
--- a/src/libaktualizr/package_manager/packagemanagerfake.cc
+++ b/src/libaktualizr/package_manager/packagemanagerfake.cc
@@ -110,5 +110,10 @@ bool PackageManagerFake::fetchTarget(const Uptane::Target& target, Uptane::Fetch
     return false;
   }
 
+  if (target.IsOstree()) {
+    LOG_ERROR << "Cannot download OSTree target " << target.filename() << " with the fake package manager!";
+    return false;
+  }
+
   return PackageManagerInterface::fetchTarget(target, fetcher, keys, progress_cb, token);
 }

--- a/src/libaktualizr/uptane/tuf.cc
+++ b/src/libaktualizr/uptane/tuf.cc
@@ -127,6 +127,7 @@ Target::Target(std::string filename, const Json::Value &content) : filename_(std
   std::sort(hashes_.begin(), hashes_.end(), [](const Hash &l, const Hash &r) { return l.type() < r.type(); });
 }
 
+// Internal use only.
 Target::Target(std::string filename, EcuMap ecus, std::vector<Hash> hashes, uint64_t length, std::string correlation_id)
     : filename_(std::move(filename)),
       ecus_(std::move(ecus)),
@@ -135,6 +136,7 @@ Target::Target(std::string filename, EcuMap ecus, std::vector<Hash> hashes, uint
       correlation_id_(std::move(correlation_id)) {
   // sort hashes so that higher priority hash algorithm goes first
   std::sort(hashes_.begin(), hashes_.end(), [](const Hash &l, const Hash &r) { return l.type() < r.type(); });
+  type_ = "UNKNOWN";
 }
 
 Target Target::Unknown() {

--- a/src/libaktualizr/uptane/tuf.h
+++ b/src/libaktualizr/uptane/tuf.h
@@ -211,8 +211,8 @@ class Target {
  public:
   // From Uptane metadata
   Target(std::string filename, const Json::Value &content);
-  // Internal, does not have type. Only used for reading installation_versions
-  // list and by various tests.
+  // Internal use only. Only used for reading installed_versions list and by
+  // various tests.
   Target(std::string filename, EcuMap ecus, std::vector<Hash> hashes, uint64_t length, std::string correlation_id = "");
 
   static Target Unknown();


### PR DESCRIPTION
Previously the download would succeed due to the empty length but the installation would fail. Better to fail as early as possible.