### PR TITLE
Docs/ota 4466 garage sign usage

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/nav.adoc
+++ b/docs/ota-client-guide/modules/ROOT/nav.adoc
@@ -96,6 +96,7 @@ ifndef::env-github[:pageroot:]
 * xref:{pageroot}provisioning-methods-and-credentialszip.adoc[Contents of the credentials file]
 * xref:{pageroot}useful-bitbake-commands.adoc[Bitbake commands]
 * xref:{pageroot}ostree-usage.adoc[OSTree commands]
+* xref:{pageroot}garage-sign.adoc[garage-sign]
 // xref:{pageroot}ecu_events.adoc[ECU events]
 * xref:{pageroot}meta-updater-usage.adoc[Advanced usage of meta-updater]
 

--- a/docs/ota-client-guide/modules/ROOT/pages/garage-sign.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/garage-sign.adoc
@@ -167,11 +167,11 @@ To add a software version, perform the following steps:
 ----
 garage-sign targets add \
   --repo <reponame> \
-  --format binary \ <1>
+  --format <target-format> \ <1>
   --length <length-of-package> \ <2>
   --name <packagename> \ <3>
   --version <version> \ <4>
-  --sha256 $(sha256sum "${file}" |cut -d' ' -f-1) \ <5>
+  --sha256 <sha256sum> \ <5>
   --hardwareids <hardware-id1> \ <6>
   --url <url-of-software> <7>
 ----
@@ -210,13 +210,13 @@ garage-sign targets pull \
   --repo <reponame> <1>
 ----
 
-. Next, upload the large binary file you want with the command below. This uploads the binary file directly to https://tuf-cli-releases.ota.here.com/index.html[garage-sign on the s3 reposerver].
+. Next, upload the large binary file you want with the command below.
 +
 [source,bash]
 ----
 garage-sign targets upload \
   --repo <reponame> \
-  --input bigfile.bin </path/to/bigfile.bin>\ <1>
+  --input </path/to/bigfile.bin> \ <1>
   --name <name-of-target> \
   --version <target-version> <2>
 ----
@@ -224,7 +224,7 @@ garage-sign targets upload \
 <1> The path to the file you want to upload is specified here.
 <2> The `name` and `version` of your `targets.json` file are specified here. These can be seen in the `targets.json` file under the `custom` field as shown in the example xref:customise-targets-metadata.adoc#_anatomy_of_targets_json_metadata[here].
 
-. After the upload is successful, add the file to your `targets.json`.
+. After the upload is successful, add metadata about the file to your `targets.json`.
 +
 [source,bash]
 ----

--- a/docs/ota-client-guide/modules/ROOT/pages/garage-sign.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/garage-sign.adoc
@@ -22,7 +22,7 @@ In a production environment, we recommend that you keep the keys for signing sof
 
 * *Local repository*
 +
-A repository is a location for storing software packages. A local repository is a server that exists on your local machine such as your computer. When using the `garage-sign` tool, it is important to create a local repository on your machine that contains your credentials from OTA Connect, and your keys for signing metadata. With your keys existing locally on your machine, any changes you make to them will not directly affect your devices on OTA Connect. It also ensures the security of your keys in production as mentioned
+A repository is a location for storing software packages. A local repository is a server that exists on your local machine such as your computer. When using the `garage-sign` tool, it is important to create a local repository on your machine that contains your credentials from OTA Connect, and your keys for signing metadata. With your keys existing locally on your machine, any changes you make to them will not directly affect your devices on OTA Connect. It also ensures the security of your keys during production.
 
 ****
 
@@ -58,6 +58,7 @@ garage-sign init \
 +
 <1> The name of your image repository which is to be initialized by the `init` command is provided here.
 <2> Here you provide the path of your `credentials.zip` file downloaded from your account on the https://connect.ota.here.com[OTA Connect Portal].
+
 . Ensure you have the latest `targets.json` file by pulling it from OTA Connect.
 +
 [source, bash]
@@ -88,7 +89,6 @@ tuf/<reponame>
 <4> The `targets.json` metadata file
 
 
-
 == Use cases of `garage-sign` with OTA Connect
 
 In most use cases, more than one `garage-sign` command is used to perform a specific task. A few use cases will be discussed in this section, however the use of the `garage-sign` tool is not limited to these.
@@ -97,9 +97,9 @@ In most use cases, more than one `garage-sign` command is used to perform a spec
 
 You might generate new keys if you:
 
-* xref:rotating-signing-keys.adoc#_rotate_the_online_keys_with_your_new_offline_keys[want to rotate your online keys with your new offline keys]
-* believe your keys have been compromised
-* would like to revoke the current keys for signing metadata
+* xref:rotating-signing-keys.adoc#_rotate_the_online_keys_with_your_new_offline_keys[want to rotate your online keys with your new offline keys].
+* believe your keys have been compromised.
+* would like to revoke the current keys for signing metadata.
 
 ==== Workflow to generate new keys
 
@@ -121,12 +121,14 @@ garage-sign key generate \
 +
 <1> You can give any name to the keys you generate, which helps to easily identify between the new `root` and `targets` keys. Here, the keys generated are given the names `myroot` and `mytargets`.
 <2> The key type must be specified as either Ed25519 or RSA. In OTA Connect, an RSA key is used for signing uptane metadata.
+
 . Afterwards, pull the latest `targets.json` file from OTA Connect with the command `garage-sign targets pull`.
 +
 [source,bash]
 ----
 garage-sign targets pull --repo <reponame>
 ----
+
 . Next, use the command `garage-sign move-offline`. This command deletes the old `root` key from OTA Connect, downloads and signs the new `root` key with the newly generated keys, and pushes the new `root.json` file to OTA Connect.
 +
 [source,bash]
@@ -141,6 +143,7 @@ garage-sign move-offline \
 <1> This is an example of an alias given to the old `root` key. It gets saved with this name.
 <2> This is an example of the name given to your new `root` key which you previously generated using the command `garage-sign key generate`.
 <3> This is an example of the name given to your new `targets` key which you previously generated using the command `garage-sign key generate`.
+
 . As a final step, sign the new `targets.json` with your newly generated `targets` key and upload it to OTA Connect.
 +
 [source,bash]
@@ -149,23 +152,16 @@ garage-sign targets sign --repo <reponame> --key-name mytargets
 garage-sign targets push --repo <reponame>
 ----
 
-
 Please refer to xref:rotating-signing-keys.adoc#_rotate_the_keys_for_root_and_targets_metadata[rotating the keys for `root` and `targets` metadata] for additional information on generating new keys.
-
 
 === Add a new software version
 
 `garage-sign` can also be used to add software packages to your repository with the command `garage-sign targets add`. The packages are downloaded by aktualizr, however `garage-sign` doesn't upload the software file. The `garage-sign targets add` commmand puts new metadata in place, hence you need to tell aktualizr where the software package can be found. This is done by uploading the file somewhere else and providing `garage-sign` with the URL of where it's available.
 
-//The software package must first be uploaded via a URL and this URL is given to the command `garage-sign targets add` which tells aktualizr where to download the file from. Usually when aktualizr tries to download a file, it looks for it at a specific location in the repository based on its name.
-
-// When aktualizr tries to download a file, it first looks for it at a specific place in the repo based on its name. But when you use garage-sign targets add, you're just putting new metadata in place--you still need to tell aktualizr where it can find the file that the metadata is talking about. Since garage-sign doesn't upload the file for you, you need to upload it somewhere yourself, and provide garage-sign with a URL where it's available so that aktualizr can go get it.
-
-
 To add a software version, perform the following steps:
 
 . First upload the software package you wish to add via a URL.
-. Next, add the software package using the command `garage-sign targets add`
+. Next, give the URL where the software was uploaded to the command `garage-sign targets add`. This tells aktualizr where it should download the software file.
 +
 [source,bash]
 ----
@@ -196,82 +192,12 @@ garage-sign targets sign --repo <reponame> --key-name mytargets
 garage-sign targets push --repo <reponame>
 ----
 
-////
-An example of uploading a new software package is shown below.
-
-[source,bash]
-----
-!#/bin/bash
-set -ex
-file=$1
-s3_bucket=$2
-packagename=$3
-version=$4
-hwid=$5
-keyname=$6
-url="http://${s3_bucket}.s3.amazonaws.com/${file}" <1>
-aws s3 cp "${file}" "s3://${s3_bucket}/${file}"
-garage-sign targets add \
-  --repo ${reponame} \
-  --format binary \ <2>
-  --length $(wc -c <"${file}") \ <3>
-  --name ${packagename} \
-  --version ${version} \ <4>
-  --sha256 $(sha256sum "${file}" |cut -d' ' -f-1) \ <5>
-  --hardwareids ${hwid} \
-  --url ${url} <6>
-garage-sign targets sign \
-  --repo ${reponame} \
-  --key-name ${keyname}
-garage-sign targets push \
-  --repo ${reponame}
-----
-
-<1> The URL of where the software package is uploaded.
-<2> You must specify the format of the target image to be added--either as an ostree or binary image. In OTA Connect, the `garage-sign` tool is often used to upload `binary` images.
-<3> The length of the image to be added must be specified in bytes.
-<4> You must also specify the version number of the target image.
-<5> The sha256 hash of the software image is specified here.
-<6> The URL of the software package is specified here for `garage-sign` so that aktualizr will know where to find the software file to download.
-////
-
 === Define metadata expiry
 
 You can also define an expiry date for your metadata using `garage-sign` on the command line. You can do this in two ways--either specifying a fixed date and time or a specific period of time. However, only one type of expiry argument must be used to define the metadata expiry date.
 
-
 include::ota-client::page$metadata-expiry.adoc[tags=metadata-expiry]
-////
-==== Define a fixed date and time for metadata expiry
 
-Use the following format of `garage-sign` to define a specific time in UTC for metadata to expire:
-
-[source,bash]
-----
-garage-sign targets sign \
-  --expires 2018-01-01T00:01:00Z \ <1>
-  --repo <reponame> \
-  --key-name mytargets
-----
-
-<1> This is an example of specifying a date and time of expiry as an instance in UTC. After this fixed date and time, metadata will no longer be valid.
-
-==== Define a period for metadata expiry
-
-Use the following format of `garage-sign` to specify a period for metadata to be valid:
-
-[source,bash]
-----
-garage-sign targets sign \
-  --expire-after 1Y3M5D \ <1>
-  --repo <reponame> \
-  --key-name mytargets
-----
-
-<1> This is an example of specifying a period for the expiry of metadata. The expiration period is defined in the order of years, months and days, (each optional but in this specified order).
-
-For additional information, please refer to xref:metadata-expiry.adoc[managing metadata expiry dates] in our guide.
-////
 === Upload a large binary file
 
 The `garage-sign` tool can also be used to upload large binary files up to 3 GB. To upload a large binary file to OTA Connect, perform the following steps:

--- a/docs/ota-client-guide/modules/ROOT/pages/garage-sign.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/garage-sign.adoc
@@ -1,0 +1,330 @@
+= garage-sign
+ifdef::env-github[]
+
+[NOTE]
+====
+We recommend that you link:https://docs.ota.here.com/ota-client/latest/{docname}.html[view this article in our documentation portal]. Not all of our articles render correctly in GitHub.
+====
+endif::[]
+
+xref:https://github.com/advancedtelematic/ota-tuf/tree/master/cli[garage-sign] is a tool for managing your OTA Connect software repository and securely signing software versions. It allows you to directly change, sign, and upload your xref:uptane.adoc[Uptane] metadata.
+
+.Why use `garage-sign`
+****
+`garage-sign` is useful in OTA Connect for managing the keys for signing your software. If your software image is not an OSTree image, you would need `garage-sign` to upload your xref:uptane.adoc[Uptane] metadata.
+
+Before using `garage-sign`, it is important to be familiar with the following two concepts.
+
+* *Offline keys*
++
+In a production environment, we recommend that you keep the keys for signing software versions offline. Therefore, the OTA Connect server will no longer sign software for you, instead, they will be signed locally by your machine. This maintains the security of the software because if someone gained access to your OTA Connect account, they will be able to send malicious software to your devices. However, if your keys are offline, your devices will not recognize the software as it will not have the correct credentials. This is where `garage-sign` becomes useful. For non-OSTree images, the `garage-sign` tool is used to manage and rotate your keys offline as well as sign your software.
+
+
+* *Local repository*
++
+A repository is a location for storing software packages. A local repository is a server that exists on your local machine such as your computer. When using the `garage-sign` tool, it is important to create a local repository on your machine that contains your credentials from OTA Connect, and your keys for signing metadata. With your keys existing locally on your machine, any changes you make to them will not directly affect your devices on OTA Connect. It also ensures the security of your keys in production as mentioned
+
+****
+
+
+== Prerequisites of `garage-sign`
+
+. Download the latest version of the `garage-sign` tool from link:https://tuf-cli-releases.ota.here.com/index.html[here].
+. Unzip the file you have downloaded to a location on your computer.
+. Change the directory of your terminal on the command line to that location.
+. Afterwards, open the `garage-sign` folder in your terminal. You can also print the help command to view the list of all possible commands with this tool.
++
+[source,bash]
+----
+cd garage-sign/
+bin/garage-sign --help
+----
+
+For more information, please refer to the link:https://github.com/advancedtelematic/ota-tuf/tree/master/cli[`garage-sign` README file].
+
+
+== Use of `garage-sign` with OTA Connect
+
+To use the `garage-sign` tool with OTA Connect, you need to perform the following steps:
+
+. Initialize a new image repository locally on your computer that pulls your `credentials.zip` from OTA Connect.
++
+[source, bash]
+----
+garage-sign init \
+  --repo <reponame> \ <1>
+  --credentials </path/to/credentials.zip> <2>
+----
++
+<1> The name of your image repository which is to be initialized by the `init` command is provided here.
+<2> Here you provide the path of your `credentials.zip` file downloaded from your account on the https://connect.ota.here.com[OTA Connect Portal].
+. Ensure you have the latest `targets.json` file by pulling it from OTA Connect.
++
+[source, bash]
+----
+garage-sign targets pull --repo <reponame>
+----
+
+The above commands create a local repository in a directory called `/tuf/<reponame>`. This directory will contain your `credentials.zip` file and has a tree structure as shown below:
+
+[source, bash]
+----
+tuf/<reponame>
+├── config.json
+├── credentials.zip
+├── keys
+│   ├── targets.pub <1>
+│   └── targets.sec <2>
+└── roles
+    ├── root.json   <3>
+    ├── targets.json.checksum
+    └── unsigned
+        └── targets.json <4>
+----
+
+<1> The public part of your `targets` key
+<2> The private part of your `targets` key
+<3> The `root.json` metadata file
+<4> The `targets.json` metadata file
+
+
+
+== Use cases of `garage-sign` with OTA Connect
+
+In most use cases, more than one `garage-sign` command is used to perform a specific task. A few use cases will be discussed in this section, however the use of the `garage-sign` tool is not limited to these.
+
+=== Generate new keys
+
+You might generate new keys if you:
+
+* xref:rotating-signing-keys.adoc#_rotate_the_online_keys_with_your_new_offline_keys[want to rotate your online keys with your new offline keys]
+* believe your keys have been compromised
+* would like to revoke the current keys for signing metadata
+
+==== Workflow to generate new keys
+
+When generating new keys for metadata, you perform the following steps:
+
+. First, generate the new `root` and `targets` keys by running the command `garage-sign key generate` twice.
++
+[source,bash]
+----
+garage-sign key generate \
+  --repo <reponame> \
+  --name myroot \ <1>
+  --type <ed25519|rsa> <2>
+garage-sign key generate \
+  --repo <reponame> \
+  --name mytargets \
+  --type <ed25519|rsa>
+----
++
+<1> You can give any name to the keys you generate, which helps to easily identify between the new `root` and `targets` keys. Here, the keys generated are given the names `myroot` and `mytargets`.
+<2> The key type must be specified as either Ed25519 or RSA. In OTA Connect, an RSA key is used for signing uptane metadata.
+. Afterwards, pull the latest `targets.json` file from OTA Connect with the command `garage-sign targets pull`.
++
+[source,bash]
+----
+garage-sign targets pull --repo <reponame>
+----
+. Next, use the command `garage-sign move-offline`. This command deletes the old `root` key from OTA Connect, downloads and signs the new `root` key with the newly generated keys, and pushes the new `root.json` file to OTA Connect.
++
+[source,bash]
+----
+garage-sign move-offline \
+  --repo <reponame> \
+  --old-root-alias originroot \ <1>
+  --new-root myroot \ <2>
+  --new-targets mytargets <3>
+----
++
+<1> This is an example of an alias given to the old `root` key. It gets saved with this name.
+<2> This is an example of the name given to your new `root` key which you previously generated using the command `garage-sign key generate`.
+<3> This is an example of the name given to your new `targets` key which you previously generated using the command `garage-sign key generate`.
+. As a final step, sign the new `targets.json` with your newly generated `targets` key and upload it to OTA Connect.
++
+[source,bash]
+----
+garage-sign targets sign --repo <reponame> --key-name mytargets
+garage-sign targets push --repo <reponame>
+----
+
+
+Please refer to xref:rotating-signing-keys.adoc#_rotate_the_keys_for_root_and_targets_metadata[rotating the keys for `root` and `targets` metadata] for additional information on generating new keys.
+
+
+=== Add a new software version
+
+`garage-sign` can also be used to add software packages to your repository with the command `garage-sign targets add`. The packages are downloaded by aktualizr, however `garage-sign` doesn't upload the software file. The `garage-sign targets add` commmand puts new metadata in place, hence you need to tell aktualizr where the software package can be found. This is done by uploading the file somewhere else and providing `garage-sign` with the URL of where it's available.
+
+//The software package must first be uploaded via a URL and this URL is given to the command `garage-sign targets add` which tells aktualizr where to download the file from. Usually when aktualizr tries to download a file, it looks for it at a specific location in the repository based on its name.
+
+// When aktualizr tries to download a file, it first looks for it at a specific place in the repo based on its name. But when you use garage-sign targets add, you're just putting new metadata in place--you still need to tell aktualizr where it can find the file that the metadata is talking about. Since garage-sign doesn't upload the file for you, you need to upload it somewhere yourself, and provide garage-sign with a URL where it's available so that aktualizr can go get it.
+
+
+To add a software version, perform the following steps:
+
+. First upload the software package you wish to add via a URL.
+. Next, add the software package using the command `garage-sign targets add`
++
+[source,bash]
+----
+garage-sign targets add \
+  --repo <reponame> \
+  --format binary \ <1>
+  --length <length-of-package> \ <2>
+  --name <packagename> \ <3>
+  --version <version> \ <4>
+  --sha256 $(sha256sum "${file}" |cut -d' ' -f-1) \ <5>
+  --hardwareids <hardware-id1> \ <6>
+  --url <url-of-software> <7>
+----
++
+<1> You must specify the format of the target image to be added--either as an ostree or binary image. In OTA Connect, the `garage-sign` tool is often used to upload `binary` images.
+<2> The length of the image to be added must be specified in bytes.
+<3> The name of the image you want to upload is specified here.
+<4> You must also specify the version number of the target image.
+<5> The sha256 hash of the software image is specified here.
+<6> This refers to the ids of hardware that your image file supports. An example can be seen in the `targets.json` file xref:customise-targets-metadata.adoc#_anatomy_of_targets_json_metadata[here] under the `custom` field.
+<7> The URL of the software package is specified here for `garage-sign` so that aktualizr will know where to find the software file to download.
+
+. Afterwards, sign your `targets.json`, which now contains your new software package, with your `targets` key and upload it to OTA Connect.
++
+[source,bash]
+----
+garage-sign targets sign --repo <reponame> --key-name mytargets
+garage-sign targets push --repo <reponame>
+----
+
+////
+An example of uploading a new software package is shown below.
+
+[source,bash]
+----
+!#/bin/bash
+set -ex
+file=$1
+s3_bucket=$2
+packagename=$3
+version=$4
+hwid=$5
+keyname=$6
+url="http://${s3_bucket}.s3.amazonaws.com/${file}" <1>
+aws s3 cp "${file}" "s3://${s3_bucket}/${file}"
+garage-sign targets add \
+  --repo ${reponame} \
+  --format binary \ <2>
+  --length $(wc -c <"${file}") \ <3>
+  --name ${packagename} \
+  --version ${version} \ <4>
+  --sha256 $(sha256sum "${file}" |cut -d' ' -f-1) \ <5>
+  --hardwareids ${hwid} \
+  --url ${url} <6>
+garage-sign targets sign \
+  --repo ${reponame} \
+  --key-name ${keyname}
+garage-sign targets push \
+  --repo ${reponame}
+----
+
+<1> The URL of where the software package is uploaded.
+<2> You must specify the format of the target image to be added--either as an ostree or binary image. In OTA Connect, the `garage-sign` tool is often used to upload `binary` images.
+<3> The length of the image to be added must be specified in bytes.
+<4> You must also specify the version number of the target image.
+<5> The sha256 hash of the software image is specified here.
+<6> The URL of the software package is specified here for `garage-sign` so that aktualizr will know where to find the software file to download.
+////
+
+=== Define metadata expiry
+
+You can also define an expiry date for your metadata using `garage-sign` on the command line. You can do this in two ways--either specifying a fixed date and time or a specific period of time. However, only one type of expiry argument must be used to define the metadata expiry date.
+
+
+include::ota-client::page$metadata-expiry.adoc[tags=metadata-expiry]
+////
+==== Define a fixed date and time for metadata expiry
+
+Use the following format of `garage-sign` to define a specific time in UTC for metadata to expire:
+
+[source,bash]
+----
+garage-sign targets sign \
+  --expires 2018-01-01T00:01:00Z \ <1>
+  --repo <reponame> \
+  --key-name mytargets
+----
+
+<1> This is an example of specifying a date and time of expiry as an instance in UTC. After this fixed date and time, metadata will no longer be valid.
+
+==== Define a period for metadata expiry
+
+Use the following format of `garage-sign` to specify a period for metadata to be valid:
+
+[source,bash]
+----
+garage-sign targets sign \
+  --expire-after 1Y3M5D \ <1>
+  --repo <reponame> \
+  --key-name mytargets
+----
+
+<1> This is an example of specifying a period for the expiry of metadata. The expiration period is defined in the order of years, months and days, (each optional but in this specified order).
+
+For additional information, please refer to xref:metadata-expiry.adoc[managing metadata expiry dates] in our guide.
+////
+=== Upload a large binary file
+
+The `garage-sign` tool can also be used to upload large binary files up to 3 GB. To upload a large binary file to OTA Connect, perform the following steps:
+
+. Ensure you have the latest version of the `targets.json` file from OTA Connect by pulling the latest version to your local repository.
++
+[source,bash]
+----
+garage-sign targets pull \
+  --repo <reponame> <1>
+----
+
+. Next, upload the large binary file you want with the command below. This uploads the binary file directly to https://tuf-cli-releases.ota.here.com/index.html[garage-sign on the s3 reposerver].
++
+[source,bash]
+----
+garage-sign targets upload \
+  --repo <reponame> \
+  --input bigfile.bin </path/to/bigfile.bin>\ <1>
+  --name <name-of-target> \
+  --version <target-version> <2>
+----
++
+<1> The path to the file you want to upload is specified here.
+<2> The `name` and `version` of your `targets.json` file are specified here. These can be seen in the `targets.json` file under the `custom` field as shown in the example xref:customise-targets-metadata.adoc#_anatomy_of_targets_json_metadata[here].
+
+. After the upload is successful, add the file to your `targets.json`.
++
+[source,bash]
+----
+garage-sign targets add-uploaded \
+  --repo <reponame> \
+  --input </path/to/bigfile.bin> \
+  --name <name-of-target> \
+  --version <target-version> \
+  --hardwareids <hardware-id1>,<hardware-id2> <1>
+----
++
+<1> This refers to the ids of hardware that your binary file supports. An example can be seen in the `targets.json` file xref:customise-targets-metadata.adoc#_anatomy_of_targets_json_metadata[here] under the `custom` field.
+
+. Sign the new `targets.json` file with your `targets` key.
++
+[source,bash]
+----
+garage-sign targets sign \
+  --repo <reponame> \
+  --key-name mytargets
+----
+
+. Finally, push the new `targets.json` file to OTA Connect.
++
+[source,bash]
+----
+garage-sign targets push \
+  --repo <reponame>
+----

--- a/docs/ota-client-guide/modules/ROOT/pages/metadata-expiry.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/metadata-expiry.adoc
@@ -35,8 +35,8 @@ include::partial$config-descriptions.adoc[tags=buildconfig-hint]
 |====================
 |Configuration  | Description
 |
-`GARAGE_TARGET_EXPIRES` 
-| 
+`GARAGE_TARGET_EXPIRES`
+|
 include::partial$config-descriptions.adoc[tags=metadata-expires]
 ----
 GARAGE_TARGET_EXPIRES = "2018-01-01T00:01:00Z"
@@ -44,7 +44,7 @@ GARAGE_TARGET_EXPIRES = "2018-01-01T00:01:00Z"
 
 |
 `GARAGE_TARGET_EXPIRE_AFTER`
-| 
+|
 include::partial$config-descriptions.adoc[tags=metadata-expireafter]
 ----
 GARAGE_TARGET_EXPIRE_AFTER = "1Y3M5D"
@@ -60,6 +60,7 @@ Command-line arguments::
 +
 --
 When you're using the `garage-sign` command to take your keys offline, you can also sign your metadata with one of the following expiry arguments.
+// tag::metadata-expiry[]
 
 .Command-line arguments for metadata expiry
 [cols="2a,4a",options="header"]
@@ -67,7 +68,7 @@ When you're using the `garage-sign` command to take your keys offline, you can a
 |Configuration  | Description
 |
 `--expires`
-| 
+|
 include::partial$config-descriptions.adoc[tags=metadata-expires]
 
 ----
@@ -76,12 +77,13 @@ garage-sign targets sign --expires 2018-01-01T00:01:00Z  --repo myimagerepo --ke
 
 |
 `--expire-after`
-| 
+|
 include::partial$config-descriptions.adoc[tags=metadata-expireafter]
 ----
 garage-sign targets sign ----expire-after 1Y3M5D  --repo myimagerepo --key-name mytargets
 ----
 |====================
-
+// end::metadata-expiry[]
 --
+
 ====

--- a/docs/ota-client-guide/modules/ROOT/pages/rotating-signing-keys.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/rotating-signing-keys.adoc
@@ -43,6 +43,7 @@ garage-sign init --repo myimagerepo --credentials /path/to/credentials.zip
 This command creates a `./tuf/myimagerepo/` directory tree in the current directory.
 This directory should be secured on an encrypted filesystem.
 
+
 === Generate new keys
 
 There are two metadata files in the repo and each file needs a new key to sign it.


### PR DESCRIPTION
Addition of a new page for `garage-sign` with information from the README file(https://github.com/advancedtelematic/ota-tuf/tree/master/cli) of the tuf git repo.