### PR TITLE
Revert "Fetch unnumbered Director root once as a workaround."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Our versioning scheme is `YEAR.N` where `N` is incremented whenever a new releas
 
 - Improved garage-deploy object fetching performance by reusing the curl handle: [PR](https://github.com/advancedtelematic/aktualizr/pull/1643)
 
+### Removed
+
+- No longer fetch unnumbered Root metadata from the Director: [PR](https://github.com/advancedtelematic/aktualizr/pull/1661)
+
 
 ## [2020.5] - 2020-04-01
 

--- a/src/libaktualizr/uptane/uptane_test.cc
+++ b/src/libaktualizr/uptane/uptane_test.cc
@@ -1203,11 +1203,7 @@ class HttpFakeUnstable : public HttpFake {
     if (unstable_valid_count >= unstable_valid_num) {
       return HttpResponse({}, 503, CURLE_OK, "");
     } else {
-      // This if is a hack only required as long as we have to explicitly fetch
-      // this to make the Director recognize new devices as "online".
-      if (url.find("director/root.json") == std::string::npos) {
-        ++unstable_valid_count;
-      }
+      ++unstable_valid_count;
       return HttpFake::get(url, maxsize);
     }
   }

--- a/src/libaktualizr/uptane/uptanerepository.cc
+++ b/src/libaktualizr/uptane/uptanerepository.cc
@@ -65,14 +65,7 @@ void RepositoryCommon::updateRoot(INvStorage& storage, const IMetadataFetcher& f
     if (storage.loadLatestRoot(&root_raw, repo_type)) {
       initRoot(repo_type, root_raw);
     } else {
-      // This block is a hack only required as long as we have to explicitly
-      // fetch this to make the Director recognize new devices as "online".
-      if (repo_type == RepositoryType::Director()) {
-        fetcher.fetchLatestRole(&root_raw, kMaxRootSize, repo_type, Role::Root());
-      }
-
       fetcher.fetchRole(&root_raw, kMaxRootSize, repo_type, Role::Root(), Version(1));
-
       initRoot(repo_type, root_raw);
       storage.storeRoot(root_raw, repo_type, Version(1));
     }


### PR DESCRIPTION
This reverts commit b322fa5a7f9188b399f14bd73c3cb2d3423778b0.

This is no longer required by the backend, and it's just a waste of bandwidth.

I've manually tested that provisioning indeed does not require this call anymore.