### PR TITLE
dockerapp: Handle warnings from Compose gracefully

### DIFF
--- a/src/libaktualizr/package_manager/docker_fake.sh
+++ b/src/libaktualizr/package_manager/docker_fake.sh
@@ -22,12 +22,16 @@ if [ "$1" = "app" ] ; then
 fi
 
 if [ "$1" = "render" ] ; then
-  echo "DOCKER-APP RENDER OUTPUT"
   if [ ! -f app1.dockerapp ] ; then
     echo "Missing docker app file!"
     exit 1
   fi
-  cat app1.dockerapp
+  if [ "$3" != "-o" ] ; then
+    echo "Unexpected arguments to render: $*"
+    exit 1
+  fi
+  echo "DOCKER-APP RENDER OUTPUT" > $4
+  cat app1.dockerapp >> $4
   exit 0
 fi
 if [ "$1" = "pull" ] ; then

--- a/src/libaktualizr/package_manager/dockerapp_standalone.cc
+++ b/src/libaktualizr/package_manager/dockerapp_standalone.cc
@@ -56,13 +56,13 @@ struct DockerApp {
     if (!app_params.empty()) {
       cmd += " --parameters-file " + app_params.string();
     }
-    std::string yaml;
-    if (Utils::shell(cmd, &yaml, true) != 0) {
-      LOG_ERROR << "Unable to run " << cmd << " output:\n" << yaml;
-      return false;
-    }
     if (persist) {
-      Utils::writeFile(app_root / "docker-compose.yml", yaml);
+      cmd += " -o " + (app_root / "docker-compose.yml").string();
+    }
+    std::string output;
+    if (Utils::shell(cmd, &output, true) != 0) {
+      LOG_ERROR << "Unable to run " << cmd << " output:\n" << output;
+      return false;
     }
     return true;
   }


### PR DESCRIPTION
Grabbing the docker-app render STDOUT isn't safe. If that file has
docker-compose *warnings*, they'll be included and then produce invalid
YAML. We should write the YAML directly to disk if we are going to
persist.

Signed-off-by: Andy Doan <andy@foundries.io>