### PR TITLE
Remove unnecessary call to saveSecondaryInfo

### DIFF
--- a/src/libaktualizr/primary/aktualizr_test.cc
+++ b/src/libaktualizr/primary/aktualizr_test.cc
@@ -175,6 +175,7 @@ TEST(Aktualizr, DeviceInstallationResult) {
 
   EcuSerials serials{
       {Uptane::EcuSerial("primary"), Uptane::HardwareIdentifier("primary_hw")},
+      {Uptane::EcuSerial("secondary_ecu_serial"), Uptane::HardwareIdentifier("secondary_hw")},
       {Uptane::EcuSerial("ecuserial3"), Uptane::HardwareIdentifier("hw_id3")},
   };
   storage->storeEcuSerials(serials);

--- a/src/libaktualizr/primary/initializer.cc
+++ b/src/libaktualizr/primary/initializer.cc
@@ -208,6 +208,8 @@ void Initializer::initEcuRegister() {
     throw ServerError(err);
   }
 
+  storage_->storeEcuRegistered();
+
   LOG_INFO << "ECUs have been successfully registered with the server.";
 }
 
@@ -256,8 +258,6 @@ Initializer::Initializer(const ProvisionConfig& config_in, std::shared_ptr<INvSt
     initEcuReportCounter();
 
     initEcuRegister();
-
-    storage_->storeEcuRegistered();
 
     return;
   }

--- a/src/libaktualizr/primary/initializer.h
+++ b/src/libaktualizr/primary/initializer.h
@@ -4,6 +4,7 @@
 #include "config/config.h"
 #include "crypto/keymanager.h"
 #include "http/httpinterface.h"
+#include "storage/invstorage.h"
 #include "uptane/secondaryinterface.h"
 
 const int MaxInitializationAttempts = 3;
@@ -41,6 +42,7 @@ class Initializer {
   std::shared_ptr<HttpInterface> http_client_;
   KeyManager& keys_;
   const std::map<Uptane::EcuSerial, Uptane::SecondaryInterface::Ptr>& secondaries_;
+  std::vector<SecondaryInfo> sec_info_;
 
   void initDeviceId();
   void resetDeviceId();
@@ -50,6 +52,7 @@ class Initializer {
   void resetEcuKeys();
   void initTlsCreds();
   void resetTlsCreds();
+  void initSecondaryInfo();
   void initEcuRegister();
   bool loadSetTlsCreds();
   void initEcuReportCounter();

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -27,18 +27,6 @@ static void report_progress_cb(event::Channel *channel, const Uptane::Target &ta
 void SotaUptaneClient::addSecondary(const std::shared_ptr<Uptane::SecondaryInterface> &sec) {
   Uptane::EcuSerial serial = sec->getSerial();
 
-  SecondaryInfo info;
-  if (!storage->loadSecondaryInfo(serial, &info) || info.type == "" || info.pub_key.Type() == KeyType::kUnknown) {
-    info.serial = serial;
-    info.hw_id = sec->getHwId();
-    info.type = sec->Type();
-    const PublicKey &p = sec->getPublicKey();
-    if (p.Type() != KeyType::kUnknown) {
-      info.pub_key = p;
-    }
-    storage->saveSecondaryInfo(info.serial, info.type, info.pub_key);
-  }
-
   if (storage->loadEcuRegistered()) {
     EcuSerials serials;
     storage->loadEcuSerials(&serials);

--- a/src/libaktualizr/storage/sqlstorage.cc
+++ b/src/libaktualizr/storage/sqlstorage.cc
@@ -163,8 +163,7 @@ void SQLStorage::saveSecondaryInfo(const Uptane::EcuSerial& ecu_serial, const st
   auto statement =
       db.prepareStatement<std::string>("SELECT count(*) FROM secondary_ecus WHERE serial = ?;", ecu_serial.ToString());
   if (statement.step() != SQLITE_ROW) {
-    LOG_ERROR << "Can't get count of secondary_ecus table: " << db.errmsg();
-    return;
+    throw std::runtime_error(db.errmsg().insert(0, "Can't get count of secondary_ecus table: "));
   }
 
   const char* req;
@@ -179,8 +178,7 @@ void SQLStorage::saveSecondaryInfo(const Uptane::EcuSerial& ecu_serial, const st
   statement = db.prepareStatement<std::string, std::string, std::string, std::string>(
       req, sec_type, key_type_str, public_key.Value(), ecu_serial.ToString());
   if (statement.step() != SQLITE_DONE || sqlite3_changes(db.get()) != 1) {
-    LOG_ERROR << "Can't save Secondary key: " << db.errmsg();
-    return;
+    throw std::runtime_error(db.errmsg().insert(0, "Can't save Secondary key: "));
   }
 
   db.commitTransaction();
@@ -194,8 +192,7 @@ void SQLStorage::saveSecondaryData(const Uptane::EcuSerial& ecu_serial, const st
   auto statement =
       db.prepareStatement<std::string>("SELECT count(*) FROM secondary_ecus WHERE serial = ?;", ecu_serial.ToString());
   if (statement.step() != SQLITE_ROW) {
-    LOG_ERROR << "Can't get count of secondary_ecus table: " << db.errmsg();
-    return;
+    throw std::runtime_error(db.errmsg().insert(0, "Can't get count of secondary_ecus table: "));
   }
 
   const char* req;
@@ -207,8 +204,7 @@ void SQLStorage::saveSecondaryData(const Uptane::EcuSerial& ecu_serial, const st
 
   statement = db.prepareStatement<std::string, std::string>(req, data, ecu_serial.ToString());
   if (statement.step() != SQLITE_DONE || sqlite3_changes(db.get()) != 1) {
-    LOG_ERROR << "Can't save Secondary data: " << db.errmsg();
-    return;
+    throw std::runtime_error(db.errmsg().insert(0, "Can't save Secondary data: "));
   }
 
   db.commitTransaction();

--- a/src/libaktualizr/storage/storage_common_test.cc
+++ b/src/libaktualizr/storage/storage_common_test.cc
@@ -586,8 +586,8 @@ TEST(storage, load_store_secondary_info) {
 
   storage->saveSecondaryInfo(Uptane::EcuSerial("secondary_1"), "ip", PublicKey("key1", KeyType::kED25519));
 
-  EXPECT_THROW(storage->saveSecondaryInfo(Uptane::EcuSerial("primary"), "ip",
-                             PublicKey("key0", KeyType::kRSA2048)), std::runtime_error);
+  EXPECT_THROW(storage->saveSecondaryInfo(Uptane::EcuSerial("primary"), "ip", PublicKey("key0", KeyType::kRSA2048)),
+               std::runtime_error);
 
   std::vector<SecondaryInfo> sec_infos;
   EXPECT_TRUE(storage->loadSecondariesInfo(&sec_infos));

--- a/src/libaktualizr/storage/storage_common_test.cc
+++ b/src/libaktualizr/storage/storage_common_test.cc
@@ -586,10 +586,8 @@ TEST(storage, load_store_secondary_info) {
 
   storage->saveSecondaryInfo(Uptane::EcuSerial("secondary_1"), "ip", PublicKey("key1", KeyType::kED25519));
 
-  testing::internal::CaptureStdout();
-  storage->saveSecondaryInfo(Uptane::EcuSerial("primary"), "ip",
-                             PublicKey("key0", KeyType::kRSA2048));  // should show an error
-  EXPECT_NE(std::string::npos, testing::internal::GetCapturedStdout().find("Can't save Secondary"));
+  EXPECT_THROW(storage->saveSecondaryInfo(Uptane::EcuSerial("primary"), "ip",
+                             PublicKey("key0", KeyType::kRSA2048)), std::runtime_error);
 
   std::vector<SecondaryInfo> sec_infos;
   EXPECT_TRUE(storage->loadSecondariesInfo(&sec_infos));


### PR DESCRIPTION
I might be wrong, but to me call to `saveSecondaryInfo` in `addSecondary` seems unnecessary.
If a device is not yet registered, it will do nothing but producing "Can't save Secondary key: unknown error" message, as there is no serial yet for this secondary in DB. Otherwise the secondary info should  be already stored by `initEcuRegister()`. 