### PR TITLE
Only send device data if it has changed

### DIFF
--- a/config/sql/migration/migrate.25.sql
+++ b/config/sql/migration/migrate.25.sql
@@ -1,0 +1,9 @@
+-- Don't modify this! Create a new migration instead--see docs/ota-client-guide/modules/ROOT/pages/schema-migrations.adoc
+SAVEPOINT MIGRATION;
+
+CREATE TABLE device_data(data_type TEXT PRIMARY KEY, hash TEXT NOT NULL);
+
+DELETE FROM version;
+INSERT INTO version VALUES(25);
+
+RELEASE MIGRATION;

--- a/config/sql/rollback/rollback.25.sql
+++ b/config/sql/rollback/rollback.25.sql
@@ -1,0 +1,9 @@
+-- Don't modify this! Create a new migration instead--see docs/ota-client-guide/modules/ROOT/pages/schema-migrations.adoc
+SAVEPOINT ROLLBACK_MIGRATION;
+
+DROP TABLE device_data;
+
+DELETE FROM version;
+INSERT INTO version VALUES(24);
+
+RELEASE ROLLBACK_MIGRATION;

--- a/config/sql/schema.sql
+++ b/config/sql/schema.sql
@@ -1,5 +1,5 @@
 CREATE TABLE version(version INTEGER);
-INSERT INTO version(rowid,version) VALUES(1,24);
+INSERT INTO version(rowid,version) VALUES(1,25);
 CREATE TABLE device_info(unique_mark INTEGER PRIMARY KEY CHECK (unique_mark = 0), device_id TEXT, is_registered INTEGER NOT NULL DEFAULT 0 CHECK (is_registered IN (0,1)));
 CREATE TABLE ecus(id INTEGER PRIMARY KEY, serial TEXT UNIQUE, hardware_id TEXT NOT NULL, is_primary INTEGER NOT NULL DEFAULT 0 CHECK (is_primary IN (0,1)));
 CREATE TABLE secondary_ecus(serial TEXT PRIMARY KEY, sec_type TEXT, public_key_type TEXT, public_key TEXT, extra TEXT, manifest TEXT);
@@ -26,3 +26,4 @@ CREATE TABLE rollback_migrations(version_from INT PRIMARY KEY, migration TEXT NO
 CREATE TABLE delegations(meta BLOB NOT NULL, role_name TEXT NOT NULL, UNIQUE(role_name));
 CREATE TABLE ecu_report_counter(ecu_serial TEXT NOT NULL PRIMARY KEY, counter INTEGER NOT NULL DEFAULT 0);
 CREATE TABLE report_events(id INTEGER PRIMARY KEY, json_string TEXT NOT NULL);
+CREATE TABLE device_data(data_type TEXT PRIMARY KEY, hash TEXT NOT NULL);

--- a/src/libaktualizr/primary/aktualizr_test.cc
+++ b/src/libaktualizr/primary/aktualizr_test.cc
@@ -1176,7 +1176,7 @@ TEST(Aktualizr, AutoRebootAfterUpdate) {
     storage->loadPrimaryInstalledVersions(&current_target, &pending_target);
     EXPECT_TRUE(!!current_target);
     EXPECT_FALSE(!!pending_target);
-    EXPECT_EQ(http->manifest_sends, 4);
+    EXPECT_EQ(http->manifest_sends, 3);
   }
 }
 

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -766,7 +766,6 @@ void SotaUptaneClient::sendDeviceData(const Json::Value &custom_hwinfo) {
   reportInstalledPackages();
   reportNetworkInfo();
   reportAktualizrConfiguration();
-  putManifestSimple();
   sendEvent<event::SendDeviceDataComplete>();
 }
 

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -169,8 +169,6 @@ class SotaUptaneClient {
   std::shared_ptr<PackageManagerInterface> package_manager_;
   std::shared_ptr<Uptane::Fetcher> uptane_fetcher;
   std::unique_ptr<ReportQueue> report_queue;
-  Json::Value last_network_info_reported;
-  Json::Value last_hw_info_reported;
   std::shared_ptr<event::Channel> events_channel;
   boost::signals2::scoped_connection conn;
   std::exception_ptr last_exception;

--- a/src/libaktualizr/storage/invstorage.h
+++ b/src/libaktualizr/storage/invstorage.h
@@ -215,6 +215,10 @@ class INvStorage {
   virtual bool loadReportEvents(Json::Value* report_array, int64_t* id_max) const = 0;
   virtual void deleteReportEvents(int64_t id_max) = 0;
 
+  virtual void storeDeviceDataHash(const std::string& data_type, const std::string& hash) = 0;
+  virtual bool loadDeviceDataHash(const std::string& data_type, std::string* hash) const = 0;
+  virtual void clearDeviceData() = 0;
+
   virtual bool checkAvailableDiskSpace(uint64_t required_bytes) const = 0;
   virtual boost::optional<std::pair<uintmax_t, std::string>> checkTargetFile(const Uptane::Target& target) const = 0;
 

--- a/src/libaktualizr/storage/sqlstorage.cc
+++ b/src/libaktualizr/storage/sqlstorage.cc
@@ -1648,6 +1648,48 @@ void SQLStorage::clearInstallationResults() {
   db.commitTransaction();
 }
 
+void SQLStorage::storeDeviceDataHash(const std::string& data_type, const std::string& hash) {
+  SQLite3Guard db = dbConnection();
+
+  auto statement = db.prepareStatement<std::string, std::string>(
+      "INSERT OR REPLACE INTO device_data(data_type,hash) VALUES (?,?);", data_type, hash);
+  if (statement.step() != SQLITE_DONE) {
+    LOG_ERROR << "Can't set " << data_type << " hash: " << db.errmsg();
+    throw std::runtime_error("Can't set " + data_type + " hash: " + db.errmsg());
+  }
+}
+
+bool SQLStorage::loadDeviceDataHash(const std::string& data_type, std::string* hash) const {
+  SQLite3Guard db = dbConnection();
+
+  auto statement =
+      db.prepareStatement<std::string>("SELECT hash FROM device_data WHERE data_type = ? LIMIT 1;", data_type);
+
+  int result = statement.step();
+  if (result == SQLITE_DONE) {
+    LOG_TRACE << data_type << " hash not present in db";
+    return false;
+  } else if (result != SQLITE_ROW) {
+    LOG_ERROR << "Can't get " << data_type << " hash: " << db.errmsg();
+    return false;
+  }
+
+  if (hash != nullptr) {
+    *hash = statement.get_result_col_str(0).value();
+  }
+
+  return true;
+}
+
+void SQLStorage::clearDeviceData() {
+  SQLite3Guard db = dbConnection();
+
+  if (db.exec("DELETE FROM device_data;", nullptr, nullptr) != SQLITE_OK) {
+    LOG_ERROR << "Can't clear device_data: " << db.errmsg();
+    return;
+  }
+}
+
 bool SQLStorage::checkAvailableDiskSpace(const uint64_t required_bytes) const {
   struct statvfs stvfsbuf {};
   const int stat_res = statvfs(dbPath().c_str(), &stvfsbuf);

--- a/src/libaktualizr/storage/sqlstorage.h
+++ b/src/libaktualizr/storage/sqlstorage.h
@@ -96,6 +96,10 @@ class SQLStorage : public SQLStorageBase, public INvStorage {
   void deleteReportEvents(int64_t id_max) override;
   void clearInstallationResults() override;
 
+  void storeDeviceDataHash(const std::string& data_type, const std::string& hash) override;
+  bool loadDeviceDataHash(const std::string& data_type, std::string* hash) const override;
+  void clearDeviceData() override;
+
   bool checkAvailableDiskSpace(uint64_t required_bytes) const override;
 
   std::unique_ptr<StorageTargetWHandle> allocateTargetFile(const Uptane::Target& target) override;

--- a/src/libaktualizr/uptane/uptane_test.cc
+++ b/src/libaktualizr/uptane/uptane_test.cc
@@ -890,7 +890,7 @@ class HttpFakeProv : public HttpFake {
       std::string file_secondary;
       std::string hash_primary;
       std::string hash_secondary;
-      if (manifest_count <= 2) {
+      if (manifest_count <= 1) {
         file_primary = "unknown";
         file_secondary = "noimage";
         // Check for default initial value of packagemanagerfake.
@@ -990,14 +990,13 @@ TEST(Uptane, ProvisionOnServer) {
   EXPECT_EQ(http->ecus_count, 1);
 
   EXPECT_NO_THROW(up->sendDeviceData());
-  EXPECT_EQ(http->manifest_count, 1);
   EXPECT_EQ(http->installed_count, 1);
   EXPECT_EQ(http->system_info_count, 1);
   EXPECT_EQ(http->network_count, 1);
 
   result::UpdateCheck update_result = up->fetchMeta();
   EXPECT_EQ(update_result.status, result::UpdateStatus::kUpdatesAvailable);
-  EXPECT_EQ(http->manifest_count, 2);
+  EXPECT_EQ(http->manifest_count, 1);
 
   // Test installation to make sure the metadata put to the server is correct.
   result::Download download_result = up->downloadImages(update_result.updates);
@@ -1009,7 +1008,7 @@ TEST(Uptane, ProvisionOnServer) {
 
   EXPECT_EQ(http->devices_count, 1);
   EXPECT_EQ(http->ecus_count, 1);
-  EXPECT_EQ(http->manifest_count, 3);
+  EXPECT_EQ(http->manifest_count, 2);
   EXPECT_EQ(http->installed_count, 1);
   EXPECT_EQ(http->system_info_count, 1);
   EXPECT_EQ(http->network_count, 1);

--- a/src/libaktualizr/uptane/uptane_test.cc
+++ b/src/libaktualizr/uptane/uptane_test.cc
@@ -774,8 +774,24 @@ TEST(Uptane, UptaneSecondaryMisconfigured) {
  */
 class HttpFakeProv : public HttpFake {
  public:
-  HttpFakeProv(const boost::filesystem::path &test_dir_in, std::string flavor = "")
-      : HttpFake(test_dir_in, std::move(flavor)) {}
+  HttpFakeProv(const boost::filesystem::path &test_dir_in, std::string flavor, Config &config_in)
+      : HttpFake(test_dir_in, std::move(flavor)), config(config_in) {}
+
+  HttpResponse post(const std::string &url, const std::string &content_type, const std::string &data) override {
+    std::cout << "post " << url << "\n";
+
+    if (url.find("/system_info/config") != std::string::npos) {
+      /* Send libaktualizr configuration to the server. */
+      config_count++;
+      std::stringstream conf_ss;
+      config.writeToStream(conf_ss);
+      EXPECT_EQ(data, conf_ss.str());
+      EXPECT_EQ(content_type, "application/toml");
+    } else {
+      EXPECT_EQ(0, 1) << "Unexpected post to URL: " << url;
+    }
+    return HttpFake::post(url, content_type, data);
+  }
 
   HttpResponse post(const std::string &url, const Json::Value &data) override {
     std::cout << "post " << url << "\n";
@@ -940,8 +956,10 @@ class HttpFakeProv : public HttpFake {
   int installed_count{0};
   int system_info_count{0};
   int network_count{0};
+  int config_count{0};
 
  private:
+  Config &config;
   int primary_download_start{0};
   int primary_download_complete{0};
   int secondary_download_start{0};
@@ -957,7 +975,7 @@ TEST(Uptane, ProvisionOnServer) {
   RecordProperty("zephyr_key", "OTA-984,TST-149");
   TemporaryDirectory temp_dir;
   Config config("tests/config/basic.toml");
-  auto http = std::make_shared<HttpFakeProv>(temp_dir.Path(), "hasupdates");
+  auto http = std::make_shared<HttpFakeProv>(temp_dir.Path(), "hasupdates", config);
   const std::string &server = http->tls_server;
   config.provision.server = server;
   config.tls.server = server;
@@ -980,6 +998,7 @@ TEST(Uptane, ProvisionOnServer) {
   EXPECT_EQ(http->installed_count, 0);
   EXPECT_EQ(http->system_info_count, 0);
   EXPECT_EQ(http->network_count, 0);
+  EXPECT_EQ(http->config_count, 0);
 
   EXPECT_NO_THROW(up->initialize());
   EcuSerials serials;
@@ -993,6 +1012,7 @@ TEST(Uptane, ProvisionOnServer) {
   EXPECT_EQ(http->installed_count, 1);
   EXPECT_EQ(http->system_info_count, 1);
   EXPECT_EQ(http->network_count, 1);
+  EXPECT_EQ(http->config_count, 1);
 
   result::UpdateCheck update_result = up->fetchMeta();
   EXPECT_EQ(update_result.status, result::UpdateStatus::kUpdatesAvailable);
@@ -1012,6 +1032,7 @@ TEST(Uptane, ProvisionOnServer) {
   EXPECT_EQ(http->installed_count, 1);
   EXPECT_EQ(http->system_info_count, 1);
   EXPECT_EQ(http->network_count, 1);
+  EXPECT_EQ(http->config_count, 1);
   EXPECT_EQ(http->events_seen, 8);
 }
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__file__)
 @with_sysroot()
 @with_aktualizr(start=False, run_mode='once', output_logs=True)
 def test_primary_ostree_secondary_file_updates(uptane_repo, secondary, aktualizr, director, sysroot,
-                                               treehub, uptane_server, **kwargs):
+                                               treehub, **kwargs):
     target_rev = treehub.revision
     # add an ostree update for Primary
     uptane_repo.add_ostree_target(aktualizr.id, target_rev)
@@ -71,16 +71,17 @@ def test_primary_ostree_secondary_file_updates(uptane_repo, secondary, aktualizr
  but are expired after that and before Secondary is rebooted,
  we still expect that the installed update is applied in this case
 """
-@with_treehub()
 @with_uptane_backend()
 @with_director()
+@with_treehub()
 @with_sysroot()
 @with_secondary(start=False)
 @with_aktualizr(start=False, run_mode='once', output_logs=True)
-def test_secodary_ostree_update_if_metadata_expires(uptane_repo, secondary, aktualizr, treehub, sysroot, director, **kwargs):
+def test_secondary_ostree_update_if_metadata_expires(uptane_repo, secondary, aktualizr, director, sysroot, treehub, **kwargs):
     target_rev = treehub.revision
     expires_within_sec = 10
 
+    # add an OSTree update for Secondary
     uptane_repo.add_ostree_target(secondary.id, target_rev, expires_within_sec=expires_within_sec)
     start_time = time.time()
 
@@ -88,30 +89,34 @@ def test_secodary_ostree_update_if_metadata_expires(uptane_repo, secondary, aktu
         with aktualizr:
             aktualizr.wait_for_completion()
 
+    # check the Primary update, must be in pending state since it requires reboot
     pending_rev = aktualizr.get_current_pending_image_info(secondary.id)
-
     if pending_rev != target_rev:
-        logger.error("Pending version {} != the target one {}".format(pending_rev, target_rev))
+        logger.error("Pending version {} != the target version {}".format(pending_rev, target_rev))
         return False
 
     # wait until the target metadata are expired
     time.sleep(max(0, expires_within_sec - (time.time() - start_time)))
 
+    # emulate reboot and run aktualizr once more
     sysroot.update_revision(pending_rev)
     secondary.emulate_reboot()
 
     with secondary:
+        # Wait for Secondary to initialize. wait_for_completion won't work; it
+        # times out.
+        time.sleep(5)
         with aktualizr:
             aktualizr.wait_for_completion()
 
+    # check the Secondary update after reboot
     if not director.get_install_result():
         logger.error("Installation result is not successful")
         return False
 
     installed_rev = aktualizr.get_current_image_info(secondary.id)
-
     if installed_rev != target_rev:
-        logger.error("Installed version {} != the target one {}".format(installed_rev, target_rev))
+        logger.error("Installed version {} != the target version {}".format(installed_rev, target_rev))
         return False
 
     return True
@@ -124,16 +129,16 @@ def test_secodary_ostree_update_if_metadata_expires(uptane_repo, secondary, aktu
  but are expired after that and before Primary is rebooted,
  we still expect that the installed update is applied in this case
 """
-@with_uptane_backend(start_generic_server=True)
+@with_uptane_backend()
 @with_director()
 @with_treehub()
 @with_sysroot()
 @with_aktualizr(start=False, run_mode='once', output_logs=True)
-def test_primary_ostree_update_if_metadata_expires(uptane_repo, aktualizr, director, sysroot, treehub, uptane_server, **kwargs):
+def test_primary_ostree_update_if_metadata_expires(uptane_repo, aktualizr, director, sysroot, treehub, **kwargs):
     target_rev = treehub.revision
     expires_within_sec = 10
 
-    # add an ostree update for Primary
+    # add an OSTree update for Primary
     uptane_repo.add_ostree_target(aktualizr.id, target_rev, expires_within_sec=expires_within_sec)
     start_time = time.time()
 
@@ -157,8 +162,16 @@ def test_primary_ostree_update_if_metadata_expires(uptane_repo, aktualizr, direc
         aktualizr.wait_for_completion()
 
     # check the Primary update after reboot
-    result = director.get_install_result() and (target_rev == aktualizr.get_current_primary_image_info())
-    return result
+    if not director.get_install_result():
+        logger.error("Installation result is not successful")
+        return False
+
+    installed_rev = aktualizr.get_current_primary_image_info()
+    if installed_rev != target_rev:
+        logger.error("Installed version {} != the target version {}".format(installed_rev, target_rev))
+        return False
+
+    return True
 
 
 if __name__ == "__main__":
@@ -176,7 +189,7 @@ if __name__ == "__main__":
 
     test_suite = [
         test_primary_ostree_secondary_file_updates,
-        test_secodary_ostree_update_if_metadata_expires,
+        test_secondary_ostree_update_if_metadata_expires,
         test_primary_ostree_update_if_metadata_expires
     ]
 


### PR DESCRIPTION
We now stored hashes of the hardware/system information, list of installed packages, network information, and configuration in the database. The hardware and network data were previously stored locally in SotaUptaneClient, but this persists over restarts, so it saves even more bandwidth.

Note that at least on my laptop, one field in the output of lshw changes every time I call it, so the hardware info gets sent every time. Thankfully, I could not reproduce that problem on qemu.

I also removed sending the manifest as part of device data. There's no reason to; it is always sent as part of checking for updates, and there is never a time that device data is sent that isn't immediately followed by checking for updates.