### PR TITLE
Make path to downloaded binaries separately configurable

### DIFF
--- a/config/sota-local-with-secondaries.toml
+++ b/config/sota-local-with-secondaries.toml
@@ -14,3 +14,4 @@ path = "storage"
 
 [pacman]
 type = "none"
+images_path = "storage/images"

--- a/config/sota-local.toml
+++ b/config/sota-local.toml
@@ -10,3 +10,4 @@ path = "storage"
 
 [pacman]
 type = "none"
+images_path = "storage/images"

--- a/docs/ota-client-guide/modules/ROOT/pages/aktualizr-config-options.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/aktualizr-config-options.adoc
@@ -140,6 +140,7 @@ Options for package management and update installation. Note that this only coin
 | `sysroot`          |                           | Path to an OSTree sysroot. Only used with `ostree`.
 | `ostree_server`    |                           | OSTree server URL. Only used with `ostree`. If empty, set to `tls.server` with `/treehub` appended.
 | `packages_file`    | `"/usr/package.manifest"` | Path to a file for storing package manifest information. Only used with `ostree`.
+| `images_path`      | `"/var/sota/images"`      | Directory to store downloaded binary Targets. Only used with `none`.
 | `fake_need_reboot` | false                     | Simulate a wait-for-reboot with the `"none"` package manager. Used for testing.
 |==========================================================================================
 

--- a/include/libaktualizr-c.h
+++ b/include/libaktualizr-c.h
@@ -9,7 +9,7 @@
 using Campaign = campaign::Campaign;
 using Updates = std::vector<Uptane::Target>;
 using Target = Uptane::Target;
-using StorageTargetHandle = StorageTargetRHandle;
+using StorageTargetHandle = std::ifstream;
 
 extern "C" {
 #else

--- a/src/libaktualizr-c/libaktualizr-c.cc
+++ b/src/libaktualizr-c/libaktualizr-c.cc
@@ -200,8 +200,8 @@ StorageTargetHandle *Aktualizr_open_stored_target(Aktualizr *a, const Target *t)
   }
 
   try {
-    auto handle = a->OpenStoredTarget(*t);
-    return handle.release();
+    auto stream = new auto(a->OpenStoredTarget(*t));
+    return stream;
   } catch (const std::exception &e) {
     std::cerr << "Aktualizr_open_stored_target exception: " << e.what() << std::endl;
     return nullptr;
@@ -210,7 +210,8 @@ StorageTargetHandle *Aktualizr_open_stored_target(Aktualizr *a, const Target *t)
 
 size_t Aktualizr_read_stored_target(StorageTargetHandle *handle, uint8_t *buf, size_t size) {
   if (handle != nullptr && buf != nullptr) {
-    return handle->rread(buf, size);
+    handle->read(reinterpret_cast<char *>(buf), static_cast<std::streamsize>(size));
+    return static_cast<size_t>(handle->gcount());
   } else {
     std::cerr << "Aktualizr_read_stored_target failed: invalid input " << (handle == nullptr ? "handle" : "buffer")
               << std::endl;
@@ -220,7 +221,7 @@ size_t Aktualizr_read_stored_target(StorageTargetHandle *handle, uint8_t *buf, s
 
 int Aktualizr_close_stored_target(StorageTargetHandle *handle) {
   if (handle != nullptr) {
-    handle->rclose();
+    handle->close();
     delete handle;
     return 0;
   } else {

--- a/src/libaktualizr-c/test/api-test-utils/api-test-utils.cc
+++ b/src/libaktualizr-c/test/api-test-utils/api-test-utils.cc
@@ -34,6 +34,7 @@ Config *Get_test_config() {
   temp_dir = std_::make_unique<TemporaryDirectory>();
   config->storage.path = temp_dir->Path();
   config->pacman.type = PACKAGE_MANAGER_NONE;
+  config->pacman.images_path = temp_dir->Path() / "images";
 
   config->postUpdateValues();
   return config;

--- a/src/libaktualizr/package_manager/debianmanager.cc
+++ b/src/libaktualizr/package_manager/debianmanager.cc
@@ -17,11 +17,13 @@ data::InstallationResult DebianManager::install(const Uptane::Target &target) co
   std::string cmd = "dpkg -i ";
   std::string output;
   TemporaryDirectory package_dir("deb_dir");
-  auto target_file = storage_->openTargetFile(target);
+  auto target_file = openTargetFile(target);
 
   boost::filesystem::path deb_path = package_dir / target.filename();
-  target_file->writeToFile(deb_path);
-  target_file->rclose();
+  std::ofstream deb_file(deb_path.string(), std::ios::binary);
+  deb_file << target_file.rdbuf();
+  target_file.close();
+  deb_file.close();
 
   int status = Utils::shell(cmd + deb_path.string(), &output, true);
   if (status == 0) {

--- a/src/libaktualizr/package_manager/debianmanager_test.cc
+++ b/src/libaktualizr/package_manager/debianmanager_test.cc
@@ -32,9 +32,9 @@ TEST(PackageManagerFactory, Debian_Install_Good) {
   target_json_test["length"] = 2;
   Uptane::Target target_test("test.deb", target_json_test);
   storage->savePrimaryInstalledVersion(target_test, InstalledVersionUpdateMode::kCurrent);
-  std::unique_ptr<StorageTargetWHandle> fhandle = storage->allocateTargetFile(target);
-  std::stringstream("ab") >> *fhandle;
-  fhandle->wcommit();
+  auto fhandle = pacman->createTargetFile(target);
+  fhandle << "ab";
+  fhandle.close();
 
   EXPECT_EQ(pacman->install(target).result_code.num_code, data::ResultCode::Numeric::kOk);
   EXPECT_TRUE(pacman->getCurrent().MatchTarget(target));
@@ -55,9 +55,9 @@ TEST(PackageManagerFactory, Debian_Install_Bad) {
   target_json["custom"]["ecuIdentifiers"]["primary_serial"]["hardwareId"] = "primary_hwid";
   Uptane::Target target("bad.deb", target_json);
 
-  std::unique_ptr<StorageTargetWHandle> fhandle = storage->allocateTargetFile(target);
-  std::stringstream("ab") >> *fhandle;
-  fhandle->wcommit();
+  auto fhandle = pacman->createTargetFile(target);
+  fhandle << "ab";
+  fhandle.close();
 
   auto result = pacman->install(target);
   EXPECT_EQ(result.result_code.num_code, data::ResultCode::Numeric::kInstallFailed);

--- a/src/libaktualizr/package_manager/dockerapp_standalone.cc
+++ b/src/libaktualizr/package_manager/dockerapp_standalone.cc
@@ -157,7 +157,7 @@ bool DockerAppStandalone::fetchTarget(const Uptane::Target &target, Uptane::Fetc
       return false;
     }
     std::stringstream ss;
-    ss << *storage_->openTargetFile(app_target);
+    ss << openTargetFile(app_target).rdbuf();
     DockerApp dapp(app, config);
     return dapp.render(ss.str(), true) && dapp.fetch();
   };

--- a/src/libaktualizr/package_manager/dockerappmanager_test.cc
+++ b/src/libaktualizr/package_manager/dockerappmanager_test.cc
@@ -149,7 +149,7 @@ TEST(DockerAppManager, DockerAppStandalone) {
            "76b183d51f53613a450825afc6f984077b68ae7b321ba041a2b3871f3c25a9a20d964ad0b60352e5fdd09b78fd53879f4e3"
            "fa3dcc8335b26d3bbf455803d2ecb")};
   Uptane::Target app_target("foo.dockerapp", Uptane::EcuMap{}, hashes, 8);
-  ASSERT_TRUE(storage->checkTargetFile(app_target));
+  ASSERT_TRUE(client->package_manager_->checkTargetFile(app_target));
 
   client->package_manager_->install(target);
   std::string content = Utils::readFile(apps_root / "app1/docker-compose.yml");

--- a/src/libaktualizr/package_manager/fetcher_death_test.cc
+++ b/src/libaktualizr/package_manager/fetcher_death_test.cc
@@ -86,6 +86,7 @@ void try_and_die(const Uptane::Target& target, bool graceful) {
 TEST(FetcherDeathTest, TestResumeAfterPause) {
   TemporaryDirectory temp_dir;
   config.storage.path = temp_dir.Path();
+  config.pacman.images_path = temp_dir.Path() / "images";
 
   Json::Value target_json;
   target_json["hashes"]["sha256"] = "dd7bd1c37a3226e520b8d6939c30991b1c08772d5dab62b381c3a63541dc629a";

--- a/src/libaktualizr/package_manager/fetcher_test.cc
+++ b/src/libaktualizr/package_manager/fetcher_test.cc
@@ -57,6 +57,7 @@ static void progress_cb(const Uptane::Target& target, const std::string& descrip
 void test_pause(const Uptane::Target& target, const std::string& type = PACKAGE_MANAGER_NONE) {
   TemporaryDirectory temp_dir;
   config.storage.path = temp_dir.Path();
+  config.pacman.images_path = temp_dir.Path() / "images";
   config.uptane.repo_server = server;
   config.pacman.type = type;
   config.pacman.sysroot = sysroot;
@@ -146,6 +147,7 @@ class HttpCustomUri : public HttpFake {
 /* Download from URI specified in target metadata. */
 TEST(Fetcher, DownloadCustomUri) {
   TemporaryDirectory temp_dir;
+  config.pacman.images_path = temp_dir.Path() / "images";
   config.storage.path = temp_dir.Path();
   config.uptane.repo_server = server;
 
@@ -184,6 +186,7 @@ class HttpDefaultUri : public HttpFake {
 TEST(Fetcher, DownloadDefaultUri) {
   TemporaryDirectory temp_dir;
   config.storage.path = temp_dir.Path();
+  config.pacman.images_path = temp_dir.Path() / "images";
   config.uptane.repo_server = server;
 
   std::shared_ptr<INvStorage> storage(new SQLStorage(config.storage, false));
@@ -246,6 +249,7 @@ class HttpZeroLength : public HttpFake {
 TEST(Fetcher, DownloadLengthZero) {
   TemporaryDirectory temp_dir;
   config.storage.path = temp_dir.Path();
+  config.pacman.images_path = temp_dir.Path() / "images";
   config.uptane.repo_server = server;
 
   std::shared_ptr<INvStorage> storage(new SQLStorage(config.storage, false));
@@ -281,6 +285,7 @@ TEST(Fetcher, DownloadLengthZero) {
 TEST(Fetcher, NotEnoughDiskSpace) {
   TemporaryDirectory temp_dir;
   config.storage.path = temp_dir.Path();
+  config.pacman.images_path = temp_dir.Path() / "images";
   config.uptane.repo_server = server;
 
   std::shared_ptr<INvStorage> storage(new SQLStorage(config.storage, false));
@@ -319,6 +324,7 @@ TEST(Fetcher, NotEnoughDiskSpace) {
 TEST(Fetcher, DownloadOstreeFail) {
   TemporaryDirectory temp_dir;
   config.storage.path = temp_dir.Path();
+  config.pacman.images_path = temp_dir.Path() / "images";
   config.uptane.repo_server = server;
 
   std::shared_ptr<INvStorage> storage(new SQLStorage(config.storage, false));

--- a/src/libaktualizr/package_manager/packagemanagerconfig.cc
+++ b/src/libaktualizr/package_manager/packagemanagerconfig.cc
@@ -15,6 +15,8 @@ void PackageConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt
       CopyFromConfig(sysroot, cp.first, pt);
     } else if (cp.first == "ostree_server") {
       CopyFromConfig(ostree_server, cp.first, pt);
+    } else if (cp.first == "images_path") {
+      CopyFromConfig(images_path, cp.first, pt);
     } else if (cp.first == "packages_file") {
       CopyFromConfig(packages_file, cp.first, pt);
     } else if (cp.first == "fake_need_reboot") {
@@ -30,6 +32,7 @@ void PackageConfig::writeToStream(std::ostream& out_stream) const {
   writeOption(out_stream, os, "os");
   writeOption(out_stream, sysroot, "sysroot");
   writeOption(out_stream, ostree_server, "ostree_server");
+  writeOption(out_stream, images_path, "images_path");
   writeOption(out_stream, packages_file, "packages_file");
   writeOption(out_stream, fake_need_reboot, "fake_need_reboot");
 

--- a/src/libaktualizr/package_manager/packagemanagerconfig.h
+++ b/src/libaktualizr/package_manager/packagemanagerconfig.h
@@ -28,6 +28,7 @@ struct PackageConfig {
   std::string os;
   boost::filesystem::path sysroot;
   std::string ostree_server;
+  boost::filesystem::path images_path{"/var/sota/images"};
   boost::filesystem::path packages_file{"/usr/package.manifest"};
 
   // Options for simulation (to be used with "none")

--- a/src/libaktualizr/package_manager/packagemanagerfake_test.cc
+++ b/src/libaktualizr/package_manager/packagemanagerfake_test.cc
@@ -15,6 +15,93 @@
 #include "utilities/types.h"
 #include "utilities/utils.h"
 
+// Test creating, appending and reading binary targets.
+TEST(PackageManagerFake, Binary) {
+  TemporaryDirectory temp_dir;
+  Config config;
+  config.pacman.type = PACKAGE_MANAGER_NONE;
+  config.pacman.images_path = temp_dir.Path() / "images";
+  config.storage.path = temp_dir.Path();
+
+  auto storage = INvStorage::newStorage(config.storage);
+  PackageManagerFake pacman(config.pacman, config.bootloader, storage, nullptr);
+
+  Json::Value target_json;
+  target_json["hashes"]["sha256"] = "D9CD8155764C3543F10FAD8A480D743137466F8D55213C8EAEFCD12F06D43A80";
+  Uptane::Target target("aa.bin", target_json);
+
+  {
+    auto out = pacman.createTargetFile(target);
+    out << "a";
+  }
+  {
+    auto in = pacman.openTargetFile(target);
+    std::stringstream ss;
+    ss << in.rdbuf();
+    ASSERT_EQ(ss.str(), "a");
+  }
+  {
+    auto out = pacman.appendTargetFile(target);
+    out << "a";
+  }
+  {
+    auto in = pacman.openTargetFile(target);
+    std::stringstream ss;
+    ss << in.rdbuf();
+    ASSERT_EQ(ss.str(), "aa");
+  }
+  // Test overwriting
+  {
+    auto out = pacman.createTargetFile(target);
+    out << "a";
+  }
+  {
+    auto in = pacman.openTargetFile(target);
+    std::stringstream ss;
+    ss << in.rdbuf();
+    ASSERT_EQ(ss.str(), "a");
+  }
+
+  pacman.removeTargetFile(target);
+  EXPECT_THROW(pacman.appendTargetFile(target), std::runtime_error);
+  EXPECT_THROW(pacman.openTargetFile(target), std::runtime_error);
+}
+
+// Test listing and removing binary targets
+TEST(PackageManagerFake, ListRemove) {
+  TemporaryDirectory temp_dir;
+  Config config;
+  config.pacman.type = PACKAGE_MANAGER_NONE;
+  config.pacman.images_path = temp_dir.Path() / "images";
+  config.storage.path = temp_dir.Path();
+
+  auto storage = INvStorage::newStorage(config.storage);
+  PackageManagerFake pacman(config.pacman, config.bootloader, storage, nullptr);
+
+  Json::Value target_json;
+  target_json["hashes"]["sha256"] = "D9CD8155764C3543F10FAD8A480D743137466F8D55213C8EAEFCD12F06D43A80";
+  Uptane::Target t1("aa.bin", target_json);
+  target_json["hashes"]["sha256"] = "A81C31AC62620B9215A14FF00544CB07A55B765594F3AB3BE77E70923AE27CF1";
+  Uptane::Target t2("bb.bin", target_json);
+
+  pacman.createTargetFile(t1);
+  pacman.createTargetFile(t2);
+
+  auto targets = pacman.getTargetFiles();
+  ASSERT_EQ(targets.size(), 2);
+  ASSERT_EQ(targets.at(0).filename(), "aa.bin");
+  ASSERT_EQ(targets.at(1).filename(), "bb.bin");
+
+  pacman.removeTargetFile(t1);
+  targets = pacman.getTargetFiles();
+  ASSERT_EQ(targets.size(), 1);
+  ASSERT_EQ(targets.at(0).filename(), "bb.bin");
+  EXPECT_FALSE(boost::filesystem::exists(temp_dir.Path() / "images" /
+                                         "D9CD8155764C3543F10FAD8A480D743137466F8D55213C8EAEFCD12F06D43A80"));
+  EXPECT_TRUE(boost::filesystem::exists(temp_dir.Path() / "images" /
+                                        "A81C31AC62620B9215A14FF00544CB07A55B765594F3AB3BE77E70923AE27CF1"));
+}
+
 /*
  * Verify a stored target.
  * Verify that a target is unavailable.
@@ -26,15 +113,16 @@ TEST(PackageManagerFake, Verify) {
   TemporaryDirectory temp_dir;
   Config config;
   config.pacman.type = PACKAGE_MANAGER_NONE;
+  config.pacman.images_path = temp_dir.Path() / "images";
   config.storage.path = temp_dir.Path();
   std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
 
   Uptane::EcuMap primary_ecu{{Uptane::EcuSerial("primary"), Uptane::HardwareIdentifier("primary_hw")}};
   const int length = 4;
-  uint8_t content[length];
+  char content[length];
   memcpy(content, "good", length);
   MultiPartSHA256Hasher hasher;
-  hasher.update(content, length);
+  hasher.update(reinterpret_cast<uint8_t *>(content), length);
   const std::string hash = hasher.getHexDigest();
   Uptane::Target target("some-pkg", primary_ecu, {Hash(Hash::Type::kSha256, hash)}, length, "");
 
@@ -43,29 +131,29 @@ TEST(PackageManagerFake, Verify) {
   EXPECT_EQ(fakepm.verifyTarget(target), TargetStatus::kNotFound);
 
   // Target has a bad hash.
-  auto whandle = storage->allocateTargetFile(target);
-  uint8_t content_bad[length + 1];
+  auto whandle = fakepm.createTargetFile(target);
+  char content_bad[length + 1];
   memset(content_bad, 0, length + 1);
-  EXPECT_EQ(whandle->wfeed(content_bad, length), length);
-  whandle->wcommit();
+  whandle.write(content_bad, length);
+  whandle.close();
   EXPECT_EQ(fakepm.verifyTarget(target), TargetStatus::kHashMismatch);
 
   // Target is oversized.
-  whandle = storage->allocateTargetFile(target);
-  EXPECT_EQ(whandle->wfeed(content_bad, length + 1), length + 1);
-  whandle->wcommit();
+  whandle = fakepm.createTargetFile(target);
+  whandle.write(content_bad, length + 1);
+  whandle.close();
   EXPECT_EQ(fakepm.verifyTarget(target), TargetStatus::kOversized);
 
   // Target is incomplete.
-  whandle = storage->allocateTargetFile(target);
-  EXPECT_EQ(whandle->wfeed(content, length - 1), length - 1);
-  whandle->wcommit();
+  whandle = fakepm.createTargetFile(target);
+  whandle.write(content, length - 1);
+  whandle.close();
   EXPECT_EQ(fakepm.verifyTarget(target), TargetStatus::kIncomplete);
 
   // Target is good.
-  whandle = storage->allocateTargetFile(target);
-  EXPECT_EQ(whandle->wfeed(content, length), length);
-  whandle->wcommit();
+  whandle = fakepm.createTargetFile(target);
+  whandle.write(content, length);
+  whandle.close();
   EXPECT_EQ(fakepm.verifyTarget(target), TargetStatus::kGood);
 }
 

--- a/src/libaktualizr/package_manager/packagemanagerinterface.cc
+++ b/src/libaktualizr/package_manager/packagemanagerinterface.cc
@@ -13,7 +13,7 @@ struct DownloadMetaStruct {
         progress_cb{std::move(progress_cb_in)} {}
   uintmax_t downloaded_length{0};
   unsigned int last_progress{0};
-  std::unique_ptr<StorageTargetWHandle> fhandle;
+  std::ofstream fhandle;
   const Hash::Type hash_type;
   MultiPartHasher& hasher() {
     switch (hash_type) {
@@ -37,18 +37,16 @@ struct DownloadMetaStruct {
 static size_t DownloadHandler(char* contents, size_t size, size_t nmemb, void* userp) {
   assert(userp);
   auto* ds = static_cast<DownloadMetaStruct*>(userp);
-  uint64_t downloaded = size * nmemb;
+  size_t downloaded = size * nmemb;
   uint64_t expected = ds->target.length();
   if ((ds->downloaded_length + downloaded) > expected) {
     return downloaded + 1;  // curl will abort if return unexpected size;
   }
 
-  // incomplete writes will stop the download (written_size != nmemb*size)
-  size_t written_size = ds->fhandle->wfeed(reinterpret_cast<uint8_t*>(contents), downloaded);
-  ds->hasher().update(reinterpret_cast<const unsigned char*>(contents), written_size);
-
+  ds->fhandle.write(contents, static_cast<std::streamsize>(downloaded));
+  ds->hasher().update(reinterpret_cast<const unsigned char*>(contents), downloaded);
   ds->downloaded_length += downloaded;
-  return written_size;
+  return downloaded;
 }
 
 static int ProgressHandler(void* clientp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow) {
@@ -70,14 +68,13 @@ static int ProgressHandler(void* clientp, curl_off_t dltotal, curl_off_t dlnow, 
   return 0;
 }
 
-static void restoreHasherState(MultiPartHasher& hasher, StorageTargetRHandle* data) {
-  size_t data_len;
+static void restoreHasherState(MultiPartHasher& hasher, std::ifstream data) {
   static constexpr size_t buf_len = 1024;
   std::array<uint8_t, buf_len> buf{};
   do {
-    data_len = data->rread(buf.data(), buf.size());
-    hasher.update(buf.data(), data_len);
-  } while (data_len != 0);
+    data.read(reinterpret_cast<char*>(buf.data()), buf.size());
+    hasher.update(buf.data(), static_cast<uint64_t>(data.gcount()));
+  } while (data.gcount() != 0);
 }
 
 bool PackageManagerInterface::fetchTarget(const Uptane::Target& target, Uptane::Fetcher& fetcher,
@@ -97,26 +94,24 @@ bool PackageManagerInterface::fetchTarget(const Uptane::Target& target, Uptane::
     std::unique_ptr<DownloadMetaStruct> ds = std_::make_unique<DownloadMetaStruct>(target, progress_cb, token);
     if (target.length() == 0) {
       LOG_INFO << "Skipping download of target with length 0";
-      ds->fhandle = storage_->allocateTargetFile(target);
+      ds->fhandle = createTargetFile(target);
       return true;
     }
     if (exists == TargetStatus::kIncomplete) {
       LOG_INFO << "Continuing incomplete download of file " << target.filename();
-      auto target_check = storage_->checkTargetFile(target);
+      auto target_check = checkTargetFile(target);
       ds->downloaded_length = target_check->first;
-      auto target_handle = storage_->openTargetFile(target);
-      ::restoreHasherState(ds->hasher(), target_handle.get());
-      target_handle->rclose();
-      ds->fhandle = target_handle->toWriteHandle();
+      ::restoreHasherState(ds->hasher(), openTargetFile(target));
+      ds->fhandle = appendTargetFile(target);
     } else {
       // If the target was found, but is oversized or the hash doesn't match,
       // just start over.
       LOG_DEBUG << "Initiating download of file " << target.filename();
-      ds->fhandle = storage_->allocateTargetFile(target);
+      ds->fhandle = createTargetFile(target);
     }
 
     const uint64_t required_bytes = target.length() - ds->downloaded_length;
-    if (checkAvailableDiskSpace(required_bytes)) {
+    if (!checkAvailableDiskSpace(required_bytes)) {
       throw std::runtime_error("Insufficient disk space available to download target");
     }
 
@@ -135,19 +130,19 @@ bool PackageManagerInterface::fetchTarget(const Uptane::Target& target, Uptane::
                        " try to download the image from the beginning: "
                     << target_url;
         ds = std_::make_unique<DownloadMetaStruct>(target, progress_cb, token);
-        ds->fhandle = storage_->allocateTargetFile(target);
+        ds->fhandle = createTargetFile(target);
         continue;
       }
 
       if (!response.wasInterrupted()) {
         break;
       }
-      ds->fhandle.reset();
+      ds->fhandle.close();
       // sleep if paused or abort the download
       if (!token->canContinue()) {
         throw Uptane::Exception("image", "Download of a target was aborted");
       }
-      ds->fhandle = storage_->openTargetFile(target)->toWriteHandle();
+      ds->fhandle = appendTargetFile(target);
     }
     LOG_TRACE << "Download status: " << response.getStatusStr() << std::endl;
     if (!response.isOk()) {
@@ -157,10 +152,11 @@ bool PackageManagerInterface::fetchTarget(const Uptane::Target& target, Uptane::
       throw Uptane::Exception("image", "Could not download file, error: " + response.error_message);
     }
     if (!target.MatchHash(Hash(ds->hash_type, ds->hasher().getHexDigest()))) {
-      ds->fhandle->wabort();
+      ds->fhandle.close();
+      removeTargetFile(target);
       throw Uptane::TargetHashMismatch(target.filename());
     }
-    ds->fhandle->wcommit();
+    ds->fhandle.close();
     result = true;
   } catch (const std::exception& e) {
     LOG_WARNING << "Error while downloading a target: " << e.what();
@@ -169,7 +165,7 @@ bool PackageManagerInterface::fetchTarget(const Uptane::Target& target, Uptane::
 }
 
 TargetStatus PackageManagerInterface::verifyTarget(const Uptane::Target& target) const {
-  auto target_exists = storage_->checkTargetFile(target);
+  auto target_exists = checkTargetFile(target);
   if (!target_exists) {
     LOG_DEBUG << "File " << target.filename() << " with expected hash not found in the database.";
     return TargetStatus::kNotFound;
@@ -184,9 +180,7 @@ TargetStatus PackageManagerInterface::verifyTarget(const Uptane::Target& target)
   // Even if the file exists and the length matches, recheck the hash.
   DownloadMetaStruct ds(target, nullptr, nullptr);
   ds.downloaded_length = target_exists->first;
-  auto target_handle = storage_->openTargetFile(target);
-  ::restoreHasherState(ds.hasher(), target_handle.get());
-  target_handle->rclose();
+  ::restoreHasherState(ds.hasher(), openTargetFile(target));
   if (!target.MatchHash(Hash(ds.hash_type, ds.hasher().getHexDigest()))) {
     LOG_ERROR << "Target exists with expected length, but hash does not match metadata! " << target;
     return TargetStatus::kHashMismatch;
@@ -212,4 +206,71 @@ bool PackageManagerInterface::checkAvailableDiskSpace(const uint64_t required_by
               << ", available: " << available_bytes << ", reserved: " << reserved_bytes;
     return false;
   }
+}
+
+boost::optional<std::pair<uintmax_t, std::string>> PackageManagerInterface::checkTargetFile(
+    const Uptane::Target& target) const {
+  std::string filename = storage_->getTargetFilename(target.filename());
+  if (!filename.empty()) {
+    auto path = config.images_path / filename;
+    if (boost::filesystem::exists(path)) {
+      return {{boost::filesystem::file_size(path), path.string()}};
+    }
+  }
+  return boost::none;
+}
+
+std::ifstream PackageManagerInterface::openTargetFile(const Uptane::Target& target) const {
+  auto file = checkTargetFile(target);
+  if (!file) {
+    throw std::runtime_error("File doesn't exist for target " + target.filename());
+  }
+  std::ifstream stream(file->second, std::ios::binary);
+  if (!stream.good()) {
+    throw std::runtime_error("Can't open file " + file->second);
+  }
+  return stream;
+}
+
+std::ofstream PackageManagerInterface::createTargetFile(const Uptane::Target& target) {
+  std::string filename = target.hashes()[0].HashString();
+  std::string filepath = (config.images_path / filename).string();
+  boost::filesystem::create_directories(config.images_path);
+  std::ofstream stream(filepath, std::ios::binary | std::ios::ate);
+  if (!stream.good()) {
+    throw std::runtime_error("Can't write to file " + filepath);
+  }
+  storage_->storeTargetFilename(target.filename(), filename);
+  return stream;
+}
+
+std::ofstream PackageManagerInterface::appendTargetFile(const Uptane::Target& target) {
+  auto file = checkTargetFile(target);
+  if (!file) {
+    throw std::runtime_error("File doesn't exist for target " + target.filename());
+  }
+  std::ofstream stream(file->second, std::ios::binary | std::ios::app);
+  if (!stream.good()) {
+    throw std::runtime_error("Can't open file " + file->second);
+  }
+  return stream;
+}
+
+void PackageManagerInterface::removeTargetFile(const Uptane::Target& target) {
+  auto file = checkTargetFile(target);
+  if (!file) {
+    throw std::runtime_error("File doesn't exist for target " + target.filename());
+  }
+  boost::filesystem::remove(file->second);
+  storage_->deleteTargetInfo(target.filename());
+}
+
+std::vector<Uptane::Target> PackageManagerInterface::getTargetFiles() {
+  std::vector<Uptane::Target> v;
+  auto names = storage_->getAllTargetNames();
+  v.reserve(names.size());
+  for (const auto& name : names) {
+    v.emplace_back(name, Uptane::EcuMap{}, std::vector<Hash>{}, 0);
+  }
+  return v;
 }

--- a/src/libaktualizr/package_manager/packagemanagerinterface.h
+++ b/src/libaktualizr/package_manager/packagemanagerinterface.h
@@ -52,6 +52,12 @@ class PackageManagerInterface {
                            const FetcherProgressCb& progress_cb, const api::FlowControlToken* token);
   virtual TargetStatus verifyTarget(const Uptane::Target& target) const;
   virtual bool checkAvailableDiskSpace(const uint64_t required_bytes) const;
+  virtual boost::optional<std::pair<uintmax_t, std::string>> checkTargetFile(const Uptane::Target& target) const;
+  virtual std::ofstream createTargetFile(const Uptane::Target& target);
+  virtual std::ofstream appendTargetFile(const Uptane::Target& target);
+  virtual std::ifstream openTargetFile(const Uptane::Target& target) const;
+  virtual void removeTargetFile(const Uptane::Target& target);
+  virtual std::vector<Uptane::Target> getTargetFiles();
 
  protected:
   PackageConfig config;

--- a/src/libaktualizr/package_manager/packagemanagerinterface.h
+++ b/src/libaktualizr/package_manager/packagemanagerinterface.h
@@ -51,6 +51,7 @@ class PackageManagerInterface {
   virtual bool fetchTarget(const Uptane::Target& target, Uptane::Fetcher& fetcher, const KeyManager& keys,
                            const FetcherProgressCb& progress_cb, const api::FlowControlToken* token);
   virtual TargetStatus verifyTarget(const Uptane::Target& target) const;
+  virtual bool checkAvailableDiskSpace(const uint64_t required_bytes) const;
 
  protected:
   PackageConfig config;

--- a/src/libaktualizr/primary/aktualizr.cc
+++ b/src/libaktualizr/primary/aktualizr.cc
@@ -210,14 +210,10 @@ Aktualizr::InstallationLog Aktualizr::GetInstallationLog() {
   return ilog;
 }
 
-std::vector<Uptane::Target> Aktualizr::GetStoredTargets() { return storage_->getTargetFiles(); }
+std::vector<Uptane::Target> Aktualizr::GetStoredTargets() { return uptane_client_->getStoredTargets(); }
 
-void Aktualizr::DeleteStoredTarget(const Uptane::Target &target) { storage_->removeTargetFile(target.filename()); }
+void Aktualizr::DeleteStoredTarget(const Uptane::Target &target) { uptane_client_->deleteStoredTarget(target); }
 
-std::unique_ptr<StorageTargetRHandle> Aktualizr::OpenStoredTarget(const Uptane::Target &target) {
-  auto handle = storage_->openTargetFile(target);
-  if (handle->isPartial()) {
-    throw std::runtime_error("Target was partially downloaded");
-  }
-  return handle;
+std::ifstream Aktualizr::OpenStoredTarget(const Uptane::Target &target) {
+  return uptane_client_->openStoredTarget(target);
 }

--- a/src/libaktualizr/primary/aktualizr.h
+++ b/src/libaktualizr/primary/aktualizr.h
@@ -129,7 +129,7 @@ class Aktualizr {
    * @param target Target object matching the desired target in the storage.
    * @return Handle to the stored binary. nullptr if none is found.
    */
-  std::unique_ptr<StorageTargetRHandle> OpenStoredTarget(const Uptane::Target& target);
+  std::ifstream OpenStoredTarget(const Uptane::Target& target);
 
   /**
    * Install targets.

--- a/src/libaktualizr/primary/aktualizr_helpers.cc
+++ b/src/libaktualizr/primary/aktualizr_helpers.cc
@@ -17,7 +17,7 @@ void targets_autoclean_cb(Aktualizr &aktualizr, const std::shared_ptr<event::Bas
     auto start = entry.installs.size() >= 2 ? entry.installs.end() - 2 : entry.installs.begin();
     for (auto it = start; it != entry.installs.end(); it++) {
       auto fit = std::find_if(installed_targets.begin(), installed_targets.end(),
-                              [&it](const Uptane::Target &t2) { return it->sha256Hash() == t2.sha256Hash(); });
+                              [&it](const Uptane::Target &t2) { return it->filename() == t2.filename(); });
 
       if (fit == installed_targets.end()) {
         continue;

--- a/src/libaktualizr/primary/aktualizr_test.cc
+++ b/src/libaktualizr/primary/aktualizr_test.cc
@@ -1194,6 +1194,7 @@ TEST(Aktualizr, FullMultipleSecondaries) {
   conf.provision.primary_ecu_serial = "testecuserial";
   conf.provision.primary_ecu_hardware_id = "testecuhwid";
   conf.storage.path = temp_dir.Path();
+  conf.pacman.images_path = temp_dir.Path() / "images";
   conf.tls.server = http->tls_server;
   conf.uptane.director_server = http->tls_server + "/director";
   conf.uptane.repo_server = http->tls_server + "/repo";
@@ -1821,7 +1822,7 @@ TEST(Aktualizr, InstallWithUpdates) {
   primary_json["hashes"]["sha512"] =
       "91814ad1c13ebe2af8d65044893633c4c3ce964edb8cb58b0f357406c255f7be94f42547e108b300346a42cd57662e4757b9d843b7acbc09"
       "0df0bc05fe55297f";
-  primary_json["length"] = 2;
+  primary_json["length"] = 59;
   Uptane::Target primary_target("primary_firmware.txt", primary_json);
 
   Json::Value secondary_json;
@@ -1829,7 +1830,7 @@ TEST(Aktualizr, InstallWithUpdates) {
   secondary_json["hashes"]["sha512"] =
       "7dbae4c36a2494b731a9239911d3085d53d3e400886edb4ae2b9b78f40bda446649e83ba2d81653f614cc66f5dd5d4dbd95afba854f148af"
       "bfae48d0ff4cc38a";
-  secondary_json["length"] = 2;
+  secondary_json["length"] = 15;
   Uptane::Target secondary_target("secondary_firmware.txt", secondary_json);
 
   // First try installing nothing. Nothing should happen.
@@ -1843,9 +1844,9 @@ TEST(Aktualizr, InstallWithUpdates) {
 
   result::UpdateCheck update_result = aktualizr.CheckUpdates().get();
   aktualizr.Download(update_result.updates).get();
-  EXPECT_NE(aktualizr.OpenStoredTarget(primary_target).get(), nullptr)
+  EXPECT_NO_THROW(aktualizr.OpenStoredTarget(primary_target))
       << "Primary firmware is not present in storage after the download";
-  EXPECT_NE(aktualizr.OpenStoredTarget(secondary_target).get(), nullptr)
+  EXPECT_NO_THROW(aktualizr.OpenStoredTarget(secondary_target))
       << "Secondary firmware is not present in storage after the download";
 
   // After updates have been downloaded, try to install them.

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -1340,7 +1340,8 @@ std::future<data::ResultCode::Numeric> SotaUptaneClient::sendFirmwareAsync(Uptan
       data_to_send = secondaryTreehubCredentials();
     } else {
       std::stringstream sstr;
-      sstr << *storage->openTargetFile(target);
+      auto str = package_manager_->openTargetFile(target);
+      sstr << str.rdbuf();
       data_to_send = sstr.str();
     }
 

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -75,6 +75,16 @@ class SotaUptaneClient {
   void completeInstall() const;
   Uptane::LazyTargetsList allTargets() const;
   Uptane::Target getCurrent() const { return package_manager_->getCurrent(); }
+  std::vector<Uptane::Target> getStoredTargets() const { return package_manager_->getTargetFiles(); }
+  void deleteStoredTarget(const Uptane::Target &target) { package_manager_->removeTargetFile(target); }
+  std::ifstream openStoredTarget(const Uptane::Target &target) {
+    auto status = package_manager_->verifyTarget(target);
+    if (status == TargetStatus::kGood) {
+      return package_manager_->openTargetFile(target);
+    } else {
+      throw std::runtime_error("Failed to open Target");
+    }
+  }
 
   void updateImageMeta();  // TODO: make private once aktualizr has a proper TUF API
   void checkImageMetaOffline();

--- a/src/libaktualizr/storage/invstorage.h
+++ b/src/libaktualizr/storage/invstorage.h
@@ -219,7 +219,6 @@ class INvStorage {
   virtual bool loadDeviceDataHash(const std::string& data_type, std::string* hash) const = 0;
   virtual void clearDeviceData() = 0;
 
-  virtual bool checkAvailableDiskSpace(uint64_t required_bytes) const = 0;
   virtual boost::optional<std::pair<uintmax_t, std::string>> checkTargetFile(const Uptane::Target& target) const = 0;
 
   // Incremental file API

--- a/src/libaktualizr/storage/sqlstorage.cc
+++ b/src/libaktualizr/storage/sqlstorage.cc
@@ -1,7 +1,6 @@
 #include "sqlstorage.h"
 
 #include <sys/stat.h>
-#include <sys/statvfs.h>
 #include <iostream>
 #include <map>
 #include <memory>
@@ -1685,25 +1684,6 @@ void SQLStorage::clearDeviceData() {
   if (db.exec("DELETE FROM device_data;", nullptr, nullptr) != SQLITE_OK) {
     LOG_ERROR << "Can't clear device_data: " << db.errmsg();
     return;
-  }
-}
-
-bool SQLStorage::checkAvailableDiskSpace(const uint64_t required_bytes) const {
-  struct statvfs stvfsbuf {};
-  const int stat_res = statvfs(dbPath().c_str(), &stvfsbuf);
-  if (stat_res < 0) {
-    LOG_WARNING << "Unable to read filesystem statistics: error code " << stat_res;
-    return true;
-  }
-  const uint64_t available_bytes = (static_cast<uint64_t>(stvfsbuf.f_bsize) * stvfsbuf.f_bavail);
-  const uint64_t reserved_bytes = 1 << 20;
-
-  if (required_bytes + reserved_bytes < available_bytes) {
-    return true;
-  } else {
-    LOG_ERROR << "Insufficient disk space available to download target! Required: " << required_bytes
-              << ", available: " << available_bytes << ", reserved: " << reserved_bytes;
-    return false;
   }
 }
 

--- a/src/libaktualizr/storage/sqlstorage.cc
+++ b/src/libaktualizr/storage/sqlstorage.cc
@@ -1687,209 +1687,39 @@ void SQLStorage::clearDeviceData() {
   }
 }
 
-boost::optional<std::pair<uintmax_t, std::string>> SQLStorage::checkTargetFile(const Uptane::Target& target) const {
+void SQLStorage::storeTargetFilename(const std::string& targetname, const std::string& filename) const {
+  SQLite3Guard db = dbConnection();
+  auto statement = db.prepareStatement<std::string, std::string>(
+      "INSERT OR REPLACE INTO target_images (targetname, filename) VALUES (?, ?);", targetname, filename);
+
+  if (statement.step() != SQLITE_DONE) {
+    LOG_ERROR << "Statement step failure: " << db.errmsg();
+    throw std::runtime_error("Could not write to db");
+  }
+}
+
+std::string SQLStorage::getTargetFilename(const std::string& targetname) const {
   SQLite3Guard db = dbConnection();
 
-  auto statement = db.prepareStatement<std::string>(
-      "SELECT sha256, sha512, filename FROM target_images WHERE targetname = ?;", target.filename());
+  auto statement =
+      db.prepareStatement<std::string>("SELECT filename FROM target_images WHERE targetname = ?;", targetname);
 
-  int statement_state;
-  while ((statement_state = statement.step()) == SQLITE_ROW) {
-    auto sha256 = statement.get_result_col_str(0);
-    auto sha512 = statement.get_result_col_str(1);
-    auto filename = statement.get_result_col_str(2);
-    if ((*sha256).empty() && (*sha512).empty()) {
-      // Old aktualizr didn't save checksums, this could require to redownload old images.
-      LOG_WARNING << "Image without checksum: " << target.filename();
-      continue;
-    }
-    bool sha256_match = false;
-    bool sha512_match = false;
-    if (!(*sha256).empty()) {
-      if (target.MatchHash(Hash(Hash::Type::kSha256, *sha256))) {
-        sha256_match = true;
-      }
-    }
-
-    if (!(*sha512).empty()) {
-      if (target.MatchHash(Hash(Hash::Type::kSha512, *sha512))) {
-        sha512_match = true;
-      }
-    }
-    if (((*sha256).empty() || sha256_match) && ((*sha512).empty() || sha512_match)) {
-      if (boost::filesystem::exists(images_path_ / *filename)) {
-        return {{boost::filesystem::file_size(images_path_ / *filename), *filename}};
-      } else {
-        return boost::none;
-      }
-    }
+  switch (statement.step()) {
+    case SQLITE_ROW:
+      return statement.get_result_col_str(0).value();
+    case SQLITE_DONE:
+      return {};
+    default:
+      throw std::runtime_error(db.errmsg().insert(0, "Error reading target filename from db: "));
   }
-
-  if (statement_state == SQLITE_DONE) {
-    return boost::none;
-  }
-  assert(statement_state != SQLITE_ROW);  // from the previous loop precondition
-  LOG_ERROR << "Statement step failure: " << db.errmsg();
-
-  return boost::none;
 }
 
-class SQLTargetWHandle : public StorageTargetWHandle {
- public:
-  SQLTargetWHandle(const SQLStorage& storage, Uptane::Target target)
-      : db_path_(storage.dbPath()), target_(std::move(target)), storage_(&storage) {
-    StorageTargetWHandle::WriteError exc("could not save file " + target_.filename() + " to the filesystem");
-
-    std::string sha256Hash;
-    std::string sha512Hash;
-    for (const auto& hash : target_.hashes()) {
-      if (hash.type() == Hash::Type::kSha256) {
-        sha256Hash = hash.HashString();
-      } else if (hash.type() == Hash::Type::kSha512) {
-        sha512Hash = hash.HashString();
-      }
-    }
-    std::string filename = (storage.images_path_ / target_.hashes()[0].HashString()).string();
-    SQLite3Guard db = storage_->dbConnection();
-    auto statement = db.prepareStatement<std::string, std::string, std::string>(
-        "INSERT OR REPLACE INTO target_images (targetname, sha256, sha512, filename) VALUES ( ?, ?, ?, ?);",
-        target_.filename(), sha256Hash, sha512Hash, target_.hashes()[0].HashString());
-
-    if (statement.step() != SQLITE_DONE) {
-      LOG_ERROR << "Statement step failure: " << db.errmsg();
-      throw exc;
-    }
-    boost::filesystem::create_directories(storage.images_path_);
-    stream_.open(filename);
-    if (!stream_.good()) {
-      LOG_ERROR << "Could not open image for write: " << storage.images_path_ / target_.filename();
-      throw exc;
-    }
-  }
-
-  ~SQLTargetWHandle() override {
-    try {
-      SQLTargetWHandle::wcommit();
-    } catch (std::exception& ex) {
-      LOG_ERROR << "Failed to commit to database: " << ex.what();
-    } catch (...) {
-      LOG_ERROR << "Failed to commit to database: unknown error";
-    }
-  }
-
-  size_t wfeed(const uint8_t* buf, size_t size) override {
-    stream_.write(reinterpret_cast<const char*>(buf), static_cast<std::streamsize>(size));
-    written_size_ += size;
-
-    return size;
-  }
-
-  void wcommit() override {
-    if (stream_) {
-      stream_.close();
-    }
-  }
-
-  void wabort() noexcept override {
-    if (stream_) {
-      stream_.close();
-    }
-
-    if (storage_ != nullptr) {
-      SQLite3Guard db = storage_->dbConnection();
-      auto statement =
-          db.prepareStatement<std::string>("DELETE FROM target_images WHERE targetname=?;", target_.filename());
-      if (statement.step() != SQLITE_DONE) {
-        LOG_ERROR << "could not delete " << target_.filename() << " from sql storage";
-      }
-    }
-  }
-
-  friend class SQLTargetRHandle;
-
- private:
-  SQLTargetWHandle(const boost::filesystem::path& db_path, Uptane::Target target,
-                   const boost::filesystem::path& image_path, const uintmax_t& start_from = 0)
-      : db_path_(db_path), target_(std::move(target)) {
-    stream_.open(image_path.string(), std::ofstream::out | std::ofstream::app);
-    if (!stream_.good()) {
-      LOG_ERROR << "Could not open image for write: " << image_path;
-      throw StorageTargetWHandle::WriteError("could not open file for write: " + image_path.string());
-    }
-
-    written_size_ = start_from;
-  }
-  boost::filesystem::path db_path_;
-  Uptane::Target target_;
-  std::ofstream stream_;
-  const SQLStorage* storage_ = nullptr;
-};
-
-std::unique_ptr<StorageTargetWHandle> SQLStorage::allocateTargetFile(const Uptane::Target& target) {
-  return std::unique_ptr<StorageTargetWHandle>(new SQLTargetWHandle(*this, target));
-}
-
-class SQLTargetRHandle : public StorageTargetRHandle {
- public:
-  SQLTargetRHandle(const SQLStorage& storage, Uptane::Target target)
-      : db_path_(storage.dbPath()), target_(std::move(target)), size_(0) {
-    StorageTargetRHandle::ReadError exc("could not read file " + target_.filename() + " from sql storage");
-
-    auto exists = storage.checkTargetFile(target_);
-    if (!exists) {
-      LOG_ERROR << "File " << target_.filename() << " with expected hash not found in the database!";
-      throw exc;
-    }
-
-    size_ = exists->first;
-    partial_ = size_ < target_.length();
-    image_path_ = storage.images_path_ / exists->second;
-    stream_.open(image_path_.string());
-    if (!stream_.good()) {
-      LOG_ERROR << "Could not open image: " << storage.images_path_ / target_.filename();
-      throw exc;
-    }
-  }
-
-  ~SQLTargetRHandle() override { SQLTargetRHandle::rclose(); }
-
-  uintmax_t rsize() const override { return size_; }
-
-  size_t rread(uint8_t* buf, size_t size) override {
-    stream_.read(reinterpret_cast<char*>(buf), static_cast<std::streamsize>(size));
-    return static_cast<size_t>(stream_.gcount());
-  }
-
-  void rclose() noexcept override {
-    if (stream_.is_open()) {
-      stream_.close();
-    }
-  }
-
-  bool isPartial() const noexcept override { return partial_; }
-  std::unique_ptr<StorageTargetWHandle> toWriteHandle() override {
-    return std::unique_ptr<StorageTargetWHandle>(new SQLTargetWHandle(db_path_, target_, image_path_, size_));
-  }
-
- private:
-  boost::filesystem::path db_path_;
-  Uptane::Target target_;
-  uintmax_t size_;
-  bool partial_{false};
-  boost::filesystem::path image_path_;
-  std::ifstream stream_;
-};
-
-std::unique_ptr<StorageTargetRHandle> SQLStorage::openTargetFile(const Uptane::Target& target) const {
-  return std_::make_unique<SQLTargetRHandle>(*this, target);
-}
-
-std::vector<Uptane::Target> SQLStorage::getTargetFiles() {
+std::vector<std::string> SQLStorage::getAllTargetNames() const {
   SQLite3Guard db = dbConnection();
 
-  auto statement = db.prepareStatement<>("SELECT targetname, filename, sha256, sha512 FROM target_images;");
+  auto statement = db.prepareStatement<>("SELECT targetname FROM target_images;");
 
-  std::vector<Uptane::Target> v;
+  std::vector<std::string> names;
 
   int result = statement.step();
   while (result != SQLITE_DONE) {
@@ -1897,57 +1727,21 @@ std::vector<Uptane::Target> SQLStorage::getTargetFiles() {
       LOG_ERROR << "Statement step failure: " << db.errmsg();
       throw std::runtime_error("Error getting target files");
     }
-
-    auto tname = statement.get_result_col_str(0).value();
-    auto fname = statement.get_result_col_str(1).value();
-    auto tsize = boost::filesystem::file_size(images_path_ / fname);
-    auto sha256 = statement.get_result_col_str(2).value();
-    auto sha512 = statement.get_result_col_str(3).value();
-
-    std::vector<Hash> hashes;
-    if (!sha256.empty()) {
-      hashes.emplace_back(Hash::Type::kSha256, sha256);
-    }
-    if (!sha512.empty()) {
-      hashes.emplace_back(Hash::Type::kSha512, sha512);
-    }
-    v.emplace_back(tname, Uptane::EcuMap{}, hashes, tsize);
-
+    names.push_back(statement.get_result_col_str(0).value());
     result = statement.step();
   }
-
-  return v;
+  return names;
 }
 
-void SQLStorage::removeTargetFile(const std::string& target_name) {
+void SQLStorage::deleteTargetInfo(const std::string& targetname) const {
   SQLite3Guard db = dbConnection();
 
-  db.beginTransaction();
-
-  auto statement =
-      db.prepareStatement<std::string>("SELECT filename FROM target_images WHERE targetname = ?;", target_name);
-
-  if (statement.step() != SQLITE_ROW) {
-    LOG_ERROR << "Statement step failure: " << db.errmsg();
-    throw std::runtime_error("Could not find target file");
-  }
-
-  std::string filename = statement.get_result_col_str(0).value();
-
-  statement = db.prepareStatement<std::string>("DELETE FROM target_images WHERE targetname=?;", target_name);
+  auto statement = db.prepareStatement<std::string>("DELETE FROM target_images WHERE targetname=?;", targetname);
 
   if (statement.step() != SQLITE_DONE) {
     LOG_ERROR << "Statement step failure: " << db.errmsg();
     throw std::runtime_error("Could not remove target file");
   }
-  try {
-    boost::filesystem::remove(images_path_ / filename);
-  } catch (std::exception& e) {
-    LOG_ERROR << "Could not remove target file";
-    throw;
-  }
-
-  db.commitTransaction();
 }
 
 void SQLStorage::cleanUp() { boost::filesystem::remove_all(dbPath()); }

--- a/src/libaktualizr/storage/sqlstorage.h
+++ b/src/libaktualizr/storage/sqlstorage.h
@@ -100,8 +100,6 @@ class SQLStorage : public SQLStorageBase, public INvStorage {
   bool loadDeviceDataHash(const std::string& data_type, std::string* hash) const override;
   void clearDeviceData() override;
 
-  bool checkAvailableDiskSpace(uint64_t required_bytes) const override;
-
   std::unique_ptr<StorageTargetWHandle> allocateTargetFile(const Uptane::Target& target) override;
   std::unique_ptr<StorageTargetRHandle> openTargetFile(const Uptane::Target& target) const override;
   boost::optional<std::pair<uintmax_t, std::string>> checkTargetFile(const Uptane::Target& target) const override;

--- a/src/libaktualizr/storage/sqlstorage.h
+++ b/src/libaktualizr/storage/sqlstorage.h
@@ -100,17 +100,15 @@ class SQLStorage : public SQLStorageBase, public INvStorage {
   bool loadDeviceDataHash(const std::string& data_type, std::string* hash) const override;
   void clearDeviceData() override;
 
-  std::unique_ptr<StorageTargetWHandle> allocateTargetFile(const Uptane::Target& target) override;
-  std::unique_ptr<StorageTargetRHandle> openTargetFile(const Uptane::Target& target) const override;
-  boost::optional<std::pair<uintmax_t, std::string>> checkTargetFile(const Uptane::Target& target) const override;
-  std::vector<Uptane::Target> getTargetFiles() override;
-  void removeTargetFile(const std::string& target_name) override;
+  void storeTargetFilename(const std::string& targetname, const std::string& filename) const override;
+  std::string getTargetFilename(const std::string& targetname) const override;
+  std::vector<std::string> getAllTargetNames() const override;
+  void deleteTargetInfo(const std::string& targetname) const override;
+
   void cleanUp() override;
   StorageType type() override { return StorageType::kSqlite; };
 
  private:
-  boost::filesystem::path images_path_{sqldb_path_.parent_path() / "images"};
-
   void cleanMetaVersion(Uptane::RepositoryType repo, const Uptane::Role& role);
 };
 

--- a/src/libaktualizr/uptane/uptane_network_test.cc
+++ b/src/libaktualizr/uptane/uptane_network_test.cc
@@ -129,6 +129,7 @@ TEST(UptaneNetwork, no_errors_sqlite) {
 TEST(UptaneNetwork, DownloadFailure) {
   TemporaryDirectory temp_dir;
   conf.storage.path = temp_dir.Path();
+  conf.pacman.images_path = temp_dir.Path() / "images";
   conf.provision.expiry_days = "download_failure";
   conf.provision.primary_ecu_serial = "download_failure";
   conf.provision.primary_ecu_hardware_id = "hardware_id";

--- a/tests/test_install_aktualizr_and_update.sh
+++ b/tests/test_install_aktualizr_and_update.sh
@@ -25,8 +25,17 @@ $1/src/uptane_generator/uptane-generator signtargets --path "$TEST_INSTALL_DESTD
 
 mkdir -m 700 -p "$TEMP_DIR/import"
 cp ./tests/test_data/prov_testupdate/* "$TEMP_DIR/import"
-echo -e "[storage]\\npath = \"$TEMP_DIR\"\\n[import]\\nbase_path = \"$TEMP_DIR/import\"" > "$TEMP_DIR/conf.toml"
-echo -e "[tls]\\nserver = \"http://localhost:$PORT\"" >> "$TEMP_DIR/conf.toml"
+cat << EOF > "$TEMP_DIR/conf.toml"
+[storage]
+path = "$TEMP_DIR"
+[import]
+base_path = "$TEMP_DIR/import"
+[tls]
+server = "http://localhost:$PORT"
+[pacman]
+images_path = "$TEMP_DIR/images"
+EOF
+
 $1/src/aktualizr_primary/aktualizr -c ./tests/config/testupdate.toml -c "$TEMP_DIR/conf.toml" once
 
 # check the updated file appeared in the installation directory and sha256sum matches expectation

--- a/tests/uptane_test_common.h
+++ b/tests/uptane_test_common.h
@@ -96,6 +96,7 @@ struct UptaneTestCommon {
     conf.provision.primary_ecu_hardware_id = "primary_hw";
     conf.storage.path = temp_dir.Path();
     conf.import.base_path = temp_dir.Path() / "import";
+    conf.pacman.images_path = temp_dir.Path() / "images";
     conf.tls.server = url;
     conf.bootloader.reboot_sentinel_dir = temp_dir.Path();
     UptaneTestCommon::addDefaultSecondary(conf, temp_dir, "secondary_ecu_serial", "secondary_hw");


### PR DESCRIPTION
Main changes:
- Move binary target handling logic from Storage class to package manager
- Add a configuration option for the path to downloaded files
- Use std::ifstream in public API instead of StorageRHandle