### PR TITLE
Feat/ota 4984/secondary replacement

### DIFF
--- a/src/aktualizr_info/aktualizr_info_test.cc
+++ b/src/aktualizr_info/aktualizr_info_test.cc
@@ -166,9 +166,8 @@ TEST_F(AktualizrInfoTest, PrintSecondaryNotRegisteredOrRemoved) {
   db_storage_->storeEcuSerials({{primary_ecu_serial, primary_hw_id}, {secondary_ecu_serial, secondary_hw_id}});
   db_storage_->storeEcuRegistered();
 
-  db_storage_->storeMisconfiguredEcus(
-      {{secondary_ecu_serial_not_reg, secondary_hw_id_not_reg, EcuState::kNotRegistered},
-       {secondary_ecu_serial_old, secondary_hw_id_old, EcuState::kOld}});
+  db_storage_->saveMisconfiguredEcu({secondary_ecu_serial_not_reg, secondary_hw_id_not_reg, EcuState::kUnused});
+  db_storage_->saveMisconfiguredEcu({secondary_ecu_serial_old, secondary_hw_id_old, EcuState::kOld});
 
   aktualizr_info_process_.run();
   ASSERT_FALSE(aktualizr_info_output.empty());

--- a/src/aktualizr_info/main.cc
+++ b/src/aktualizr_info/main.cc
@@ -357,7 +357,7 @@ int main(int argc, char **argv) {
     std::vector<MisconfiguredEcu> misconfigured_ecus;
     storage->loadMisconfiguredEcus(&misconfigured_ecus);
     if (misconfigured_ecus.size() != 0U) {
-      std::cout << "Removed or not registered ECUs:" << std::endl;
+      std::cout << "Removed or unregistered ECUs (deprecated):" << std::endl;
       std::vector<MisconfiguredEcu>::const_iterator it;
       for (it = misconfigured_ecus.begin(); it != misconfigured_ecus.end(); ++it) {
         std::cout << "   '" << it->serial << "' with hardware_id '" << it->hardware_id << "' "

--- a/src/aktualizr_primary/CMakeLists.txt
+++ b/src/aktualizr_primary/CMakeLists.txt
@@ -7,7 +7,9 @@ target_include_directories(aktualizr PUBLIC ${PROJECT_SOURCE_DIR}/third_party)
 
 install(TARGETS aktualizr RUNTIME DESTINATION bin COMPONENT aktualizr)
 
-add_aktualizr_test(NAME primary_secondary_registration SOURCES primary_secondary_registration_test.cc secondary.cc secondary_config.cc PROJECT_WORKING_DIRECTORY ARGS ${PROJECT_BINARY_DIR}/uptane_repos LIBRARIES PUBLIC aktualizr-posix virtual_secondary uptane_generator_lib)
+add_aktualizr_test(NAME primary_secondary_registration
+                   SOURCES primary_secondary_registration_test.cc secondary.cc secondary_config.cc
+                   PROJECT_WORKING_DIRECTORY LIBRARIES PUBLIC aktualizr-posix virtual_secondary uptane_generator_lib)
 target_include_directories(t_primary_secondary_registration PUBLIC ${PROJECT_SOURCE_DIR}/src/libaktualizr-posix)
 
 aktualizr_source_file_checks(${SOURCES} ${HEADERS} ${TEST_SOURCES})

--- a/src/aktualizr_primary/main.cc
+++ b/src/aktualizr_primary/main.cc
@@ -131,7 +131,7 @@ int main(int argc, char *argv[]) {
       try {
         Primary::initSecondaries(aktualizr, config.uptane.secondary_config_file);
       } catch (const std::exception &e) {
-        LOG_ERROR << "Failed to initialize Secondaries :" << e.what();
+        LOG_ERROR << "Failed to initialize Secondaries: " << e.what();
         LOG_ERROR << "Exiting...";
         return EXIT_FAILURE;
       }

--- a/src/aktualizr_secondary/aktualizr_secondary.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary.cc
@@ -199,7 +199,7 @@ bool AktualizrSecondary::doFullVerification(const Metadata& metadata) {
 
 void AktualizrSecondary::uptaneInitialize() {
   if (keys_->generateUptaneKeyPair().size() == 0) {
-    throw std::runtime_error("Failed to generate uptane key pair");
+    throw std::runtime_error("Failed to generate Uptane key pair");
   }
 
   // from uptane/initialize.cc but we only take care of our own serial/hwid

--- a/src/aktualizr_secondary/aktualizr_secondary_factory.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_factory.cc
@@ -30,6 +30,8 @@ AktualizrSecondary::Ptr AktualizrSecondaryFactory::create(const AktualizrSeconda
 
     if (installed_version_res && !!current_version) {
       current_target_name = current_version->filename();
+    } else {
+      current_target_name = "unknown";
     }
 
     update_agent =

--- a/src/libaktualizr/primary/CMakeLists.txt
+++ b/src/libaktualizr/primary/CMakeLists.txt
@@ -20,6 +20,9 @@ add_aktualizr_test(NAME aktualizr SOURCES aktualizr_test.cc PROJECT_WORKING_DIRE
 add_dependencies(t_aktualizr uptane_repo_full_no_correlation_id)
 target_link_libraries(t_aktualizr virtual_secondary)
 
+add_aktualizr_test(NAME reregistration SOURCES reregistration_test.cc PROJECT_WORKING_DIRECTORY LIBRARIES uptane_generator_lib)
+target_link_libraries(t_reregistration virtual_secondary)
+
 if (BUILD_OSTREE)
     add_aktualizr_test(NAME aktualizr_fullostree SOURCES aktualizr_fullostree_test.cc PROJECT_WORKING_DIRECTORY ARGS $<TARGET_FILE:uptane-generator> ${PROJECT_BINARY_DIR}/ostree_repo)
     set_target_properties(t_aktualizr_fullostree PROPERTIES LINK_FLAGS -Wl,--export-dynamic)

--- a/src/libaktualizr/primary/aktualizr.cc
+++ b/src/libaktualizr/primary/aktualizr.cc
@@ -31,8 +31,6 @@ void Aktualizr::Initialize() {
   api_queue_.run();
 }
 
-bool Aktualizr::IsRegistered() const { return storage_->loadEcuRegistered(); }
-
 bool Aktualizr::UptaneCycle() {
   result::UpdateCheck update_result = CheckUpdates().get();
   if (update_result.updates.empty()) {

--- a/src/libaktualizr/primary/aktualizr.h
+++ b/src/libaktualizr/primary/aktualizr.h
@@ -33,11 +33,6 @@ class Aktualizr {
   void Initialize();
 
   /**
-   * Returns true if the device has been registered to the backend succesffully.
-   */
-  bool IsRegistered() const;
-
-  /**
    * Asynchronously run aktualizr indefinitely until Shutdown is called.
    * @param custom_hwinfo if not empty will be sent to the backend instead of `lshw` output
    * @return Empty std::future object

--- a/src/libaktualizr/primary/aktualizr_test.cc
+++ b/src/libaktualizr/primary/aktualizr_test.cc
@@ -45,22 +45,6 @@ void verifyNothingInstalled(const Json::Value& manifest) {
       "noimage");
 }
 
-static Primary::VirtualSecondaryConfig virtual_configuration(const boost::filesystem::path& client_dir) {
-  Primary::VirtualSecondaryConfig ecu_config;
-
-  ecu_config.partial_verifying = false;
-  ecu_config.full_client_dir = client_dir;
-  ecu_config.ecu_serial = "ecuserial3";
-  ecu_config.ecu_hardware_id = "hw_id3";
-  ecu_config.ecu_private_key = "sec.priv";
-  ecu_config.ecu_public_key = "sec.pub";
-  ecu_config.firmware_path = client_dir / "firmware.txt";
-  ecu_config.target_name_path = client_dir / "firmware_name.txt";
-  ecu_config.metadata_path = client_dir / "secondary_metadata";
-
-  return ecu_config;
-}
-
 /*
  * Initialize -> UptaneCycle -> no updates -> no further action or events.
  */
@@ -127,45 +111,6 @@ TEST(Aktualizr, FullNoUpdates) {
 }
 
 /*
- * Add Secondaries via API
- */
-TEST(Aktualizr, AddSecondary) {
-  TemporaryDirectory temp_dir;
-  auto http = std::make_shared<HttpFake>(temp_dir.Path(), "noupdates", fake_meta_dir);
-  Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
-
-  auto storage = INvStorage::newStorage(conf.storage);
-  UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
-
-  Primary::VirtualSecondaryConfig ecu_config = virtual_configuration(temp_dir.Path());
-
-  aktualizr.AddSecondary(std::make_shared<Primary::VirtualSecondary>(ecu_config));
-
-  aktualizr.Initialize();
-
-  EcuSerials serials;
-  storage->loadEcuSerials(&serials);
-
-  std::vector<std::string> expected_ecus = {"CA:FE:A6:D2:84:9D", "ecuserial3", "secondary_ecu_serial"};
-  EXPECT_EQ(serials.size(), 3);
-  for (const auto& ecu : serials) {
-    auto found = std::find(expected_ecus.begin(), expected_ecus.end(), ecu.first.ToString());
-    if (found != expected_ecus.end()) {
-      expected_ecus.erase(found);
-    } else {
-      FAIL() << "Unknown ecu: " << ecu.first.ToString();
-    }
-  }
-  EXPECT_EQ(expected_ecus.size(), 0);
-
-  // Historically, adding Secondaries after provisioning was not supported. Now
-  // it is.
-  ecu_config.ecu_serial = "ecuserial4";
-  auto sec4 = std::make_shared<Primary::VirtualSecondary>(ecu_config);
-  EXPECT_NO_THROW(aktualizr.AddSecondary(sec4));
-}
-
-/*
  * Compute device installation failure code as concatenation of ECU failure codes.
  */
 TEST(Aktualizr, DeviceInstallationResult) {
@@ -182,7 +127,7 @@ TEST(Aktualizr, DeviceInstallationResult) {
   storage->storeEcuSerials(serials);
 
   UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
-  Primary::VirtualSecondaryConfig ecu_config = virtual_configuration(temp_dir.Path());
+  Primary::VirtualSecondaryConfig ecu_config = UptaneTestCommon::altVirtualConfiguration(temp_dir.Path());
   aktualizr.AddSecondary(std::make_shared<Primary::VirtualSecondary>(ecu_config));
   aktualizr.Initialize();
 

--- a/src/libaktualizr/primary/aktualizr_test.cc
+++ b/src/libaktualizr/primary/aktualizr_test.cc
@@ -174,25 +174,21 @@ TEST(Aktualizr, DeviceInstallationResult) {
   Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
 
   auto storage = INvStorage::newStorage(conf.storage);
-
   EcuSerials serials{
-      {Uptane::EcuSerial("primary"), Uptane::HardwareIdentifier("primary_hw")},
+      {Uptane::EcuSerial("CA:FE:A6:D2:84:9D"), Uptane::HardwareIdentifier("primary_hw")},
       {Uptane::EcuSerial("secondary_ecu_serial"), Uptane::HardwareIdentifier("secondary_hw")},
       {Uptane::EcuSerial("ecuserial3"), Uptane::HardwareIdentifier("hw_id3")},
   };
   storage->storeEcuSerials(serials);
 
   UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
-
   Primary::VirtualSecondaryConfig ecu_config = virtual_configuration(temp_dir.Path());
-
   aktualizr.AddSecondary(std::make_shared<Primary::VirtualSecondary>(ecu_config));
-
   aktualizr.Initialize();
 
   storage->saveEcuInstallationResult(Uptane::EcuSerial("ecuserial3"), data::InstallationResult());
-  storage->saveEcuInstallationResult(Uptane::EcuSerial("primary"), data::InstallationResult());
-  storage->saveEcuInstallationResult(Uptane::EcuSerial("primary"),
+  storage->saveEcuInstallationResult(Uptane::EcuSerial("CA:FE:A6:D2:84:9D"), data::InstallationResult());
+  storage->saveEcuInstallationResult(Uptane::EcuSerial("CA:FE:A6:D2:84:9D"),
                                      data::InstallationResult(data::ResultCode::Numeric::kInstallFailed, ""));
 
   data::InstallationResult result;

--- a/src/libaktualizr/primary/aktualizr_test.cc
+++ b/src/libaktualizr/primary/aktualizr_test.cc
@@ -158,9 +158,11 @@ TEST(Aktualizr, AddSecondary) {
   }
   EXPECT_EQ(expected_ecus.size(), 0);
 
+  // Historically, adding Secondaries after provisioning was not supported. Now
+  // it is.
   ecu_config.ecu_serial = "ecuserial4";
   auto sec4 = std::make_shared<Primary::VirtualSecondary>(ecu_config);
-  EXPECT_THROW(aktualizr.AddSecondary(sec4), std::logic_error);
+  EXPECT_NO_THROW(aktualizr.AddSecondary(sec4));
 }
 
 /*

--- a/src/libaktualizr/primary/initializer.cc
+++ b/src/libaktualizr/primary/initializer.cc
@@ -36,13 +36,8 @@ void Initializer::resetDeviceId() { storage_->clearDeviceId(); }
 
 // Postcondition [(serial, hw_id)] is in the storage
 void Initializer::initEcuSerials() {
-  EcuSerials ecu_serials;
-
-  // TODO: the assumption now is that the set of connected ECUs doesn't change, but it might obviously
-  //   not be the case. ECU discovery seems to be a big story and should be worked on accordingly.
-  if (storage_->loadEcuSerials(&ecu_serials)) {
-    return;
-  }
+  EcuSerials stored_ecu_serials;
+  storage_->loadEcuSerials(&stored_ecu_serials);
 
   std::string primary_ecu_serial_local = config_.primary_ecu_serial;
   if (primary_ecu_serial_local.empty()) {
@@ -53,23 +48,67 @@ void Initializer::initEcuSerials() {
   if (primary_ecu_hardware_id.empty()) {
     primary_ecu_hardware_id = Utils::getHostname();
     if (primary_ecu_hardware_id == "") {
-      throw Error("Could not get current host name, please configure an hardware ID explicitely");
+      throw Error("Could not get current host name, please configure an hardware ID explicitly");
     }
   }
 
-  ecu_serials.emplace_back(Uptane::EcuSerial(primary_ecu_serial_local),
-                           Uptane::HardwareIdentifier(primary_ecu_hardware_id));
-
+  EcuSerials new_ecu_serials;
+  new_ecu_serials.emplace_back(Uptane::EcuSerial(primary_ecu_serial_local),
+                               Uptane::HardwareIdentifier(primary_ecu_hardware_id));
   for (const auto& s : secondaries_) {
-    ecu_serials.emplace_back(s.first, s.second->getHwId());
+    new_ecu_serials.emplace_back(s.first, s.second->getHwId());
   }
 
-  storage_->storeEcuSerials(ecu_serials);
+  register_ecus = stored_ecu_serials.empty();
+  if (!stored_ecu_serials.empty()) {
+    // We should probably clear the misconfigured_ecus table once we have
+    // consent working.
+    std::vector<bool> found(stored_ecu_serials.size(), false);
+
+    EcuCompare primary_comp(new_ecu_serials[0]);
+    EcuSerials::const_iterator store_it;
+    store_it = std::find_if(stored_ecu_serials.cbegin(), stored_ecu_serials.cend(), primary_comp);
+    if (store_it == stored_ecu_serials.cend()) {
+      LOG_INFO << "Configured Primary ECU serial " << new_ecu_serials[0].first << " with hardware ID "
+               << new_ecu_serials[0].second << " not found in storage.";
+      register_ecus = true;
+    } else {
+      found[static_cast<size_t>(store_it - stored_ecu_serials.cbegin())] = true;
+    }
+
+    // Check all configured Secondaries to see if any are new.
+    for (auto it = secondaries_.cbegin(); it != secondaries_.cend(); ++it) {
+      EcuCompare secondary_comp(std::make_pair(it->second->getSerial(), it->second->getHwId()));
+      store_it = std::find_if(stored_ecu_serials.cbegin(), stored_ecu_serials.cend(), secondary_comp);
+      if (store_it == stored_ecu_serials.cend()) {
+        LOG_INFO << "Configured Secondary ECU serial " << it->second->getSerial() << " with hardware ID "
+                 << it->second->getHwId() << " not found in storage.";
+        register_ecus = true;
+      } else {
+        found[static_cast<size_t>(store_it - stored_ecu_serials.cbegin())] = true;
+      }
+    }
+
+    // Check all stored Secondaries not already matched to see if any have been
+    // removed. Store them in a separate table to keep track of them.
+    std::vector<bool>::iterator found_it;
+    for (found_it = found.begin(); found_it != found.end(); ++found_it) {
+      if (!*found_it) {
+        auto not_registered = stored_ecu_serials[static_cast<size_t>(found_it - found.begin())];
+        LOG_INFO << "ECU serial " << not_registered.first << " with hardware ID " << not_registered.second
+                 << " in storage was not found in Secondary configuration.";
+        register_ecus = true;
+        storage_->saveMisconfiguredEcu({not_registered.first, not_registered.second, EcuState::kOld});
+      }
+    }
+  }
+
+  if (register_ecus) {
+    storage_->storeEcuSerials(new_ecu_serials);
+  }
 }
 
-void Initializer::resetEcuSerials() { storage_->clearEcuSerials(); }
-
-// Postcondition: (public, private) is in the storage. It should not be stored until secondaries are provisioned
+// Postcondition: (public, private) is in the storage. It should not be stored until Secondaries are provisioned
 void Initializer::initPrimaryEcuKeys() {
   std::string key_pair;
   try {
@@ -82,8 +121,6 @@ void Initializer::initPrimaryEcuKeys() {
     throw KeyGenerationError("Unknow error");
   }
 }
-
-void Initializer::resetEcuKeys() { storage_->clearPrimaryKeys(); }
 
 bool Initializer::loadSetTlsCreds() {
   keys_.copyCertsToCurl(*http_client_);
@@ -153,7 +190,9 @@ void Initializer::resetTlsCreds() {
 
 // Postcondition: "ECUs registered" flag set in the storage
 void Initializer::initEcuRegister() {
-  if (storage_->loadEcuRegistered()) {
+  // Allow re-registration if the ECUs have changed.
+  if (storage_->loadEcuRegistered() && !register_ecus) {
+    LOG_DEBUG << "All ECUs are already registered with the server.";
     return;
   }
 
@@ -215,7 +254,8 @@ void Initializer::initSecondaryInfo() {
     // won't be there in case of an upgrade from an older version.
     // On the first initialization ECU serials should be already
     // initialized by this point.
-    if (!storage_->loadSecondaryInfo(serial, &info) || info.type == "" || info.pub_key.Type() == KeyType::kUnknown) {
+    if (register_ecus || !storage_->loadSecondaryInfo(serial, &info) || info.type == "" ||
+        info.pub_key.Type() == KeyType::kUnknown) {
       info.serial = serial;
       info.hw_id = sec.getHwId();
       info.type = sec.Type();

--- a/src/libaktualizr/primary/initializer.h
+++ b/src/libaktualizr/primary/initializer.h
@@ -6,6 +6,7 @@
 #include "http/httpinterface.h"
 #include "storage/invstorage.h"
 #include "uptane/secondaryinterface.h"
+#include "uptane/tuf.h"
 
 const int MaxInitializationAttempts = 3;
 
@@ -21,7 +22,7 @@ class Initializer {
   };
   class KeyGenerationError : public Error {
    public:
-    KeyGenerationError(const std::string& what) : Error(std::string("Could not generate uptane key pair: ") + what) {}
+    KeyGenerationError(const std::string& what) : Error(std::string("Could not generate Uptane key pair: ") + what) {}
   };
   class StorageError : public Error {
    public:
@@ -37,25 +38,37 @@ class Initializer {
   };
 
  private:
-  const ProvisionConfig& config_;
-  std::shared_ptr<INvStorage> storage_;
-  std::shared_ptr<HttpInterface> http_client_;
-  KeyManager& keys_;
-  const std::map<Uptane::EcuSerial, Uptane::SecondaryInterface::Ptr>& secondaries_;
-  std::vector<SecondaryInfo> sec_info_;
-
   void initDeviceId();
   void resetDeviceId();
   void initEcuSerials();
-  void resetEcuSerials();
   void initPrimaryEcuKeys();
-  void resetEcuKeys();
   void initTlsCreds();
   void resetTlsCreds();
   void initSecondaryInfo();
   void initEcuRegister();
   bool loadSetTlsCreds();
   void initEcuReportCounter();
+
+  const ProvisionConfig& config_;
+  std::shared_ptr<INvStorage> storage_;
+  std::shared_ptr<HttpInterface> http_client_;
+  KeyManager& keys_;
+  const std::map<Uptane::EcuSerial, Uptane::SecondaryInterface::Ptr>& secondaries_;
+  std::vector<SecondaryInfo> sec_info_;
+  bool register_ecus{false};
+};
+
+class EcuCompare {
+ public:
+  explicit EcuCompare(std::pair<Uptane::EcuSerial, Uptane::HardwareIdentifier> ecu_in)
+      : serial(std::move(ecu_in.first)), hardware_id(std::move(ecu_in.second)) {}
+  bool operator()(const std::pair<Uptane::EcuSerial, Uptane::HardwareIdentifier>& in) const {
+    return (in.first == serial && in.second == hardware_id);
+  }
+
+ private:
+  const Uptane::EcuSerial serial;
+  const Uptane::HardwareIdentifier hardware_id;
 };
 
 #endif  // INITIALIZER_H_

--- a/src/libaktualizr/primary/initializer.h
+++ b/src/libaktualizr/primary/initializer.h
@@ -55,7 +55,8 @@ class Initializer {
   KeyManager& keys_;
   const std::map<Uptane::EcuSerial, Uptane::SecondaryInterface::Ptr>& secondaries_;
   std::vector<SecondaryInfo> sec_info_;
-  bool register_ecus{false};
+  EcuSerials new_ecu_serials_;
+  bool register_ecus_{false};
 };
 
 class EcuCompare {

--- a/src/libaktualizr/primary/reregistration_test.cc
+++ b/src/libaktualizr/primary/reregistration_test.cc
@@ -1,0 +1,151 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "config/config.h"
+#include "httpfake.h"
+#include "primary/aktualizr.h"
+#include "uptane_test_common.h"
+#include "virtualsecondary.h"
+
+boost::filesystem::path fake_meta_dir;
+
+void verifyEcus(TemporaryDirectory& temp_dir, std::vector<std::string> expected_ecus) {
+  const Json::Value ecu_data = Utils::parseJSONFile(temp_dir / "post.json");
+  EXPECT_EQ(ecu_data["ecus"].size(), expected_ecus.size());
+  for (const Json::Value& ecu : ecu_data["ecus"]) {
+    auto found = std::find(expected_ecus.begin(), expected_ecus.end(), ecu["ecu_serial"].asString());
+    if (found != expected_ecus.end()) {
+      expected_ecus.erase(found);
+    } else {
+      FAIL() << "Unknown ECU in registration data: " << ecu["ecu_serial"].asString();
+    }
+  }
+  EXPECT_EQ(expected_ecus.size(), 0);
+}
+
+class HttpFakeRegistration : public HttpFake {
+ public:
+  HttpFakeRegistration(const boost::filesystem::path& test_dir_in, const boost::filesystem::path& meta_dir_in)
+      : HttpFake(test_dir_in, "noupdates", meta_dir_in) {}
+
+  HttpResponse post(const std::string& url, const Json::Value& data) override {
+    if (url.find("/director/ecus") != std::string::npos) {
+      registration_count += 1;
+      EXPECT_EQ(data["primary_ecu_serial"].asString(), "CA:FE:A6:D2:84:9D");
+      EXPECT_EQ(data["ecus"][0]["ecu_serial"].asString(), "CA:FE:A6:D2:84:9D");
+      EXPECT_EQ(data["ecus"][0]["hardware_identifier"].asString(), "primary_hw");
+    }
+    return HttpFake::post(url, data);
+  }
+
+  unsigned int registration_count{0};
+};
+
+/*
+ * Add a Secondary via API, register the ECUs, then add another, and re-register.
+ */
+TEST(Aktualizr, AddSecondary) {
+  TemporaryDirectory temp_dir;
+  auto http = std::make_shared<HttpFakeRegistration>(temp_dir.Path(), fake_meta_dir);
+  Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
+  auto storage = INvStorage::newStorage(conf.storage);
+
+  UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
+  Primary::VirtualSecondaryConfig ecu_config = UptaneTestCommon::altVirtualConfiguration(temp_dir.Path());
+  aktualizr.AddSecondary(std::make_shared<Primary::VirtualSecondary>(ecu_config));
+  aktualizr.Initialize();
+
+  std::vector<std::string> expected_ecus = {"CA:FE:A6:D2:84:9D", "ecuserial3", "secondary_ecu_serial"};
+  verifyEcus(temp_dir, expected_ecus);
+  EXPECT_EQ(http->registration_count, 1);
+
+  ecu_config.ecu_serial = "ecuserial4";
+  auto sec4 = std::make_shared<Primary::VirtualSecondary>(ecu_config);
+  aktualizr.AddSecondary(sec4);
+  aktualizr.Initialize();
+  expected_ecus.push_back(ecu_config.ecu_serial);
+  verifyEcus(temp_dir, expected_ecus);
+  EXPECT_EQ(http->registration_count, 2);
+}
+
+/*
+ * Add a Secondary via API, register the ECUs, remove one, and re-register.
+ */
+TEST(Aktualizr, RemoveSecondary) {
+  TemporaryDirectory temp_dir;
+  auto http = std::make_shared<HttpFakeRegistration>(temp_dir.Path(), fake_meta_dir);
+  Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
+  auto storage = INvStorage::newStorage(conf.storage);
+
+  {
+    UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
+    Primary::VirtualSecondaryConfig ecu_config = UptaneTestCommon::altVirtualConfiguration(temp_dir.Path());
+    aktualizr.AddSecondary(std::make_shared<Primary::VirtualSecondary>(ecu_config));
+    aktualizr.Initialize();
+
+    std::vector<std::string> expected_ecus = {"CA:FE:A6:D2:84:9D", "ecuserial3", "secondary_ecu_serial"};
+    verifyEcus(temp_dir, expected_ecus);
+    EXPECT_EQ(http->registration_count, 1);
+  }
+
+  {
+    UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
+    aktualizr.Initialize();
+
+    std::vector<std::string> expected_ecus = {"CA:FE:A6:D2:84:9D", "secondary_ecu_serial"};
+    verifyEcus(temp_dir, expected_ecus);
+    EXPECT_EQ(http->registration_count, 2);
+  }
+}
+
+/*
+ * Add a Secondary via API, register the ECUs, replace one, and re-register.
+ */
+TEST(Aktualizr, ReplaceSecondary) {
+  TemporaryDirectory temp_dir;
+  auto http = std::make_shared<HttpFakeRegistration>(temp_dir.Path(), fake_meta_dir);
+  Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
+  auto storage = INvStorage::newStorage(conf.storage);
+
+  {
+    UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
+    Primary::VirtualSecondaryConfig ecu_config = UptaneTestCommon::altVirtualConfiguration(temp_dir.Path());
+    aktualizr.AddSecondary(std::make_shared<Primary::VirtualSecondary>(ecu_config));
+    aktualizr.Initialize();
+
+    std::vector<std::string> expected_ecus = {"CA:FE:A6:D2:84:9D", "ecuserial3", "secondary_ecu_serial"};
+    verifyEcus(temp_dir, expected_ecus);
+    EXPECT_EQ(http->registration_count, 1);
+  }
+
+  {
+    UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
+    Primary::VirtualSecondaryConfig ecu_config = UptaneTestCommon::altVirtualConfiguration(temp_dir.Path());
+    ecu_config.ecu_serial = "ecuserial4";
+    aktualizr.AddSecondary(std::make_shared<Primary::VirtualSecondary>(ecu_config));
+    aktualizr.Initialize();
+
+    std::vector<std::string> expected_ecus = {"CA:FE:A6:D2:84:9D", "ecuserial4", "secondary_ecu_serial"};
+    verifyEcus(temp_dir, expected_ecus);
+    EXPECT_EQ(http->registration_count, 2);
+  }
+}
+
+#ifndef __NO_MAIN__
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+  logger_init();
+  logger_set_threshold(boost::log::trivial::trace);
+
+  TemporaryDirectory tmp_dir;
+  fake_meta_dir = tmp_dir.Path();
+  MetaFake meta_fake(fake_meta_dir);
+
+  return RUN_ALL_TESTS();
+}
+#endif
+
+// vim: set tabstop=2 shiftwidth=2 expandtab:

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -487,6 +487,9 @@ void SotaUptaneClient::getNewTargets(std::vector<Uptane::Target> *new_targets, u
       // in the vehicle.
       const auto hw_id_known = getEcuHwId(ecu_serial);
       if (!hw_id_known) {
+        // This is triggered if a Secondary is removed after an update was
+        // installed on it because of the empty targets optimization.
+        // Thankfully if the Director issues new Targets, it fixes itself.
         LOG_ERROR << "Unknown ECU ID in Director Targets metadata: " << ecu_serial.ToString();
         throw Uptane::BadEcuId(target.filename());
       }

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -406,8 +406,8 @@ void SotaUptaneClient::computeDeviceInstallationResult(data::InstallationResult 
     if (!storage->loadEcuInstallationResults(&ecu_results)) {
       // failed to load ECUs' installation result
       device_installation_result = data::InstallationResult(data::ResultCode::Numeric::kInternalError,
-                                                            "Unable to get installation results from ecus");
-      raw_ir = "Failed to load ECUs' installation result";
+                                                            "Unable to get installation results from ECUs");
+      raw_ir = "Failed to load ECU installation results";
 
       break;
     }
@@ -425,7 +425,7 @@ void SotaUptaneClient::computeDeviceInstallationResult(data::InstallationResult 
         device_installation_result = data::InstallationResult(data::ResultCode::Numeric::kInternalError,
                                                               "Unable to get installation results from ECUs");
 
-        raw_ir = "Couldn't find any ECU with the given serial: " + ecu_serial.ToString();
+        raw_ir = "Failed to find an ECU with the given serial: " + ecu_serial.ToString();
 
         break;
       }

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -27,6 +27,7 @@
 #include "uptane/imagerepository.h"
 #include "uptane/iterator.h"
 #include "uptane/secondaryinterface.h"
+#include "uptane/tuf.h"
 
 class SotaUptaneClient {
  public:
@@ -137,7 +138,6 @@ class SotaUptaneClient {
   void reportInstalledPackages();
   void reportNetworkInfo();
   void reportAktualizrConfiguration();
-  void verifySecondaries();
   bool waitSecondariesReachable(const std::vector<Uptane::Target> &updates);
   bool sendMetadataToEcus(const std::vector<Uptane::Target> &targets);
   std::future<data::ResultCode::Numeric> sendFirmwareAsync(Uptane::SecondaryInterface &secondary,
@@ -157,7 +157,7 @@ class SotaUptaneClient {
                                                    bool offline);
   void checkAndUpdatePendingSecondaries();
   const Uptane::EcuSerial &primaryEcuSerial() const { return primary_ecu_serial_; }
-  boost::optional<Uptane::HardwareIdentifier> ecuHwId(const Uptane::EcuSerial &serial) const;
+  boost::optional<Uptane::HardwareIdentifier> getEcuHwId(const Uptane::EcuSerial &serial) const;
 
   template <class T, class... Args>
   void sendEvent(Args &&... args) {
@@ -195,17 +195,6 @@ class TargetCompare {
 
  private:
   const Uptane::Target &target;
-};
-
-class SerialCompare {
- public:
-  explicit SerialCompare(Uptane::EcuSerial serial_in) : serial(std::move(serial_in)) {}
-  bool operator()(const std::pair<Uptane::EcuSerial, Uptane::HardwareIdentifier> &in) const {
-    return (in.first == serial);
-  }
-
- private:
-  const Uptane::EcuSerial serial;
 };
 
 #endif  // SOTA_UPTANE_CLIENT_H_

--- a/src/libaktualizr/primary/uptane_key_test.cc
+++ b/src/libaktualizr/primary/uptane_key_test.cc
@@ -151,7 +151,8 @@ TEST(UptaneKey, RecoverWithoutKeys) {
   {
     auto storage = INvStorage::newStorage(config.storage);
     auto sota_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage, http);
-
+    sota_client->addSecondary(std::make_shared<Primary::VirtualSecondary>(ecu_config1));
+    sota_client->addSecondary(std::make_shared<Primary::VirtualSecondary>(ecu_config2));
     EXPECT_NO_THROW(sota_client->initialize());
     UptaneKey_Check_Test::checkKeyTests(storage, *sota_client);
 
@@ -167,7 +168,8 @@ TEST(UptaneKey, RecoverWithoutKeys) {
   {
     auto storage = INvStorage::newStorage(config.storage);
     auto sota_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage, http);
-
+    sota_client->addSecondary(std::make_shared<Primary::VirtualSecondary>(ecu_config1));
+    sota_client->addSecondary(std::make_shared<Primary::VirtualSecondary>(ecu_config2));
     EXPECT_NO_THROW(sota_client->initialize());
     UptaneKey_Check_Test::checkKeyTests(storage, *sota_client);
   }

--- a/src/libaktualizr/storage/invstorage.cc
+++ b/src/libaktualizr/storage/invstorage.cc
@@ -172,7 +172,9 @@ void INvStorage::FSSToSQLS(FSStorageRead& fs_storage, SQLStorage& sql_storage) {
 
   std::vector<MisconfiguredEcu> ecus;
   if (fs_storage.loadMisconfiguredEcus(&ecus)) {
-    sql_storage.storeMisconfiguredEcus(ecus);
+    for (auto& ecu : ecus) {
+      sql_storage.saveMisconfiguredEcu(ecu);
+    }
   }
 
   std::vector<Uptane::Target> installed_versions;

--- a/src/libaktualizr/storage/invstorage.h
+++ b/src/libaktualizr/storage/invstorage.h
@@ -24,7 +24,9 @@ using load_data_t = bool (INvStorage::*)(std::string*) const;
 
 typedef std::vector<std::pair<Uptane::EcuSerial, Uptane::HardwareIdentifier>> EcuSerials;
 
-enum class EcuState { kOld = 0, kNotRegistered };
+// kUnused was previously kNotRegistered, but re-registration is now possible so
+// that is no longer a misconfiguration.
+enum class EcuState { kOld = 0, kUnused };
 
 struct MisconfiguredEcu {
   MisconfiguredEcu(Uptane::EcuSerial serial_in, Uptane::HardwareIdentifier hardware_id_in, EcuState state_in)
@@ -109,7 +111,7 @@ class INvStorage {
   virtual void storeCachedEcuManifest(const Uptane::EcuSerial& ecu_serial, const std::string& manifest) = 0;
   virtual bool loadCachedEcuManifest(const Uptane::EcuSerial& ecu_serial, std::string* manifest) const = 0;
 
-  virtual void storeMisconfiguredEcus(const std::vector<MisconfiguredEcu>& ecus) = 0;
+  virtual void saveMisconfiguredEcu(const MisconfiguredEcu& ecu) = 0;
   virtual bool loadMisconfiguredEcus(std::vector<MisconfiguredEcu>* ecus) const = 0;
   virtual void clearMisconfiguredEcus() = 0;
 

--- a/src/libaktualizr/storage/sqlstorage.h
+++ b/src/libaktualizr/storage/sqlstorage.h
@@ -63,7 +63,7 @@ class SQLStorage : public SQLStorageBase, public INvStorage {
   void clearEcuSerials() override;
   void storeCachedEcuManifest(const Uptane::EcuSerial& ecu_serial, const std::string& manifest) override;
   bool loadCachedEcuManifest(const Uptane::EcuSerial& ecu_serial, std::string* manifest) const override;
-  void storeMisconfiguredEcus(const std::vector<MisconfiguredEcu>& ecus) override;
+  void saveMisconfiguredEcu(const MisconfiguredEcu& ecu) override;
   bool loadMisconfiguredEcus(std::vector<MisconfiguredEcu>* ecus) const override;
   void clearMisconfiguredEcus() override;
   void storeEcuRegistered() override;

--- a/src/libaktualizr/storage/storage_common_test.cc
+++ b/src/libaktualizr/storage/storage_common_test.cc
@@ -253,20 +253,17 @@ TEST(storage, load_store_misconfigured_ecus) {
   TemporaryDirectory temp_dir;
   std::unique_ptr<INvStorage> storage = Storage(temp_dir.Path());
 
-  std::vector<MisconfiguredEcu> ecus;
-  ecus.push_back(MisconfiguredEcu(Uptane::EcuSerial("primary"), Uptane::HardwareIdentifier("primary_hw"),
-                                  EcuState::kNotRegistered));
-
-  storage->storeMisconfiguredEcus(ecus);
+  storage->saveMisconfiguredEcu(
+      {Uptane::EcuSerial("primary"), Uptane::HardwareIdentifier("primary_hw"), EcuState::kOld});
 
   std::vector<MisconfiguredEcu> ecus_out;
 
   EXPECT_TRUE(storage->loadMisconfiguredEcus(&ecus_out));
 
-  EXPECT_EQ(ecus_out.size(), ecus.size());
+  EXPECT_EQ(ecus_out.size(), 1);
   EXPECT_EQ(ecus_out[0].serial, Uptane::EcuSerial("primary"));
   EXPECT_EQ(ecus_out[0].hardware_id, Uptane::HardwareIdentifier("primary_hw"));
-  EXPECT_EQ(ecus_out[0].state, EcuState::kNotRegistered);
+  EXPECT_EQ(ecus_out[0].state, EcuState::kOld);
 
   storage->clearMisconfiguredEcus();
   ecus_out.clear();

--- a/src/libaktualizr/uptane/CMakeLists.txt
+++ b/src/libaktualizr/uptane/CMakeLists.txt
@@ -51,7 +51,7 @@ add_aktualizr_test(NAME uptane_network SOURCES uptane_network_test.cc PROJECT_WO
 set_tests_properties(test_uptane_network PROPERTIES LABELS "crypto")
 target_link_libraries(t_uptane_network virtual_secondary)
 
-add_aktualizr_test(NAME uptane_serial SOURCES uptane_serial_test.cc ARGS ${PROJECT_BINARY_DIR}
+add_aktualizr_test(NAME uptane_serial SOURCES uptane_serial_test.cc
                    PROJECT_WORKING_DIRECTORY LIBRARIES uptane_generator_lib)
 target_link_libraries(t_uptane_serial virtual_secondary)
 

--- a/src/libaktualizr/uptane/uptane_network_test.cc
+++ b/src/libaktualizr/uptane/uptane_network_test.cc
@@ -60,15 +60,6 @@ bool doTestInit(StorageType storage_type, const std::string &device_register_sta
     conf.provision.expiry_days = "noerrors";
     conf.provision.primary_ecu_serial = "noerrors";
 
-    if (device_register_state == "noerrors" && ecu_register_state != "noerrors") {
-      // restore a "good" ECU serial in the ECU register fault injection case
-      // (the bad value has been cached in storage)
-      EcuSerials serials;
-      store->loadEcuSerials(&serials);
-      serials[0].first = Uptane::EcuSerial(conf.provision.primary_ecu_serial);
-      store->storeEcuSerials(serials);
-    }
-
     KeyManager keys(store, conf.keymanagerConfig());
     try {
       Initializer initializer(conf.provision, store, http, keys, {});

--- a/src/libaktualizr/uptane/uptane_serial_test.cc
+++ b/src/libaktualizr/uptane/uptane_serial_test.cc
@@ -21,8 +21,6 @@
 
 namespace bpo = boost::program_options;
 
-boost::filesystem::path build_dir;
-
 /**
  * Check that aktualizr generates random ecu_serial for Primary and all
  * Secondaries.
@@ -133,11 +131,6 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   logger_set_threshold(boost::log::trivial::trace);
 
-  if (argc != 2) {
-    std::cerr << "Error: " << argv[0] << " requires the path to the build directory as an input argument.\n";
-    return EXIT_FAILURE;
-  }
-  build_dir = argv[1];
   return RUN_ALL_TESTS();
 }
 #endif

--- a/src/libaktualizr/uptane/uptane_test.cc
+++ b/src/libaktualizr/uptane/uptane_test.cc
@@ -740,13 +740,13 @@ TEST(Uptane, UptaneSecondaryMisconfigured) {
     storage->loadMisconfiguredEcus(&ecus);
     EXPECT_EQ(ecus.size(), 2);
     if (ecus[0].serial.ToString() == "new_secondary_ecu_serial") {
-      EXPECT_EQ(ecus[0].state, EcuState::kNotRegistered);
+      EXPECT_EQ(ecus[0].state, EcuState::kUnused);
       EXPECT_EQ(ecus[1].serial.ToString(), "secondary_ecu_serial");
       EXPECT_EQ(ecus[1].state, EcuState::kOld);
     } else if (ecus[0].serial.ToString() == "secondary_ecu_serial") {
       EXPECT_EQ(ecus[0].state, EcuState::kOld);
       EXPECT_EQ(ecus[1].serial.ToString(), "new_secondary_ecu_serial");
-      EXPECT_EQ(ecus[1].state, EcuState::kNotRegistered);
+      EXPECT_EQ(ecus[1].state, EcuState::kUnused);
     } else {
       FAIL() << "Unexpected Secondary serial in storage: " << ecus[0].serial.ToString();
     }

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -139,6 +139,14 @@ class Aktualizr:
             config_file.seek(0)
             json.dump(sec_cfg, config_file)
 
+    def remove_secondary(self, secondary):
+        with open(self._secondary_config_file, "r+") as config_file:
+            sec_cfg = json.load(config_file)
+            sec_cfg["IP"]["secondaries"].remove({"addr": "127.0.0.1:{}".format(secondary.port)})
+            config_file.seek(0)
+            json.dump(sec_cfg, config_file)
+            config_file.truncate()
+
     def update_wait_timeout(self, timeout):
         with open(self._secondary_config_file, "r+") as config_file:
             sec_cfg = json.load(config_file)
@@ -293,7 +301,7 @@ class KeyStore:
 
 class IPSecondary:
 
-    def __init__(self, aktualizr_secondary_exe, id, port=None, primary_port=None,
+    def __init__(self, id, aktualizr_secondary_exe='src/aktualizr_secondary/aktualizr-secondary', port=None, primary_port=None,
                  sysroot=None, treehub=None, output_logs=True, force_reboot=False,
                  ostree_mock_path=None, **kwargs):
         self.id = id

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -183,7 +183,7 @@ class Aktualizr:
         device_status = self.get_info()
         if not ((device_status.find(ecu_id[0]) != -1) and (device_status.find(ecu_id[1]) != -1)):
             return False
-        not_registered_field = "Removed or not registered ECUs:"
+        not_registered_field = "Removed or unregistered ECUs (deprecated):"
         not_reg_start = device_status.find(not_registered_field)
         return not_reg_start == -1 or (device_status.find(ecu_id[1], not_reg_start) == -1)
 

--- a/tests/uptane_test_common.h
+++ b/tests/uptane_test_common.h
@@ -87,6 +87,22 @@ struct UptaneTestCommon {
     return ecu_config;
   }
 
+  static Primary::VirtualSecondaryConfig altVirtualConfiguration(const boost::filesystem::path& client_dir) {
+    Primary::VirtualSecondaryConfig ecu_config;
+
+    ecu_config.partial_verifying = false;
+    ecu_config.full_client_dir = client_dir;
+    ecu_config.ecu_serial = "ecuserial3";
+    ecu_config.ecu_hardware_id = "hw_id3";
+    ecu_config.ecu_private_key = "sec.priv";
+    ecu_config.ecu_public_key = "sec.pub";
+    ecu_config.firmware_path = client_dir / "firmware.txt";
+    ecu_config.target_name_path = client_dir / "firmware_name.txt";
+    ecu_config.metadata_path = client_dir / "secondary_metadata";
+
+    return ecu_config;
+  }
+
   static Config makeTestConfig(const TemporaryDirectory& temp_dir, const std::string& url) {
     Config conf("tests/config/basic.toml");
     conf.uptane.director_server = url + "/director";


### PR DESCRIPTION
Allow ECU re-registration to support adding, removing, and replacing Secondaries. Tested manually and with unit tests for virtual and IP Secondaries.