### PR TITLE
Remove shared cred p12 from the archive after provisioning

### DIFF
--- a/src/libaktualizr-c/test/api-test-utils/api-test-utils.cc
+++ b/src/libaktualizr-c/test/api-test-utils/api-test-utils.cc
@@ -30,6 +30,7 @@ Config *Get_test_config() {
   config->provision.primary_ecu_hardware_id = "primary_hw";
   config->provision.server = serverAddress;
   config->provision.provision_path = "tests/test_data/cred.zip";
+  config->provision.mode = ProvisionMode::kSharedCredReuse;
 
   temp_dir = std_::make_unique<TemporaryDirectory>();
   config->storage.path = temp_dir->Path();

--- a/src/libaktualizr/bootstrap/bootstrap.cc
+++ b/src/libaktualizr/bootstrap/bootstrap.cc
@@ -12,18 +12,18 @@ Bootstrap::Bootstrap(const boost::filesystem::path& provision_path, const std::s
     : ca_(""), cert_(""), pkey_("") {
   if (provision_path.empty()) {
     LOG_ERROR << "Provision path is empty!";
-    throw std::runtime_error("Unable to parse bootstrap credentials");
+    throw std::runtime_error("Unable to parse bootstrap (shared) credentials");
   }
 
   std::ifstream as(provision_path.c_str(), std::ios::in | std::ios::binary);
   if (as.fail()) {
-    LOG_ERROR << "Unable to open provided provision archive " << provision_path << ": " << std::strerror(errno);
-    throw std::runtime_error("Unable to parse bootstrap credentials");
+    LOG_ERROR << "Unable to open provided provisioning archive " << provision_path << ": " << std::strerror(errno);
+    throw std::runtime_error("Unable to parse bootstrap (shared) credentials");
   }
 
   std::string p12_str = Utils::readFileFromArchive(as, "autoprov_credentials.p12");
   if (p12_str.empty()) {
-    throw std::runtime_error("Unable to parse bootstrap credentials");
+    throw std::runtime_error("Unable to parse bootstrap (shared) credentials");
   }
 
   readTlsP12(p12_str, provision_password, pkey_, cert_, ca_);
@@ -48,12 +48,12 @@ std::string Bootstrap::readServerUrl(const boost::filesystem::path& provision_pa
   try {
     std::ifstream as(provision_path.c_str(), std::ios::in | std::ios::binary);
     if (as.fail()) {
-      LOG_ERROR << "Unable to open provided provision archive " << provision_path << ": " << std::strerror(errno);
+      LOG_ERROR << "Unable to open provided provisioning archive " << provision_path << ": " << std::strerror(errno);
       throw std::runtime_error("Unable to parse bootstrap credentials");
     }
     url = Utils::readFileFromArchive(as, "autoprov.url", true);
   } catch (std::runtime_error& exc) {
-    LOG_ERROR << "Unable to read server url from archive: " << exc.what();
+    LOG_ERROR << "Unable to read server URL from archive: " << exc.what();
     url = "";
   }
 
@@ -65,12 +65,12 @@ std::string Bootstrap::readServerCa(const boost::filesystem::path& provision_pat
   try {
     std::ifstream as(provision_path.c_str(), std::ios::in | std::ios::binary);
     if (as.fail()) {
-      LOG_ERROR << "Unable to open provided provision archive " << provision_path << ": " << std::strerror(errno);
+      LOG_ERROR << "Unable to open provided provisioning archive " << provision_path << ": " << std::strerror(errno);
       throw std::runtime_error("Unable to parse bootstrap credentials");
     }
     server_ca = Utils::readFileFromArchive(as, "server_ca.pem");
   } catch (std::runtime_error& exc) {
-    LOG_ERROR << "Unable to read server ca from archive: " << exc.what();
+    LOG_ERROR << "Unable to read server CA certificate from archive: " << exc.what();
     return "";
   }
 

--- a/src/libaktualizr/config/config.h
+++ b/src/libaktualizr/config/config.h
@@ -19,7 +19,10 @@
 #include "utilities/config_utils.h"
 #include "utilities/types.h"
 
-enum class ProvisionMode { kSharedCred = 0, kDeviceCred };
+// kSharedCredReuse is intended solely for testing. It should not be used in
+// production.
+enum class ProvisionMode { kSharedCred = 0, kDeviceCred, kSharedCredReuse, kDefault };
+std::ostream& operator<<(std::ostream& os, ProvisionMode mode);
 
 // Try to keep the order of config options the same as in Config::writeToStream()
 // and Config::updateFromPropertyTree() in config.cc.
@@ -40,7 +43,7 @@ struct ProvisionConfig {
   std::string p12_password;
   std::string expiry_days{"36000"};
   boost::filesystem::path provision_path;
-  ProvisionMode mode{ProvisionMode::kSharedCred};
+  ProvisionMode mode{ProvisionMode::kDefault};
   std::string device_id;
   std::string primary_ecu_serial;
   std::string primary_ecu_hardware_id;

--- a/src/libaktualizr/config/config_test.cc
+++ b/src/libaktualizr/config/config_test.cc
@@ -108,8 +108,16 @@ TEST(config, DeviceCredMode) {
  * Start in shared credential provisioning mode.
  */
 TEST(config, SharedCredMode) {
-  Config config("tests/config/basic.toml");
+  Config config("config/sota-local.toml");
   EXPECT_EQ(config.provision.mode, ProvisionMode::kSharedCred);
+}
+
+/**
+ * Start in shared credential provisioning mode with reuse.
+ */
+TEST(config, SharedCredReuseMode) {
+  Config config("tests/config/basic.toml");
+  EXPECT_EQ(config.provision.mode, ProvisionMode::kSharedCredReuse);
 }
 
 /* Write config to file or to the log.

--- a/src/libaktualizr/primary/initializer.cc
+++ b/src/libaktualizr/primary/initializer.cc
@@ -136,13 +136,13 @@ void Initializer::initTlsCreds() {
   }
 
   if (config_.mode != ProvisionMode::kSharedCred) {
-    throw StorageError("Shared credentials expected but not found");
+    throw StorageError("Device credentials expected but not found");
   }
 
-  // Shared credential provision is required and possible => (automatically)
+  // Shared credential provisioning is required and possible => (automatically)
   // provision with shared credentials.
 
-  // set bootstrap credentials
+  // Set bootstrap (shared) credentials.
   Bootstrap boot(config_.provision_path, config_.p12_password);
   http_client_->setCerts(boot.getCa(), CryptoSource::kFile, boot.getCert(), CryptoSource::kFile, boot.getPkey(),
                          CryptoSource::kFile);
@@ -176,7 +176,7 @@ void Initializer::initTlsCreds() {
   }
   storage_->storeTlsCreds(ca, cert, pkey);
 
-  // set provisioned credentials
+  // Set provisioned (device) credentials.
   if (!loadSetTlsCreds()) {
     throw Error("Failed to configure HTTP client with device credentials.");
   }

--- a/src/libaktualizr/primary/initializer.cc
+++ b/src/libaktualizr/primary/initializer.cc
@@ -181,6 +181,16 @@ void Initializer::initTlsCreds() {
     throw Error("Failed to configure HTTP client with device credentials.");
   }
 
+  // Remove shared provisioning credentials from the archive; we have no more
+  // use for them.
+  Utils::removeFileFromArchive(config_.provision_path, "autoprov_credentials.p12");
+  // Remove the treehub.json if it's still there. It shouldn't have been put on
+  // the device, but it has happened before.
+  try {
+    Utils::removeFileFromArchive(config_.provision_path, "treehub.json");
+  } catch (...) {
+  }
+
   LOG_INFO << "Provisioned successfully on Device Gateway.";
 }
 

--- a/src/libaktualizr/primary/initializer.cc
+++ b/src/libaktualizr/primary/initializer.cc
@@ -26,7 +26,7 @@ void Initializer::initDeviceId() {
     } catch (const std::exception& e) {
       // No certificate: for device credential provisioning, abort. For shared
       // credential provisioning, generate a random name.
-      if (config_.mode == ProvisionMode::kSharedCred) {
+      if (config_.mode == ProvisionMode::kSharedCred || config_.mode == ProvisionMode::kSharedCredReuse) {
         device_id = Utils::genPrettyName();
       } else if (config_.mode == ProvisionMode::kDeviceCred) {
         throw e;
@@ -135,7 +135,7 @@ void Initializer::initTlsCreds() {
     return;
   }
 
-  if (config_.mode != ProvisionMode::kSharedCred) {
+  if (config_.mode == ProvisionMode::kDeviceCred) {
     throw StorageError("Device credentials expected but not found");
   }
 
@@ -181,14 +181,16 @@ void Initializer::initTlsCreds() {
     throw Error("Failed to configure HTTP client with device credentials.");
   }
 
-  // Remove shared provisioning credentials from the archive; we have no more
-  // use for them.
-  Utils::removeFileFromArchive(config_.provision_path, "autoprov_credentials.p12");
-  // Remove the treehub.json if it's still there. It shouldn't have been put on
-  // the device, but it has happened before.
-  try {
-    Utils::removeFileFromArchive(config_.provision_path, "treehub.json");
-  } catch (...) {
+  if (config_.mode != ProvisionMode::kSharedCredReuse) {
+    // Remove shared provisioning credentials from the archive; we have no more
+    // use for them.
+    Utils::removeFileFromArchive(config_.provision_path, "autoprov_credentials.p12");
+    // Remove the treehub.json if it's still there. It shouldn't have been put on
+    // the device, but it has happened before.
+    try {
+      Utils::removeFileFromArchive(config_.provision_path, "treehub.json");
+    } catch (...) {
+    }
   }
 
   LOG_INFO << "Provisioned successfully on Device Gateway.";

--- a/src/libaktualizr/primary/uptane_key_test.cc
+++ b/src/libaktualizr/primary/uptane_key_test.cc
@@ -23,7 +23,7 @@ void initKeyTests(Config& config, Primary::VirtualSecondaryConfig& ecu_config1,
   boost::filesystem::copy_file("tests/test_data/cred.zip", temp_dir / "cred.zip");
   config.provision.primary_ecu_serial = "testecuserial";
   config.provision.provision_path = temp_dir / "cred.zip";
-  config.provision.mode = ProvisionMode::kSharedCred;
+  config.provision.mode = ProvisionMode::kSharedCredReuse;
   config.tls.server = tls_server;
   config.uptane.director_server = tls_server + "/director";
   config.uptane.repo_server = tls_server + "/repo";

--- a/src/libaktualizr/uptane/uptane_ci_test.cc
+++ b/src/libaktualizr/uptane/uptane_ci_test.cc
@@ -28,7 +28,7 @@ TEST(UptaneCI, ProvisionAndPutManifest) {
   TemporaryDirectory temp_dir;
   Config config("tests/config/minimal.toml");
   config.provision.provision_path = credentials;
-  config.provision.mode = ProvisionMode::kSharedCred;
+  config.provision.mode = ProvisionMode::kSharedCredReuse;
   config.storage.path = temp_dir.Path();
   config.pacman.type = PACKAGE_MANAGER_NONE;
   config.postUpdateValues();  // re-run copy of urls
@@ -43,7 +43,7 @@ TEST(UptaneCI, CheckKeys) {
   TemporaryDirectory temp_dir;
   Config config("tests/config/minimal.toml");
   config.provision.provision_path = credentials;
-  config.provision.mode = ProvisionMode::kSharedCred;
+  config.provision.mode = ProvisionMode::kSharedCredReuse;
   config.storage.path = temp_dir.Path();
   config.pacman.type = PACKAGE_MANAGER_OSTREE;
   config.pacman.sysroot = sysroot;

--- a/src/libaktualizr/utilities/utils.h
+++ b/src/libaktualizr/utilities/utils.h
@@ -31,6 +31,7 @@ struct Utils {
   static void copyDir(const boost::filesystem::path &from, const boost::filesystem::path &to);
   static std::string readFileFromArchive(std::istream &as, const std::string &filename, bool trim = false);
   static void writeArchive(const std::map<std::string, std::string> &entries, std::ostream &as);
+  static void removeFileFromArchive(const boost::filesystem::path &archive_path, const std::string &filename);
   static Json::Value getHardwareInfo();
   static Json::Value getNetworkInfo();
   static std::string getHostname();

--- a/tests/config/basic.toml
+++ b/tests/config/basic.toml
@@ -1,5 +1,6 @@
 [provision]
 provision_path = "tests/test_data/cred.zip"
+mode = "SharedCredReuse"
 
 [tls]
 server = "https://7d0a4914-c392-4ccd-a8f9-3d4ed969da07.tcpgw.prod01.advancedtelematic.com:8000"

--- a/tests/config/device_id.toml
+++ b/tests/config/device_id.toml
@@ -3,4 +3,5 @@ key_type = "ED25519"
 
 [provision]
 provision_path = "tests/test_data/cred.zip"
+mode = "SharedCredReuse"
 device_id = "test-name-123"

--- a/tests/shared_cred_prov_test.py
+++ b/tests/shared_cred_prov_test.py
@@ -28,6 +28,7 @@ type = "none"
 
 [provision]
 provision_path = "{creds}"
+mode = "SharedCredReuse"
 
 [storage]
 path = "{tmp_dir}"


### PR DESCRIPTION
It should never be needed again and presents a potential security risk if left available for an attacker who gains access to the device.

Also remove `treehub.json`. It shouldn't be there in the first place, but in the distant past it was often accidentally left there.

There is now an explicit config option to prevent this behavior if you don't want it, which should only be used for tests. Set `provision.mode = "SharedCredReuse"` to use that.