### PR TITLE
Fix the leak test (so that it keeps leaking).

### DIFF
--- a/tests/leak_test.cc
+++ b/tests/leak_test.cc
@@ -3,10 +3,14 @@
 /**
  * A test case that leaks memory, to check that we can spot this in valgrind
  */
-TEST(Leak, ThisTestLeaks) { EXPECT_TRUE(new int[45]); }
+TEST(Leak, ThisTestLeaks) {
+  int* temp = new int[45];
+  int temp2 = *temp++;
+  std::cout << temp2;
+}
 
 #ifndef __NO_MAIN__
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
It appears that gcc 9 fixes the leak automatically, so valgrind doesn't detect it. Now we actually use the leaky variable, which seems to do the trick.

See the oe-selftest ptest results [here](https://main.gitlab.in.here.com/olp/edge/ota/connect/client/meta-updater/pipelines/825839) for proof that it works.