### PR TITLE
Improve error reporting for sending metadata to Secondaries

### DIFF
--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -97,6 +97,7 @@ class SotaUptaneClient {
  private:
   FRIEND_TEST(Aktualizr, FullNoUpdates);
   FRIEND_TEST(Aktualizr, DeviceInstallationResult);
+  FRIEND_TEST(Aktualizr, DeviceInstallationResultMetadata);
   FRIEND_TEST(Aktualizr, FullMultipleSecondaries);
   FRIEND_TEST(Aktualizr, CheckNoUpdates);
   FRIEND_TEST(Aktualizr, DownloadWithUpdates);
@@ -142,7 +143,8 @@ class SotaUptaneClient {
   bool waitSecondariesReachable(const std::vector<Uptane::Target> &updates);
   void storeInstallationFailure(const data::InstallationResult &result);
   data::InstallationResult rotateSecondaryRoot(Uptane::RepositoryType repo, SecondaryInterface &secondary);
-  data::InstallationResult sendMetadataToEcus(const std::vector<Uptane::Target> &targets);
+  void sendMetadataToEcus(const std::vector<Uptane::Target> &targets, data::InstallationResult *result,
+                          std::string *raw_installation_report);
   std::future<data::InstallationResult> sendFirmwareAsync(SecondaryInterface &secondary, const Uptane::Target &target);
   std::vector<result::Install::EcuReport> sendImagesToEcus(const std::vector<Uptane::Target> &targets);
 

--- a/src/libaktualizr/uptane/uptane_delegation_test.cc
+++ b/src/libaktualizr/uptane/uptane_delegation_test.cc
@@ -90,12 +90,13 @@ TEST(Delegation, Basic) {
 TEST(Delegation, RevokeAfterCheckUpdates) {
   for (auto generate_fun : {delegation_basic, delegation_nested}) {
     TemporaryDirectory temp_dir;
+    auto http = std::make_shared<HttpFakeDelegation>(temp_dir.Path());
+    Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
+    auto storage = INvStorage::newStorage(conf.storage);
+
     auto delegation_path = temp_dir.Path() / "delegation_test";
-    generate_fun(delegation_path, false);
     {
-      auto http = std::make_shared<HttpFakeDelegation>(temp_dir.Path());
-      Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
-      auto storage = INvStorage::newStorage(conf.storage);
+      generate_fun(delegation_path, false);
       UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
       aktualizr.Initialize();
 
@@ -106,9 +107,6 @@ TEST(Delegation, RevokeAfterCheckUpdates) {
     // Revoke delegation after CheckUpdates() and test if we can properly handle it.
     {
       generate_fun(delegation_path, true);
-      auto http = std::make_shared<HttpFakeDelegation>(temp_dir.Path());
-      Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
-      auto storage = INvStorage::newStorage(conf.storage);
       UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
       aktualizr.Initialize();
 
@@ -130,12 +128,13 @@ TEST(Delegation, RevokeAfterCheckUpdates) {
 TEST(Delegation, RevokeAfterDownload) {
   for (auto generate_fun : {delegation_basic, delegation_nested}) {
     TemporaryDirectory temp_dir;
+    auto http = std::make_shared<HttpFakeDelegation>(temp_dir.Path());
+    Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
+    auto storage = INvStorage::newStorage(conf.storage);
+
     auto delegation_path = temp_dir.Path() / "delegation_test";
-    generate_fun(delegation_path, false);
     {
-      auto http = std::make_shared<HttpFakeDelegation>(temp_dir.Path());
-      Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
-      auto storage = INvStorage::newStorage(conf.storage);
+      generate_fun(delegation_path, false);
       UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
       aktualizr.Initialize();
 
@@ -148,10 +147,6 @@ TEST(Delegation, RevokeAfterDownload) {
     // Revoke delegation after Download() and test if we can properly handle it
     {
       generate_fun(delegation_path, true);
-
-      auto http = std::make_shared<HttpFakeDelegation>(temp_dir.Path());
-      Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
-      auto storage = INvStorage::newStorage(conf.storage);
       UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
       aktualizr.Initialize();
 
@@ -173,12 +168,13 @@ TEST(Delegation, RevokeAfterDownload) {
 TEST(Delegation, RevokeAfterInstall) {
   for (auto generate_fun : {delegation_basic, delegation_nested}) {
     TemporaryDirectory temp_dir;
+    auto http = std::make_shared<HttpFakeDelegation>(temp_dir.Path());
+    Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
+    auto storage = INvStorage::newStorage(conf.storage);
+
     auto delegation_path = temp_dir.Path() / "delegation_test";
-    generate_fun(delegation_path, false);
     {
-      auto http = std::make_shared<HttpFakeDelegation>(temp_dir.Path());
-      Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
-      auto storage = INvStorage::newStorage(conf.storage);
+      generate_fun(delegation_path, false);
       UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
       aktualizr.Initialize();
 
@@ -196,10 +192,6 @@ TEST(Delegation, RevokeAfterInstall) {
     // Revoke delegation after Install() and test if can properly CheckUpdates again
     {
       generate_fun(delegation_path, true);
-
-      auto http = std::make_shared<HttpFakeDelegation>(temp_dir.Path());
-      Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
-      auto storage = INvStorage::newStorage(conf.storage);
       UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
       aktualizr.Initialize();
 

--- a/src/libaktualizr/uptane/uptane_network_test.cc
+++ b/src/libaktualizr/uptane/uptane_network_test.cc
@@ -187,7 +187,6 @@ TEST(UptaneNetwork, LogConnectivityRestored) {
   config.provision.primary_ecu_hardware_id = "primary_hw";
   config.storage.path = temp_dir.Path();
   config.tls.server = http->tls_server;
-  UptaneTestCommon::addDefaultSecondary(config, temp_dir, "secondary_ecu_serial", "secondary_hw");
 
   auto storage = INvStorage::newStorage(config.storage);
   auto up = std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage, http);

--- a/src/libaktualizr/uptane/uptane_serial_test.cc
+++ b/src/libaktualizr/uptane/uptane_serial_test.cc
@@ -80,16 +80,15 @@ TEST(Uptane, ReloadSerial) {
   EcuSerials ecu_serials_1;
   EcuSerials ecu_serials_2;
 
+  Config conf("tests/config/basic.toml");
+  conf.storage.path = temp_dir.Path();
+  conf.provision.primary_ecu_serial = "";
+  UptaneTestCommon::addDefaultSecondary(conf, temp_dir, "", "secondary_hardware", false);
+
   // Initialize. Should store new serials.
   {
-    Config conf("tests/config/basic.toml");
-    conf.storage.path = temp_dir.Path();
-    conf.provision.primary_ecu_serial = "";
-
     auto storage = INvStorage::newStorage(conf.storage);
     auto http = std::make_shared<HttpFake>(temp_dir.Path());
-
-    UptaneTestCommon::addDefaultSecondary(conf, temp_dir, "", "secondary_hardware", false);
     auto uptane_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(conf, storage, http);
 
     ASSERT_NO_THROW(uptane_client->initialize());
@@ -102,13 +101,8 @@ TEST(Uptane, ReloadSerial) {
   // Keep storage directory, but initialize new objects. Should load existing
   // serials.
   {
-    Config conf("tests/config/basic.toml");
-    conf.storage.path = temp_dir.Path();
-    conf.provision.primary_ecu_serial = "";
-
     auto storage = INvStorage::newStorage(conf.storage);
     auto http = std::make_shared<HttpFake>(temp_dir.Path());
-    UptaneTestCommon::addDefaultSecondary(conf, temp_dir, "", "secondary_hardware", false);
     auto uptane_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(conf, storage, http);
 
     ASSERT_NO_THROW(uptane_client->initialize());

--- a/src/libaktualizr/uptane/uptane_test.cc
+++ b/src/libaktualizr/uptane/uptane_test.cc
@@ -210,15 +210,16 @@ TEST(Uptane, PutManifest) {
   Config config = config_common();
   config.storage.path = temp_dir.Path();
   boost::filesystem::copy_file("tests/test_data/cred.zip", (temp_dir / "cred.zip").string());
-  boost::filesystem::copy_file("tests/test_data/firmware.txt", (temp_dir / "firmware.txt").string());
-  boost::filesystem::copy_file("tests/test_data/firmware_name.txt", (temp_dir / "firmware_name.txt").string());
   config.provision.provision_path = temp_dir / "cred.zip";
   config.provision.mode = ProvisionMode::kSharedCred;
   config.uptane.director_server = http->tls_server + "/director";
   config.uptane.repo_server = http->tls_server + "/repo";
   config.provision.primary_ecu_serial = "testecuserial";
   config.pacman.type = PACKAGE_MANAGER_NONE;
-  UptaneTestCommon::addDefaultSecondary(config, temp_dir, "secondary_ecu_serial", "secondary_hardware");
+  Primary::VirtualSecondaryConfig sec_config =
+      UptaneTestCommon::addDefaultSecondary(config, temp_dir, "secondary_ecu_serial", "secondary_hardware");
+  boost::filesystem::copy_file("tests/test_data/firmware.txt", sec_config.firmware_path);
+  boost::filesystem::copy_file("tests/test_data/firmware_name.txt", sec_config.target_name_path);
 
   auto storage = INvStorage::newStorage(config.storage);
 

--- a/src/virtual_secondary/virtualsecondary.cc
+++ b/src/virtual_secondary/virtualsecondary.cc
@@ -53,6 +53,10 @@ void VirtualSecondaryConfig::dump(const boost::filesystem::path& file_full_path)
   json_config["metadata_path"] = metadata_path.string();
 
   Json::Value root;
+  // Append to the config file if it already exists.
+  if (boost::filesystem::exists(file_full_path)) {
+    root = Utils::parseJSONFile(file_full_path);
+  }
   root[Type].append(json_config);
 
   Json::StreamWriterBuilder json_bwriter;

--- a/tests/uptane_test_common.h
+++ b/tests/uptane_test_common.h
@@ -64,19 +64,21 @@ struct UptaneTestCommon {
   static Primary::VirtualSecondaryConfig addDefaultSecondary(Config& config, const TemporaryDirectory& temp_dir,
                                                              const std::string& serial, const std::string& hw_id,
                                                              bool hardcoded_keys = true) {
-    Primary::VirtualSecondaryConfig ecu_config;
+    boost::filesystem::path sec_dir = temp_dir / boost::filesystem::unique_path();
 
+    Primary::VirtualSecondaryConfig ecu_config;
     ecu_config.partial_verifying = false;
-    ecu_config.full_client_dir = temp_dir.Path();
+    ecu_config.full_client_dir = sec_dir;
     ecu_config.ecu_serial = serial;
     ecu_config.ecu_hardware_id = hw_id;
     ecu_config.ecu_private_key = "sec.priv";
     ecu_config.ecu_public_key = "sec.pub";
-    ecu_config.firmware_path = temp_dir / "firmware.txt";
-    ecu_config.target_name_path = temp_dir / "firmware_name.txt";
-    ecu_config.metadata_path = temp_dir / "secondary_metadata";
+    ecu_config.firmware_path = sec_dir / "firmware.txt";
+    ecu_config.target_name_path = sec_dir / "firmware_name.txt";
+    ecu_config.metadata_path = sec_dir / "secondary_metadata";
 
-    config.uptane.secondary_config_file = temp_dir / boost::filesystem::unique_path() / "virtual_secondary_conf.json";
+    // Create or append to the Secondary config file.
+    config.uptane.secondary_config_file = temp_dir / "virtual_secondary_conf.json";
     ecu_config.dump(config.uptane.secondary_config_file);
 
     if (hardcoded_keys) {


### PR DESCRIPTION
Previously, only the last Secondary to report an error would get reported. Now we handle all Secondary metadata sending failures and combine them into the device report as is done for installation.