### PR TITLE
cert-provider: Fix error when gateway URL in config is empty.

### DIFF
--- a/src/cert_provider/cert_provider_test.h
+++ b/src/cert_provider/cert_provider_test.h
@@ -88,7 +88,7 @@ class DeviceCredGenerator : public Process {
           privateKeyFileFullPath{(rootDir / directory / privateKeyFile)},
           certFileFullPath{rootDir / directory / certFile},
           serverRootCAFullPath{rootDir / directory / serverRootCA},
-          gtwURLFileFullPath{rootDir / gtwURLFile} {}
+          gtwURLFileFullPath{rootDir / directory / gtwURLFile} {}
 
     const std::string directory;
     const std::string privateKeyFile;

--- a/src/cert_provider/main.cc
+++ b/src/cert_provider/main.cc
@@ -440,7 +440,7 @@ int main(int argc, char* argv[]) {
           ca_file = config.storage.tls_cacert_path;
         }
       }
-      if (provide_url) {
+      if (provide_url && !config.tls.server_url_path.empty()) {
         url_file = config.tls.server_url_path;
       }
     }
@@ -534,7 +534,7 @@ int main(int argc, char* argv[]) {
         copyLocal(tmp_ca_file.PathString(), root_ca_file);
       }
       if (provide_url) {
-        auto gtw_url_file = local_dir / url_file.get("");
+        auto gtw_url_file = local_dir / url_file.get(directory);
         std::cout << "Writing the gateway URL to " << gtw_url_file << " ...\n";
         copyLocal(tmp_url_file.PathString(), gtw_url_file);
       }


### PR DESCRIPTION
Now it just uses the default name.