### PR TITLE
Add consistent tests for --version and --help options of all tools.

### DIFF
--- a/src/aktualizr_get/CMakeLists.txt
+++ b/src/aktualizr_get/CMakeLists.txt
@@ -8,6 +8,15 @@ add_aktualizr_test(NAME aktualizr_get
                    SOURCES get.cc get_test.cc
                    PROJECT_WORKING_DIRECTORY)
 
+# Check the --help option works.
+add_test(NAME aktualizr-get-option-help
+         COMMAND aktualizr-get --help)
+
+# Report version.
+add_test(NAME aktualizr-get-option-version
+         COMMAND aktualizr-get --version)
+set_tests_properties(aktualizr-get-option-version PROPERTIES PASS_REGULAR_EXPRESSION "Current aktualizr-get version is: ${AKTUALIZR_VERSION}")
+
 aktualizr_source_file_checks(main.cc get.cc get.h get_test.cc)
 
 # vim: set tabstop=4 shiftwidth=4 expandtab:

--- a/src/aktualizr_get/main.cc
+++ b/src/aktualizr_get/main.cc
@@ -11,6 +11,17 @@
 
 namespace bpo = boost::program_options;
 
+void check_info_options(const bpo::options_description &description, const bpo::variables_map &vm) {
+  if (vm.count("help") != 0 || (vm.count("command") == 0 && vm.count("version") == 0)) {
+    std::cout << description << '\n';
+    exit(EXIT_SUCCESS);
+  }
+  if (vm.count("version") != 0) {
+    std::cout << "Current aktualizr-get version is: " << aktualizr_version() << "\n";
+    exit(EXIT_SUCCESS);
+  }
+}
+
 bpo::variables_map parse_options(int argc, char **argv) {
   bpo::options_description description(
       "A tool similar to wget that will do an HTTP get on the given URL using the device's configured credentials.");
@@ -19,7 +30,7 @@ bpo::variables_map parse_options(int argc, char **argv) {
   // The first three are commandline only.
   description.add_options()
       ("help,h", "print usage")
-      ("version,v", "Current aktualizr version")
+      ("version,v", "Current aktualizr-get version")
       ("config,c", bpo::value<std::vector<boost::filesystem::path> >()->composing(), "configuration file or directory")
       ("loglevel", bpo::value<int>(), "set log level 0-5 (trace, debug, info, warning, error, fatal)")
       ("url,u", bpo::value<std::string>(), "url to get");
@@ -30,12 +41,8 @@ bpo::variables_map parse_options(int argc, char **argv) {
   try {
     bpo::basic_parsed_options<char> parsed_options = bpo::command_line_parser(argc, argv).options(description).run();
     bpo::store(parsed_options, vm);
+    check_info_options(description, vm);
     bpo::notify(vm);
-    if (vm.count("help") != 0) {
-      std::cout << description << '\n';
-      exit(EXIT_SUCCESS);
-    }
-
   } catch (const bpo::required_option &ex) {
     // print the error and append the default commandline option description
     std::cout << ex.what() << std::endl << description;

--- a/src/aktualizr_info/CMakeLists.txt
+++ b/src/aktualizr_info/CMakeLists.txt
@@ -5,7 +5,6 @@ set(AKTUALIZR_INFO_HEADERS aktualizr_info_config.h)
 add_executable(aktualizr-info ${AKTUALIZR_INFO_SRC})
 target_link_libraries(aktualizr-info aktualizr_lib)
 
-
 install(TARGETS aktualizr-info
         COMPONENT aktualizr
         RUNTIME DESTINATION bin)
@@ -14,6 +13,15 @@ add_aktualizr_test(NAME aktualizr_info_config
                    SOURCES aktualizr_info_config.cc aktualizr_info_config_test.cc PROJECT_WORKING_DIRECTORY)
 
 add_aktualizr_test(NAME aktualizr_info SOURCES aktualizr_info_test.cc)
+
+# Check the --help option works.
+add_test(NAME aktualizr-info-option-help
+         COMMAND aktualizr-info --help)
+
+# Report version.
+add_test(NAME aktualizr-info-option-version
+         COMMAND aktualizr-info --version)
+set_tests_properties(aktualizr-info-option-version PROPERTIES PASS_REGULAR_EXPRESSION "Current aktualizr-info version is: ${AKTUALIZR_VERSION}")
 
 aktualizr_source_file_checks(${AKTUALIZR_INFO_SRC}
                              ${AKTUALIZR_INFO_HEADERS}

--- a/src/aktualizr_lite/CMakeLists.txt
+++ b/src/aktualizr_lite/CMakeLists.txt
@@ -27,5 +27,14 @@ set_tests_properties(test_lite-helpers PROPERTIES
 
 endif(BUILD_OSTREE)
 
+# Check the --help option works.
+add_test(NAME aktualizr-lite-option-help
+         COMMAND aktualizr-lite --help)
+
+# Report version.
+add_test(NAME aktualizr-lite-option-version
+         COMMAND aktualizr-lite --version)
+set_tests_properties(aktualizr-lite-option-version PROPERTIES PASS_REGULAR_EXPRESSION "Current aktualizr-lite version is: ${AKTUALIZR_VERSION}")
+
 aktualizr_source_file_checks(main.cc ${AKTUALIZR_LITE_SRC} ${AKTUALIZR_LITE_HEADERS} helpers_test.cc ostree_mock.cc)
 # vim: set tabstop=4 shiftwidth=4 expandtab:

--- a/src/aktualizr_lite/main.cc
+++ b/src/aktualizr_lite/main.cc
@@ -164,7 +164,7 @@ void check_info_options(const bpo::options_description &description, const bpo::
     exit(EXIT_SUCCESS);
   }
   if (vm.count("version") != 0) {
-    std::cout << "Current aktualizr version is: " << aktualizr_version() << "\n";
+    std::cout << "Current aktualizr-lite version is: " << aktualizr_version() << "\n";
     exit(EXIT_SUCCESS);
   }
 }
@@ -183,7 +183,7 @@ bpo::variables_map parse_options(int argc, char **argv) {
   // The first three are commandline only.
   description.add_options()
       ("help,h", "print usage")
-      ("version,v", "Current aktualizr version")
+      ("version,v", "Current aktualizr-lite version")
       ("config,c", bpo::value<std::vector<boost::filesystem::path> >()->composing(), "configuration file or directory")
       ("loglevel", bpo::value<int>(), "set log level 0-5 (trace, debug, info, warning, error, fatal)")
       ("repo-server", bpo::value<std::string>(), "URL of the Uptane Image repository")

--- a/src/aktualizr_primary/CMakeLists.txt
+++ b/src/aktualizr_primary/CMakeLists.txt
@@ -12,6 +12,15 @@ add_aktualizr_test(NAME primary_secondary_registration
                    PROJECT_WORKING_DIRECTORY LIBRARIES PUBLIC aktualizr-posix virtual_secondary uptane_generator_lib)
 target_include_directories(t_primary_secondary_registration PUBLIC ${PROJECT_SOURCE_DIR}/src/libaktualizr-posix)
 
+# Check the --help option works.
+add_test(NAME aktualizr-option-help
+         COMMAND aktualizr --help)
+
+# Report version.
+add_test(NAME aktualizr-option-version
+         COMMAND aktualizr --version)
+set_tests_properties(aktualizr-option-version PROPERTIES PASS_REGULAR_EXPRESSION "Current aktualizr version is: ${AKTUALIZR_VERSION}")
+
 aktualizr_source_file_checks(${SOURCES} ${HEADERS} ${TEST_SOURCES})
 
 # vim: set tabstop=4 shiftwidth=4 expandtab:

--- a/src/aktualizr_secondary/CMakeLists.txt
+++ b/src/aktualizr_secondary/CMakeLists.txt
@@ -81,8 +81,15 @@ add_aktualizr_test(NAME aktualizr_secondary
                    SOURCES aktualizr_secondary_test.cc
                    LIBRARIES aktualizr_secondary_lib uptane_generator_lib)
 
-# test running the executable with command line option --help
-add_test(NAME aktualizr_secondary_cmdline--help COMMAND aktualizr-secondary --help)
+# Check the --help option works.
+add_test(NAME aktualizr-secondary-option-help
+         COMMAND aktualizr-secondary --help)
+
+# Report version.
+add_test(NAME aktualizr-secondary-option-version
+         COMMAND aktualizr-secondary --version)
+set_tests_properties(aktualizr-secondary-option-version PROPERTIES PASS_REGULAR_EXPRESSION "Current aktualizr-secondary version is: ${AKTUALIZR_VERSION}")
+
 # test running the executable with command line option --something
 add_test(NAME aktualizr_secondary_cmdline--something
          COMMAND aktualizr-secondary --something -c ${PROJECT_SOURCE_DIR}/tests/config/minimal.toml)

--- a/src/cert_provider/CMakeLists.txt
+++ b/src/cert_provider/CMakeLists.txt
@@ -36,6 +36,15 @@ if (SOTA_PACKED_CREDENTIALS)
     set_tests_properties(test_aktualizr_cert_provider_shared_cred PROPERTIES LABELS "credentials")
 endif(SOTA_PACKED_CREDENTIALS)
 
+# Check the --help option works.
+add_test(NAME aktualizr-cert-provider-option-help
+         COMMAND aktualizr-cert-provider --help)
+
+# Report version.
+add_test(NAME aktualizr-cert-provider-option-version
+         COMMAND aktualizr-cert-provider --version)
+set_tests_properties(aktualizr-cert-provider-option-version PROPERTIES PASS_REGULAR_EXPRESSION "Current aktualizr-cert-provider version is: ${AKTUALIZR_VERSION}")
+
 aktualizr_source_file_checks(${AKTUALIZR_CERT_PROVIDER_SRC}
                              ${AKTUALIZR_CERT_HEADERS}
                              cert_provider_shared_cred_test.cc

--- a/src/sota_tools/CMakeLists.txt
+++ b/src/sota_tools/CMakeLists.txt
@@ -181,6 +181,15 @@ if (BUILD_SOTA_TOOLS)
                        PROJECT_WORKING_DIRECTORY)
 
     ### garage-check tests
+    # Check the --help option works.
+    add_test(NAME garage-check-option-help
+        COMMAND garage-check --help)
+
+    # Report version.
+    add_test(NAME garage-check-option-version
+        COMMAND garage-check --version)
+    set_tests_properties(garage-check-option-version PROPERTIES PASS_REGULAR_EXPRESSION "Current garage-check version is: ${AKTUALIZR_VERSION}")
+
     # Verify that a commit exists in a remote repo.
     # Get targets.json from Image repository.
     # Find specified OSTree ref in targets.json.
@@ -201,6 +210,11 @@ if (BUILD_SOTA_TOOLS)
     # Check the --help option works.
     add_test(NAME garage-push-option-help
         COMMAND garage-push --help)
+
+    # Report version.
+    add_test(NAME garage-push-option-version
+        COMMAND garage-push --version)
+    set_tests_properties(garage-push-option-version PROPERTIES PASS_REGULAR_EXPRESSION "Current garage-push version is: ${AKTUALIZR_VERSION}")
 
     # Abort when given bogus command line options.
     add_test(NAME garage-push-bad-option
@@ -291,7 +305,7 @@ if (BUILD_SOTA_TOOLS)
     # Report version.
     add_test(NAME garage-deploy-option-version
         COMMAND garage-deploy --version)
-    set_tests_properties(garage-deploy-option-version PROPERTIES PASS_REGULAR_EXPRESSION "Current garage-deploy version is:")
+    set_tests_properties(garage-deploy-option-version PROPERTIES PASS_REGULAR_EXPRESSION "Current garage-deploy version is: ${AKTUALIZR_VERSION}")
 
     # Abort when given bogus command line options.
     add_test(NAME garage-deploy-bad-option

--- a/src/uptane_generator/CMakeLists.txt
+++ b/src/uptane_generator/CMakeLists.txt
@@ -19,6 +19,15 @@ add_aktualizr_test(NAME uptane_generator
                    ARGS $<TARGET_FILE:uptane-generator>
                    PROJECT_WORKING_DIRECTORY)
 
+# Check the --help option works.
+add_test(NAME uptane-generator-option-help
+         COMMAND uptane-generator --help)
+
+# Report version.
+add_test(NAME uptane-generator-option-version
+         COMMAND uptane-generator --version)
+set_tests_properties(uptane-generator-option-version PROPERTIES PASS_REGULAR_EXPRESSION "Current uptane-generator version is: ${AKTUALIZR_VERSION}")
+
 aktualizr_source_file_checks(${TEST_SOURCES} main.cc)
 
 # vim: set tabstop=4 shiftwidth=4 expandtab:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -121,10 +121,6 @@ endif(BUILD_DEB)
 # The test feature of cmake checks the return value when the program
 # exits. If the return value is zero, the testcase passes.
 
-# test running the executable with command line option --help
-add_test(NAME test_cmdline--help COMMAND aktualizr --help)
-# test running the executable with command line option -h
-add_test(NAME test_cmdline-h COMMAND aktualizr -h)
 # test running the executable with command line option --something
 add_test(NAME test_cmdline--something
          COMMAND aktualizr --something -c ${PROJECT_SOURCE_DIR}/tests/config/minimal.toml)


### PR DESCRIPTION
Also actually test that the version printed is what we expect.

This is pretty minor but seems worth doing right.