### PR TITLE
New StructGuard variant to support non-void return types.

### DIFF
--- a/src/libaktualizr/utilities/utils.cc
+++ b/src/libaktualizr/utilities/utils.cc
@@ -475,7 +475,7 @@ void Utils::copyDir(const boost::filesystem::path &from, const boost::filesystem
 }
 
 std::string Utils::readFileFromArchive(std::istream &as, const std::string &filename, const bool trim) {
-  StructGuard<struct archive> a(archive_read_new(), reinterpret_cast<void (*)(struct archive *)>(archive_read_free));
+  StructGuardInt<struct archive> a(archive_read_new(), archive_read_free);
   if (a == nullptr) {
     LOG_ERROR << "archive error: could not initialize archive object";
     throw std::runtime_error("archive error");
@@ -545,7 +545,7 @@ static ssize_t write_cb(struct archive *a, void *client_data, const void *buffer
 }
 
 void Utils::writeArchive(const std::map<std::string, std::string> &entries, std::ostream &as) {
-  StructGuard<struct archive> a(archive_write_new(), reinterpret_cast<void (*)(struct archive *)>(archive_write_free));
+  StructGuardInt<struct archive> a(archive_write_new(), archive_write_free);
   if (a == nullptr) {
     LOG_ERROR << "archive error: could not initialize archive object";
     throw std::runtime_error("archive error");
@@ -598,7 +598,7 @@ void Utils::removeFileFromArchive(const boost::filesystem::path &archive_path, c
     throw std::runtime_error("Unable to parse provisioning credentials");
   }
 
-  StructGuard<struct archive> a_in(archive_read_new(), reinterpret_cast<void (*)(struct archive *)>(archive_read_free));
+  StructGuardInt<struct archive> a_in(archive_read_new(), archive_read_free);
   if (a_in == nullptr) {
     LOG_ERROR << "archive error: could not initialize archive object";
     throw std::runtime_error("archive error");
@@ -612,8 +612,7 @@ void Utils::removeFileFromArchive(const boost::filesystem::path &archive_path, c
     throw std::runtime_error("archive error");
   }
 
-  StructGuard<struct archive> a_out(archive_write_new(),
-                                    reinterpret_cast<void (*)(struct archive *)>(archive_write_free));
+  StructGuardInt<struct archive> a_out(archive_write_new(), archive_write_free);
   if (a_out == nullptr) {
     LOG_ERROR << "archive error: could not initialize archive object";
     throw std::runtime_error("archive error");

--- a/src/libaktualizr/utilities/utils.h
+++ b/src/libaktualizr/utilities/utils.h
@@ -121,6 +121,8 @@ class BasedPath {
 //   BTW local variables are destructed in reverse order of instantiation
 template <typename T>
 using StructGuard = std::unique_ptr<T, void (*)(T *)>;
+template <typename T>
+using StructGuardInt = std::unique_ptr<T, int (*)(T *)>;
 
 class Socket {
  public:

--- a/tests/uptane_test_common.h
+++ b/tests/uptane_test_common.h
@@ -64,7 +64,8 @@ struct UptaneTestCommon {
   static Primary::VirtualSecondaryConfig addDefaultSecondary(Config& config, const TemporaryDirectory& temp_dir,
                                                              const std::string& serial, const std::string& hw_id,
                                                              bool hardcoded_keys = true) {
-    boost::filesystem::path sec_dir = temp_dir / boost::filesystem::unique_path();
+    const boost::filesystem::path sec_dir = temp_dir / boost::filesystem::unique_path();
+    Utils::createDirectories(sec_dir, S_IRWXU);
 
     Primary::VirtualSecondaryConfig ecu_config;
     ecu_config.partial_verifying = false;
@@ -90,17 +91,23 @@ struct UptaneTestCommon {
   }
 
   static Primary::VirtualSecondaryConfig altVirtualConfiguration(const boost::filesystem::path& client_dir) {
-    Primary::VirtualSecondaryConfig ecu_config;
+    const boost::filesystem::path sec_dir = client_dir / boost::filesystem::unique_path();
+    Utils::createDirectories(sec_dir, S_IRWXU);
 
+    Primary::VirtualSecondaryConfig ecu_config;
     ecu_config.partial_verifying = false;
-    ecu_config.full_client_dir = client_dir;
+    ecu_config.full_client_dir = sec_dir;
     ecu_config.ecu_serial = "ecuserial3";
     ecu_config.ecu_hardware_id = "hw_id3";
     ecu_config.ecu_private_key = "sec.priv";
     ecu_config.ecu_public_key = "sec.pub";
-    ecu_config.firmware_path = client_dir / "firmware.txt";
-    ecu_config.target_name_path = client_dir / "firmware_name.txt";
-    ecu_config.metadata_path = client_dir / "secondary_metadata";
+    ecu_config.firmware_path = sec_dir / "firmware.txt";
+    ecu_config.target_name_path = sec_dir / "firmware_name.txt";
+    ecu_config.metadata_path = sec_dir / "secondary_metadata";
+
+    // store hard-coded keys to make the tests run WAY faster
+    Utils::writeFile((ecu_config.full_client_dir / ecu_config.ecu_private_key), std::string(sec_private_key));
+    Utils::writeFile((ecu_config.full_client_dir / ecu_config.ecu_public_key), std::string(sec_public_key));
 
     return ecu_config;
   }


### PR DESCRIPTION
gcc9 explicitly complains about the previous solution of casting the function parameter.