### PR TITLE
Add more tests for Secondary initialization.

### DIFF
--- a/src/aktualizr_primary/primary_secondary_registration_test.cc
+++ b/src/aktualizr_primary/primary_secondary_registration_test.cc
@@ -37,22 +37,30 @@ TEST(PrimarySecondaryReg, SecondariesMigration) {
   auto storage = INvStorage::newStorage(conf.storage);
   Json::Value sec_conf;
 
-  {
-    // Prepare storage the "old" way (without the secondary_ecus table):
-    storage->storeDeviceId("device");
-    storage->storeEcuSerials({{primary_serial, primary_hwid}, {secondary_serial, secondary_hwid}});
-    storage->storeEcuRegistered();
+  // Prepare storage the "old" way (without the secondary_ecus table):
+  storage->storeDeviceId("device");
+  storage->storeEcuSerials({{primary_serial, primary_hwid}, {secondary_serial, secondary_hwid}});
+  storage->storeEcuRegistered();
 
-    sec_conf["IP"]["secondary_wait_port"] = 9030;
-    sec_conf["IP"]["secondary_wait_timeout"] = 1;
-    sec_conf["IP"]["secondaries"] = Json::arrayValue;
-    sec_conf["IP"]["secondaries"][0]["addr"] = "127.0.0.1:9061";
-    Utils::writeFile(sec_conf_path, sec_conf);
+  sec_conf["IP"]["secondary_wait_port"] = 9030;
+  sec_conf["IP"]["secondary_wait_timeout"] = 1;
+  sec_conf["IP"]["secondaries"] = Json::arrayValue;
+  sec_conf["IP"]["secondaries"][0]["addr"] = "127.0.0.1:9061";
+  Utils::writeFile(sec_conf_path, sec_conf);
+
+  {
+    // Confirm that the fields from the secondary_ecus table are empty.
+    std::vector<SecondaryInfo> secs_info;
+    storage->loadSecondariesInfo(&secs_info);
+    EXPECT_EQ(secs_info.size(), 1);
+    EXPECT_EQ(secs_info[0].serial.ToString(), secondary_serial.ToString());
+    EXPECT_EQ(secs_info[0].type, "");
+    EXPECT_EQ(secs_info[0].extra, "");
   }
 
   {
     // Verify that aktualizr can still start if it can't connect to its
-    // Secondary:
+    // Secondary. This will migrate the Secondary.
     UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
     Primary::initSecondaries(aktualizr, sec_conf_path);
     aktualizr.Initialize();
@@ -60,10 +68,52 @@ TEST(PrimarySecondaryReg, SecondariesMigration) {
 
     std::vector<SecondaryInfo> secs_info;
     storage->loadSecondariesInfo(&secs_info);
+    EXPECT_EQ(secs_info.size(), 1);
     EXPECT_EQ(secs_info[0].serial.ToString(), secondary_serial.ToString());
     EXPECT_EQ(secs_info[0].type, "IP");
     EXPECT_EQ(secs_info[0].extra, R"({"ip":"127.0.0.1","port":9061})");
   }
+
+  {
+    // Try again (again without connecting) to verify that the Secondary is
+    // correctly found in the storage.
+    UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
+    Primary::initSecondaries(aktualizr, sec_conf_path);
+    aktualizr.Initialize();
+    aktualizr.CheckUpdates().get();
+
+    std::vector<SecondaryInfo> secs_info;
+    storage->loadSecondariesInfo(&secs_info);
+    EXPECT_EQ(secs_info.size(), 1);
+    EXPECT_EQ(secs_info[0].serial.ToString(), secondary_serial.ToString());
+    EXPECT_EQ(secs_info[0].type, "IP");
+    EXPECT_EQ(secs_info[0].extra, R"({"ip":"127.0.0.1","port":9061})");
+  }
+}
+
+/*
+ * Register Virtual Secondaries via json configuration.
+ * Reject multiple Secondaries with the same serial.
+ */
+TEST(PrimarySecondaryReg, VirtualSecondary) {
+  TemporaryDirectory temp_dir;
+  auto http = std::make_shared<HttpFake>(temp_dir.Path(), "noupdates", fake_meta_dir);
+  Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
+  auto storage = INvStorage::newStorage(conf.storage);
+
+  UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
+  // This should fail because TestAktualizr automatically adds the default
+  // Secondary created in makeTestConfig.
+  EXPECT_THROW(Primary::initSecondaries(aktualizr, conf.uptane.secondary_config_file), std::exception);
+
+  boost::filesystem::remove(conf.uptane.secondary_config_file);
+  UptaneTestCommon::addDefaultSecondary(conf, temp_dir, "serial2", "hwid2");
+  UptaneTestCommon::addDefaultSecondary(conf, temp_dir, "serial3", "hwid3");
+  Primary::initSecondaries(aktualizr, conf.uptane.secondary_config_file);
+  aktualizr.Initialize();
+
+  std::vector<std::string> expected_ecus = {"CA:FE:A6:D2:84:9D", "secondary_ecu_serial", "serial2", "serial3"};
+  UptaneTestCommon::verifyEcus(temp_dir, expected_ecus);
 }
 
 #ifndef __NO_MAIN__

--- a/src/libaktualizr/primary/reregistration_test.cc
+++ b/src/libaktualizr/primary/reregistration_test.cc
@@ -11,20 +11,6 @@
 
 boost::filesystem::path fake_meta_dir;
 
-void verifyEcus(TemporaryDirectory& temp_dir, std::vector<std::string> expected_ecus) {
-  const Json::Value ecu_data = Utils::parseJSONFile(temp_dir / "post.json");
-  EXPECT_EQ(ecu_data["ecus"].size(), expected_ecus.size());
-  for (const Json::Value& ecu : ecu_data["ecus"]) {
-    auto found = std::find(expected_ecus.begin(), expected_ecus.end(), ecu["ecu_serial"].asString());
-    if (found != expected_ecus.end()) {
-      expected_ecus.erase(found);
-    } else {
-      FAIL() << "Unknown ECU in registration data: " << ecu["ecu_serial"].asString();
-    }
-  }
-  EXPECT_EQ(expected_ecus.size(), 0);
-}
-
 class HttpFakeRegistration : public HttpFake {
  public:
   HttpFakeRegistration(const boost::filesystem::path& test_dir_in, const boost::filesystem::path& meta_dir_in)
@@ -58,15 +44,14 @@ TEST(Aktualizr, AddSecondary) {
   aktualizr.Initialize();
 
   std::vector<std::string> expected_ecus = {"CA:FE:A6:D2:84:9D", "ecuserial3", "secondary_ecu_serial"};
-  verifyEcus(temp_dir, expected_ecus);
+  UptaneTestCommon::verifyEcus(temp_dir, expected_ecus);
   EXPECT_EQ(http->registration_count, 1);
 
   ecu_config.ecu_serial = "ecuserial4";
-  auto sec4 = std::make_shared<Primary::VirtualSecondary>(ecu_config);
-  aktualizr.AddSecondary(sec4);
+  aktualizr.AddSecondary(std::make_shared<Primary::VirtualSecondary>(ecu_config));
   aktualizr.Initialize();
   expected_ecus.push_back(ecu_config.ecu_serial);
-  verifyEcus(temp_dir, expected_ecus);
+  UptaneTestCommon::verifyEcus(temp_dir, expected_ecus);
   EXPECT_EQ(http->registration_count, 2);
 }
 
@@ -86,7 +71,7 @@ TEST(Aktualizr, RemoveSecondary) {
     aktualizr.Initialize();
 
     std::vector<std::string> expected_ecus = {"CA:FE:A6:D2:84:9D", "ecuserial3", "secondary_ecu_serial"};
-    verifyEcus(temp_dir, expected_ecus);
+    UptaneTestCommon::verifyEcus(temp_dir, expected_ecus);
     EXPECT_EQ(http->registration_count, 1);
   }
 
@@ -95,7 +80,7 @@ TEST(Aktualizr, RemoveSecondary) {
     aktualizr.Initialize();
 
     std::vector<std::string> expected_ecus = {"CA:FE:A6:D2:84:9D", "secondary_ecu_serial"};
-    verifyEcus(temp_dir, expected_ecus);
+    UptaneTestCommon::verifyEcus(temp_dir, expected_ecus);
     EXPECT_EQ(http->registration_count, 2);
   }
 }
@@ -116,7 +101,7 @@ TEST(Aktualizr, ReplaceSecondary) {
     aktualizr.Initialize();
 
     std::vector<std::string> expected_ecus = {"CA:FE:A6:D2:84:9D", "ecuserial3", "secondary_ecu_serial"};
-    verifyEcus(temp_dir, expected_ecus);
+    UptaneTestCommon::verifyEcus(temp_dir, expected_ecus);
     EXPECT_EQ(http->registration_count, 1);
   }
 
@@ -128,7 +113,7 @@ TEST(Aktualizr, ReplaceSecondary) {
     aktualizr.Initialize();
 
     std::vector<std::string> expected_ecus = {"CA:FE:A6:D2:84:9D", "ecuserial4", "secondary_ecu_serial"};
-    verifyEcus(temp_dir, expected_ecus);
+    UptaneTestCommon::verifyEcus(temp_dir, expected_ecus);
     EXPECT_EQ(http->registration_count, 2);
   }
 }

--- a/tests/uptane_test_common.h
+++ b/tests/uptane_test_common.h
@@ -138,6 +138,21 @@ struct UptaneTestCommon {
     packages_to_install.emplace_back(serial, ot_json);
     return packages_to_install;
   }
+
+  static void verifyEcus(TemporaryDirectory& temp_dir, std::vector<std::string> expected_ecus) {
+    const Json::Value ecu_data = Utils::parseJSONFile(temp_dir / "post.json");
+    EXPECT_EQ(ecu_data["ecus"].size(), expected_ecus.size());
+    for (const Json::Value& ecu : ecu_data["ecus"]) {
+      auto found = std::find(expected_ecus.begin(), expected_ecus.end(), ecu["ecu_serial"].asString());
+      if (found != expected_ecus.end()) {
+        expected_ecus.erase(found);
+      } else {
+        FAIL() << "Unknown ECU in registration data: " << ecu["ecu_serial"].asString();
+      }
+    }
+    EXPECT_EQ(expected_ecus.size(), 0);
+  }
+
 };
 
 #endif // UPTANE_TEST_COMMON_H_


### PR DESCRIPTION
* Virtual Secondary initialization in aktualizr-primary via the config file was not covered.
* The IP Secondary migration and initialization in aktualizr-primary is now somewhat more thoroughly covered.