### PR TITLE
make_src_archive.sh: Fix a bug if submodules weren't checked out.

### DIFF
--- a/scripts/make_src_archive.sh
+++ b/scripts/make_src_archive.sh
@@ -7,12 +7,14 @@ SCRIPTS_DIR=$(readlink -f "$(dirname "$0")")
 OUTPUT=$(realpath "$1")
 REPO=$(realpath "${2:-.}")
 
+# Just in case this wasn't done before.
+git -C "$REPO" submodule update --init --recursive
+
 python3 -m venv venv
 
 . venv/bin/activate
 
-# pip install 'git_archive_all==1.19.4'
-pip install git+https://github.com/Kentzo/git-archive-all@1f7938cd6db76bfcf7eb1046ccb818df72b141ad
+pip install 'git_archive_all==1.21.0'
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf $TMPDIR' EXIT


### PR DESCRIPTION
Also upgrade git_archive_all to 1.21.0 to fix some warnings.

This fixes a problem encountered while making the latest release (see https://main.gitlab.in.here.com/olp/edge/ota/connect/client/aktualizr/-/jobs/3979786).