### PR TITLE
introducing builder for secondary provider

### DIFF
--- a/src/aktualizr_secondary/secondary_rpc_test.cc
+++ b/src/aktualizr_secondary/secondary_rpc_test.cc
@@ -9,6 +9,7 @@
 #include "msg_handler.h"
 #include "package_manager/packagemanagerfactory.h"
 #include "package_manager/packagemanagerinterface.h"
+#include "primary/secondary_provider_builder.h"
 #include "secondary_tcp_server.h"
 #include "storage/invstorage.h"
 #include "test_utils.h"
@@ -473,7 +474,7 @@ class SecondaryRpcCommon : public ::testing::Test {
     storage_->storeNonRoot(image_targets_, Uptane::RepositoryType::Image(), Uptane::Role::Targets());
 
     package_manager_ = PackageManagerFactory::makePackageManager(config_.pacman, config_.bootloader, storage_, nullptr);
-    secondary_provider_ = std::make_shared<SecondaryProvider>(config_, storage_, package_manager_);
+    secondary_provider_ = SecondaryProviderBuilder::Build(config_, storage_, package_manager_);
     ip_secondary_->init(secondary_provider_);
   }
 
@@ -677,7 +678,7 @@ TEST(SecondaryTcpServer, TestIpSecondaryIfSecondaryIsNotRunning) {
   std::shared_ptr<PackageManagerInterface> package_manager =
       PackageManagerFactory::makePackageManager(config.pacman, config.bootloader, storage, nullptr);
   std::shared_ptr<SecondaryProvider> secondary_provider =
-      std::make_shared<SecondaryProvider>(config, storage, package_manager);
+      SecondaryProviderBuilder::Build(config, storage, package_manager);
   ip_secondary->init(secondary_provider);
 
   // Expect nothing since the Secondary is not running.

--- a/src/libaktualizr/primary/CMakeLists.txt
+++ b/src/libaktualizr/primary/CMakeLists.txt
@@ -12,6 +12,7 @@ set(HEADERS secondary_config.h
             reportqueue.h
             secondaryinterface.h
             secondary_provider.h
+	    secondary_provider_builder.h
             sotauptaneclient.h)
 
 

--- a/src/libaktualizr/primary/CMakeLists.txt
+++ b/src/libaktualizr/primary/CMakeLists.txt
@@ -12,9 +12,8 @@ set(HEADERS secondary_config.h
             reportqueue.h
             secondaryinterface.h
             secondary_provider.h
-	    secondary_provider_builder.h
+            secondary_provider_builder.h
             sotauptaneclient.h)
-
 
 add_library(primary OBJECT ${SOURCES})
 

--- a/src/libaktualizr/primary/secondary_provider.h
+++ b/src/libaktualizr/primary/secondary_provider.h
@@ -8,11 +8,11 @@
 #include "storage/invstorage.h"
 #include "uptane/tuf.h"
 
+class SecondaryProviderBuilder;
+
 class SecondaryProvider {
  public:
-  SecondaryProvider(Config& config_in, const std::shared_ptr<const INvStorage>& storage_in,
-                    const std::shared_ptr<const PackageManagerInterface>& package_manager_in)
-      : config_(config_in), storage_(storage_in), package_manager_(package_manager_in) {}
+  friend class SecondaryProviderBuilder;
 
   bool getMetadata(Uptane::MetaBundle* meta_bundle, const Uptane::Target& target) const;
   bool getDirectorMetadata(std::string* root, std::string* targets) const;
@@ -22,6 +22,10 @@ class SecondaryProvider {
   std::ifstream getTargetFileHandle(const Uptane::Target& target) const;
 
  private:
+  SecondaryProvider(Config& config_in, const std::shared_ptr<const INvStorage>& storage_in,
+                    const std::shared_ptr<const PackageManagerInterface>& package_manager_in)
+      : config_(config_in), storage_(storage_in), package_manager_(package_manager_in) {}
+
   Config& config_;
   const std::shared_ptr<const INvStorage> storage_;
   const std::shared_ptr<const PackageManagerInterface> package_manager_;

--- a/src/libaktualizr/primary/secondary_provider_builder.h
+++ b/src/libaktualizr/primary/secondary_provider_builder.h
@@ -5,9 +5,6 @@
 
 #include "primary/secondary_provider.h"
 
-/**
- * @brief The SecondaryProviderBuilder class
- */
 class SecondaryProviderBuilder {
  public:
   static std::shared_ptr<SecondaryProvider> Build(

--- a/src/libaktualizr/primary/secondary_provider_builder.h
+++ b/src/libaktualizr/primary/secondary_provider_builder.h
@@ -1,0 +1,25 @@
+#ifndef UPTANE_SECONDARY_PROVIDER_BUILDER_H
+#define UPTANE_SECONDARY_PROVIDER_BUILDER_H
+
+#include <memory>
+
+#include "primary/secondary_provider.h"
+
+/**
+ * @brief The SecondaryProviderBuilder class
+ */
+class SecondaryProviderBuilder {
+ public:
+  static std::shared_ptr<SecondaryProvider> Build(
+      Config& config, const std::shared_ptr<const INvStorage>& storage,
+      const std::shared_ptr<const PackageManagerInterface>& package_manager) {
+    return std::shared_ptr<SecondaryProvider>(new SecondaryProvider(config, storage, package_manager));
+  }
+  SecondaryProviderBuilder(SecondaryProviderBuilder&&) = delete;
+  SecondaryProviderBuilder(const SecondaryProviderBuilder&) = delete;
+  SecondaryProviderBuilder& operator=(const SecondaryProviderBuilder&) = delete;
+
+ private:
+  SecondaryProviderBuilder() {}
+};
+#endif  // UPTANE_SECONDARY_PROVIDER_BUILDER_H

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -20,6 +20,7 @@
 #include "http/httpclient.h"
 #include "package_manager/packagemanagerfactory.h"
 #include "package_manager/packagemanagerinterface.h"
+#include "primary/secondary_provider_builder.h"
 #include "primary/secondaryinterface.h"
 #include "reportqueue.h"
 #include "storage/invstorage.h"
@@ -45,7 +46,7 @@ class SotaUptaneClient {
         primary_ecu_serial_(primary_serial),
         primary_ecu_hw_id_(hwid) {
     report_queue = std_::make_unique<ReportQueue>(config, http, storage);
-    secondary_provider_ = std::make_shared<SecondaryProvider>(config, storage, package_manager_);
+    secondary_provider_ = SecondaryProviderBuilder::Build(config, storage, package_manager_);
   }
 
   SotaUptaneClient(Config &config_in, const std::shared_ptr<INvStorage> &storage_in,
@@ -190,6 +191,8 @@ class SotaUptaneClient {
   std::mutex download_mutex;
   Uptane::EcuSerial primary_ecu_serial_;
   Uptane::HardwareIdentifier primary_ecu_hw_id_;
+
+  SecondaryProvider *sp;
 };
 
 class TargetCompare {

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -191,8 +191,6 @@ class SotaUptaneClient {
   std::mutex download_mutex;
   Uptane::EcuSerial primary_ecu_serial_;
   Uptane::HardwareIdentifier primary_ecu_hw_id_;
-
-  SecondaryProvider *sp;
 };
 
 class TargetCompare {


### PR DESCRIPTION
The reason for this PR is to remove the possibility of creation of the SecondaryProvider instance for libaktualizr's user.

Signed-off-by: Kostiantyn Bushko <kostiantyn.bushko@yahoo.com>