### PR TITLE
Bump the default Yocto branch to dunfell.

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/pages/_partials/aktualizr-version.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/_partials/aktualizr-version.adoc
@@ -5,6 +5,6 @@
 // latest version.
 :aktualizr-version: 2020.8
 
-:yocto-version: 3.0
+:yocto-version: 3.1
 
-:yocto-branch: zeus
+:yocto-branch: dunfell

--- a/docs/ota-client-guide/modules/ROOT/pages/yocto-release-branches.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/yocto-release-branches.adoc
@@ -10,7 +10,7 @@ endif::[]
 
 == Supported branches
 
-Yocto has a number of release branches. Their details are documented in the https://wiki.yoctoproject.org/wiki/Releases[Yocto wiki]. HERE OTA Connect currently actively supports the following branches:
+Yocto has a number of release branches. Their details are documented in the https://wiki.yoctoproject.org/wiki/Releases[Yocto wiki]. HERE OTA Connect currently supports the following branches:
 
 * dunfell
 * zeus


### PR DESCRIPTION
See also https://github.com/advancedtelematic/updater-repo/pull/41.