### PR TITLE
Add missing configuration values to simulate a device.

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/examples/sota-local.toml
+++ b/docs/ota-client-guide/modules/ROOT/examples/sota-local.toml
@@ -1,6 +1,8 @@
 [provision]
 provision_path = "credentials.zip"
 primary_ecu_hardware_id = "local-fake"
+# This setting is for testing purposes only. Do not use in a real device.
+mode = "SharedCredReuse"
 
 [logger]
 loglevel = 1
@@ -10,6 +12,7 @@ path = "storage"
 
 [pacman]
 type = "none"
+images_path = "storage/images"
 
 [uptane]
 secondary_config_file = "virtualsec.json"


### PR DESCRIPTION
Found a couple of missing configuration parameters that are needed after upgrading aktualizr to 2020.8 on a Mac.