### PR TITLE
Only test aktualizr-lite if it is built

### DIFF
--- a/src/aktualizr_lite/CMakeLists.txt
+++ b/src/aktualizr_lite/CMakeLists.txt
@@ -25,8 +25,6 @@ add_dependencies(t_lite-helpers t_lite-mock)
 set_tests_properties(test_lite-helpers PROPERTIES
         ENVIRONMENT LD_PRELOAD=$<TARGET_FILE:t_lite-mock> LABELS "noptest")
 
-endif(BUILD_OSTREE)
-
 # Check the --help option works.
 add_test(NAME aktualizr-lite-option-help
          COMMAND aktualizr-lite --help)
@@ -35,6 +33,8 @@ add_test(NAME aktualizr-lite-option-help
 add_test(NAME aktualizr-lite-option-version
          COMMAND aktualizr-lite --version)
 set_tests_properties(aktualizr-lite-option-version PROPERTIES PASS_REGULAR_EXPRESSION "Current aktualizr-lite version is: ${AKTUALIZR_VERSION}")
+
+endif(BUILD_OSTREE)
 
 aktualizr_source_file_checks(main.cc ${AKTUALIZR_LITE_SRC} ${AKTUALIZR_LITE_HEADERS} helpers_test.cc ostree_mock.cc)
 # vim: set tabstop=4 shiftwidth=4 expandtab:


### PR DESCRIPTION
When BUILD_OSTREE is false, aktualizr-lite doesn't exist. Disable the tests too.

Signed-off-by: Phil Wise <phil@phil-wise.com>