### PR TITLE
Improve libaktualizr API exceptions.

### DIFF
--- a/include/libaktualizr/aktualizr.h
+++ b/include/libaktualizr/aktualizr.h
@@ -29,7 +29,7 @@ class Aktualizr {
    * @throw SQLException
    * @throw boost::filesystem::filesystem_error
    * @throw std::bad_alloc (memory allocation failure)
-   * @throw std::runtime_error (filesystem and json parsing failures; libsodium initialization failure)
+   * @throw std::runtime_error (filesystem failure; libsodium initialization failure)
    */
   explicit Aktualizr(const Config& config);
 
@@ -47,10 +47,10 @@ class Aktualizr {
    * @throw boost::filesystem::filesystem_error
    * @throw std::bad_alloc (memory allocation failure)
    * @throw std::runtime_error (curl, P11, SQL, filesystem, credentials archive
-   *                            parsing, certificate parsing, json parsing
-   *                            failures; missing ECU serials or device ID;
-   *                            database inconsistency with pending updates;
-   *                            invalid OSTree deployment)
+   *                            parsing, and certificate parsing failures;
+   *                            missing ECU serials or device ID; database
+   *                            inconsistency with pending updates; invalid
+   *                            OSTree deployment)
    * @throw std::system_error (failure to lock a mutex)
    */
   void Initialize();
@@ -63,9 +63,9 @@ class Aktualizr {
    * @throw SQLException
    * @throw boost::filesystem::filesystem_error
    * @throw std::bad_alloc (memory allocation failure)
-   * @throw std::runtime_error (curl, SQL, filesystem, and json parsing failures;
-   *                            database inconsistency with pending updates;
-   *                            error getting metadata from database or filesystem)
+   * @throw std::runtime_error (curl, SQL, and filesystem failures; database
+   *                            inconsistency with pending updates; error
+   *                            getting metadata from database or filesystem)
    * @throw std::system_error (failure to lock a mutex)
    */
   std::future<void> RunForever(const Json::Value& custom_hwinfo = Json::nullValue);
@@ -84,7 +84,7 @@ class Aktualizr {
    * @return std::future object with data about available campaigns.
    *
    * @throw std::bad_alloc (memory allocation failure)
-   * @throw std::runtime_error (curl and json parsing failures)
+   * @throw std::runtime_error (curl failure)
    */
   std::future<result::CampaignCheck> CampaignCheck();
 
@@ -112,7 +112,7 @@ class Aktualizr {
    * @throw SQLException
    * @throw boost::filesystem::filesystem_error
    * @throw std::bad_alloc (memory allocation failure)
-   * @throw std::runtime_error (curl, filesystem, and json parsing failures)
+   * @throw std::runtime_error (curl and filesystem failures)
    * @throw std::system_error (failure to lock a mutex)
    */
   std::future<void> SendDeviceData(const Json::Value& custom_hwinfo = Json::nullValue);
@@ -127,8 +127,8 @@ class Aktualizr {
    * @throw SQLException
    * @throw boost::filesystem::filesystem_error
    * @throw std::bad_alloc (memory allocation failure)
-   * @throw std::runtime_error (curl, SQL, filesystem, and json parsing failures;
-   *                            database inconsistency with pending updates)
+   * @throw std::runtime_error (curl, SQL, and filesystem failures; database
+   *                            inconsistency with pending updates)
    * @throw std::system_error (failure to lock a mutex)
    */
   std::future<result::UpdateCheck> CheckUpdates();
@@ -236,7 +236,7 @@ class Aktualizr {
    *
    * @throw SQLException
    * @throw std::bad_alloc (memory allocation failure)
-   * @throw std::runtime_error (curl failures; database inconsistency with pending updates)
+   * @throw std::runtime_error (curl failure; database inconsistency with pending updates)
    * @throw std::system_error (failure to lock a mutex)
    */
   std::future<bool> SendManifest(const Json::Value& custom = Json::nullValue);
@@ -284,9 +284,9 @@ class Aktualizr {
    * @throw SQLException
    * @throw boost::filesystem::filesystem_error
    * @throw std::bad_alloc (memory allocation failure)
-   * @throw std::runtime_error (curl, SQL, filesystem, and json parsing failures;
-   *                            database inconsistency with pending updates;
-   *                            error getting metadata from database or filesystem)
+   * @throw std::runtime_error (curl, SQL, and filesystem failures; database
+   *                            inconsistency with pending updates; error
+   *                            getting metadata from database or filesystem)
    * @throw std::system_error (failure to lock a mutex)
    */
   bool UptaneCycle();

--- a/include/libaktualizr/aktualizr.h
+++ b/include/libaktualizr/aktualizr.h
@@ -43,7 +43,6 @@ class Aktualizr {
    * before using any other aktualizr functions except AddSecondary.
    *
    * @throw Initializer::Error and subclasses
-   * @throw Uptane::Exception and subclasses
    * @throw SQLException
    * @throw boost::filesystem::filesystem_error
    * @throw std::system_error (failure to lock a mutex)

--- a/include/libaktualizr/aktualizr.h
+++ b/include/libaktualizr/aktualizr.h
@@ -28,7 +28,7 @@ class Aktualizr {
    *
    * @throw SQLException
    * @throw boost::filesystem::filesystem_error
-   * @throw std::bad_alloc
+   * @throw std::bad_alloc (memory allocation failure)
    * @throw std::runtime_error (filesystem and json parsing failures; libsodium initialization failure)
    */
   explicit Aktualizr(const Config& config);
@@ -45,13 +45,13 @@ class Aktualizr {
    * @throw Initializer::Error and subclasses
    * @throw SQLException
    * @throw boost::filesystem::filesystem_error
-   * @throw std::system_error (failure to lock a mutex)
    * @throw std::bad_alloc (memory allocation failure)
    * @throw std::runtime_error (curl, P11, SQL, filesystem, credentials archive
    *                            parsing, certificate parsing, json parsing
    *                            failures; missing ECU serials or device ID;
    *                            database inconsistency with pending updates;
    *                            invalid OSTree deployment)
+   * @throw std::system_error (failure to lock a mutex)
    */
   void Initialize();
 
@@ -62,11 +62,11 @@ class Aktualizr {
    *
    * @throw SQLException
    * @throw boost::filesystem::filesystem_error
-   * @throw std::system_error (failure to lock a mutex)
-   * @throw std::bad_alloc
+   * @throw std::bad_alloc (memory allocation failure)
    * @throw std::runtime_error (curl, SQL, filesystem, and json parsing failures;
    *                            database inconsistency with pending updates;
    *                            error getting metadata from database or filesystem)
+   * @throw std::system_error (failure to lock a mutex)
    */
   std::future<void> RunForever(const Json::Value& custom_hwinfo = Json::nullValue);
 
@@ -83,6 +83,7 @@ class Aktualizr {
    * updates before the contents of the update are known.
    * @return std::future object with data about available campaigns.
    *
+   * @throw std::bad_alloc (memory allocation failure)
    * @throw std::runtime_error (curl and json parsing failures)
    */
   std::future<result::CampaignCheck> CampaignCheck();
@@ -98,6 +99,7 @@ class Aktualizr {
    * @return Empty std::future object
    *
    * @throw std::bad_alloc (memory allocation failure)
+   * @throw std::system_error (failure to lock a mutex)
    */
   std::future<void> CampaignControl(const std::string& campaign_id, campaign::Cmd cmd);
 
@@ -109,8 +111,9 @@ class Aktualizr {
    *
    * @throw SQLException
    * @throw boost::filesystem::filesystem_error
-   * @throw std::bad_alloc
+   * @throw std::bad_alloc (memory allocation failure)
    * @throw std::runtime_error (curl, filesystem, and json parsing failures)
+   * @throw std::system_error (failure to lock a mutex)
    */
   std::future<void> SendDeviceData(const Json::Value& custom_hwinfo = Json::nullValue);
 
@@ -123,9 +126,10 @@ class Aktualizr {
    *
    * @throw SQLException
    * @throw boost::filesystem::filesystem_error
-   * @throw std::bad_alloc
+   * @throw std::bad_alloc (memory allocation failure)
    * @throw std::runtime_error (curl, SQL, filesystem, and json parsing failures;
    *                            database inconsistency with pending updates)
+   * @throw std::system_error (failure to lock a mutex)
    */
   std::future<result::UpdateCheck> CheckUpdates();
 
@@ -135,6 +139,7 @@ class Aktualizr {
    * @return std::future object with information about download results.
    *
    * @throw SQLException
+   * @throw std::bad_alloc (memory allocation failure)
    * @throw std::system_error (failure to lock a mutex)
    */
   std::future<result::Download> Download(const std::vector<Uptane::Target>& updates);
@@ -199,7 +204,9 @@ class Aktualizr {
    * @return std::future object with information about installation results.
    *
    * @throw SQLException
+   * @throw std::bad_alloc (memory allocation failure)
    * @throw std::runtime_error (error getting metadata from database or filesystem)
+   * @throw std::system_error (failure to lock a mutex)
    */
   std::future<result::Install> Install(const std::vector<Uptane::Target>& updates);
 
@@ -228,7 +235,9 @@ class Aktualizr {
    * @return std::future object with manifest update result (true on success).
    *
    * @throw SQLException
+   * @throw std::bad_alloc (memory allocation failure)
    * @throw std::runtime_error (curl failures; database inconsistency with pending updates)
+   * @throw std::system_error (failure to lock a mutex)
    */
   std::future<bool> SendManifest(const Json::Value& custom = Json::nullValue);
 
@@ -238,8 +247,8 @@ class Aktualizr {
    *
    * @return Information about pause results.
    *
+   * @throw std::bad_alloc (memory allocation failure)
    * @throw std::system_error (failure to lock a mutex)
-   * @throw std::bad_alloc
    */
   result::Pause Pause();
 
@@ -250,8 +259,8 @@ class Aktualizr {
    *
    * @return Information about resume results.
    *
+   * @throw std::bad_alloc (memory allocation failure)
    * @throw std::system_error (failure to lock a mutex)
-   * @throw std::bad_alloc
    */
   result::Pause Resume();
 
@@ -274,11 +283,11 @@ class Aktualizr {
    *
    * @throw SQLException
    * @throw boost::filesystem::filesystem_error
-   * @throw std::system_error (failure to lock a mutex)
-   * @throw std::bad_alloc
+   * @throw std::bad_alloc (memory allocation failure)
    * @throw std::runtime_error (curl, SQL, filesystem, and json parsing failures;
    *                            database inconsistency with pending updates;
    *                            error getting metadata from database or filesystem)
+   * @throw std::system_error (failure to lock a mutex)
    */
   bool UptaneCycle();
 

--- a/include/libaktualizr/aktualizr.h
+++ b/include/libaktualizr/aktualizr.h
@@ -46,7 +46,7 @@ class Aktualizr {
    * @throw SQLException
    * @throw boost::filesystem::filesystem_error
    * @throw std::bad_alloc (memory allocation failure)
-   * @throw std::runtime_error (curl, P11, SQL, filesystem, credentials archive
+   * @throw std::runtime_error (curl, P11, filesystem, credentials archive
    *                            parsing, and certificate parsing failures;
    *                            missing ECU serials or device ID; database
    *                            inconsistency with pending updates; invalid
@@ -63,7 +63,7 @@ class Aktualizr {
    * @throw SQLException
    * @throw boost::filesystem::filesystem_error
    * @throw std::bad_alloc (memory allocation failure)
-   * @throw std::runtime_error (curl, SQL, and filesystem failures; database
+   * @throw std::runtime_error (curl and filesystem failures; database
    *                            inconsistency with pending updates; error
    *                            getting metadata from database or filesystem)
    * @throw std::system_error (failure to lock a mutex)
@@ -127,7 +127,7 @@ class Aktualizr {
    * @throw SQLException
    * @throw boost::filesystem::filesystem_error
    * @throw std::bad_alloc (memory allocation failure)
-   * @throw std::runtime_error (curl, SQL, and filesystem failures; database
+   * @throw std::runtime_error (curl and filesystem failures; database
    *                            inconsistency with pending updates)
    * @throw std::system_error (failure to lock a mutex)
    */
@@ -284,7 +284,7 @@ class Aktualizr {
    * @throw SQLException
    * @throw boost::filesystem::filesystem_error
    * @throw std::bad_alloc (memory allocation failure)
-   * @throw std::runtime_error (curl, SQL, and filesystem failures; database
+   * @throw std::runtime_error (curl and filesystem failures; database
    *                            inconsistency with pending updates; error
    *                            getting metadata from database or filesystem)
    * @throw std::system_error (failure to lock a mutex)
@@ -305,7 +305,6 @@ class Aktualizr {
    * be retrieved later through `GetSecondaries`
    *
    * @throw SQLException
-   * @throw std::runtime_error (SQL failure)
    */
   void SetSecondaryData(const Uptane::EcuSerial& ecu, const std::string& data);
 

--- a/include/libaktualizr/types.h
+++ b/include/libaktualizr/types.h
@@ -216,14 +216,6 @@ std::ostream &operator<<(std::ostream &os, const TimeStamp &t);
 /// General data structures.
 namespace data {
 
-using UpdateRequestId = std::string;
-struct Package {
-  std::string name;
-  std::string version;
-  Json::Value toJson() const;
-  static Package fromJson(const std::string & /*json_str*/);
-};
-
 struct ResultCode {
   // Keep these in sync with AKInstallationResultCode ASN.1 definitions.
   enum class Numeric {

--- a/include/libaktualizr/types.h
+++ b/include/libaktualizr/types.h
@@ -121,7 +121,7 @@ class PublicKey {
   PublicKey() = default;
   explicit PublicKey(const boost::filesystem::path &path);
 
-  explicit PublicKey(Json::Value uptane_json);
+  explicit PublicKey(const Json::Value &uptane_json);
 
   PublicKey(const std::string &value, KeyType type);
 
@@ -392,7 +392,7 @@ class Target {
   std::string sha512Hash() const;
   const std::vector<Hash> &hashes() const { return hashes_; }
   const std::vector<HardwareIdentifier> &hardwareIds() const { return hwids_; }
-  std::string custom_version() const { return custom_["version"].asString(); }
+  std::string custom_version() const;
   Json::Value custom_data() const { return custom_; }
   void updateCustom(Json::Value &custom) { custom_ = custom; }
   std::string correlation_id() const { return correlation_id_; }

--- a/src/libaktualizr/primary/initializer.cc
+++ b/src/libaktualizr/primary/initializer.cc
@@ -156,7 +156,13 @@ void Initializer::initTlsCreds() {
   data["ttl"] = config_.expiry_days;
   HttpResponse response = http_client_->post(config_.server + "/devices", data);
   if (!response.isOk()) {
-    Json::Value resp_code = response.getJson()["code"];
+    Json::Value resp_code;
+    try {
+      resp_code = response.getJson()["code"];
+    } catch (const std::exception& ex) {
+      LOG_ERROR << "Unable to parse reponse code from device registration: " << ex.what();
+      throw ServerError(ex.what());
+    }
     if (resp_code.isString() && resp_code.asString() == "device_already_registered") {
       LOG_ERROR << "Device ID " << device_id << " is already registered.";
       throw ServerOccupied();

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -194,7 +194,13 @@ void SotaUptaneClient::reportNetworkInfo() {
     return;
   }
 
-  const Json::Value network_info = Utils::getNetworkInfo();
+  Json::Value network_info;
+  try {
+    network_info = Utils::getNetworkInfo();
+  } catch (const std::exception &ex) {
+    LOG_ERROR << "Failed to get network info: " << ex.what();
+    return;
+  }
   const Hash new_hash = Hash::generate(Hash::Type::kSha256, Utils::jsonToCanonicalStr(network_info));
   std::string stored_hash;
   if (!(storage->loadDeviceDataHash("network_info", &stored_hash) &&

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -1039,7 +1039,6 @@ result::Install SotaUptaneClient::uptaneInstall(const std::vector<Uptane::Target
     return std::make_tuple(result, rr);
   }();
 
-  // TODO(OTA-2178): think of exception handling; the SQLite related code can throw exceptions
   storage->storeDeviceInstallationResult(r.dev_report, raw_report, correlation_id);
 
   sendEvent<event::AllInstallsComplete>(r);

--- a/src/libaktualizr/storage/fsstorage_read.cc
+++ b/src/libaktualizr/storage/fsstorage_read.cc
@@ -233,12 +233,17 @@ bool FSStorageRead::loadMisconfiguredEcus(std::vector<MisconfiguredEcu>* ecus) c
   if (!boost::filesystem::exists(Utils::absolutePath(config_.path, "misconfigured_ecus"))) {
     return false;
   }
-  Json::Value content_json = Utils::parseJSONFile(Utils::absolutePath(config_.path, "misconfigured_ecus").string());
 
-  for (auto it = content_json.begin(); it != content_json.end(); ++it) {
-    ecus->push_back(MisconfiguredEcu(Uptane::EcuSerial((*it)["serial"].asString()),
-                                     Uptane::HardwareIdentifier((*it)["hardware_id"].asString()),
-                                     static_cast<EcuState>((*it)["state"].asInt())));
+  try {
+    Json::Value content_json = Utils::parseJSONFile(Utils::absolutePath(config_.path, "misconfigured_ecus").string());
+    for (auto it = content_json.begin(); it != content_json.end(); ++it) {
+      ecus->push_back(MisconfiguredEcu(Uptane::EcuSerial((*it)["serial"].asString()),
+                                       Uptane::HardwareIdentifier((*it)["hardware_id"].asString()),
+                                       static_cast<EcuState>((*it)["state"].asInt())));
+    }
+  } catch (const std::exception& ex) {
+    LOG_ERROR << "Unable to parse misconfigured_ecus: " << ex.what();
+    return false;
   }
   return true;
 }

--- a/src/libaktualizr/storage/sqlstorage_base.cc
+++ b/src/libaktualizr/storage/sqlstorage_base.cc
@@ -77,7 +77,7 @@ SQLStorageBase::SQLStorageBase(boost::filesystem::path sqldb_path, bool readonly
 SQLite3Guard SQLStorageBase::dbConnection() const {
   SQLite3Guard db(dbPath(), readonly_, mutex_);
   if (db.get_rc() != SQLITE_OK) {
-    throw SQLException(std::string("Can't open database: ") + db.errmsg());
+    throw SQLInternalException(std::string("Can't open database: ") + db.errmsg());
   }
   return db;
 }

--- a/src/libaktualizr/storage/storage_common_test.cc
+++ b/src/libaktualizr/storage/storage_common_test.cc
@@ -500,7 +500,7 @@ TEST(StorageCommon, LoadStoreSecondaryInfo) {
   storage->saveSecondaryInfo(Uptane::EcuSerial("secondary_1"), "ip", PublicKey("key1", KeyType::kED25519));
 
   EXPECT_THROW(storage->saveSecondaryInfo(Uptane::EcuSerial("primary"), "ip", PublicKey("key0", KeyType::kRSA2048)),
-               std::runtime_error);
+               std::logic_error);
 
   std::vector<SecondaryInfo> sec_infos;
   EXPECT_TRUE(storage->loadSecondariesInfo(&sec_infos));

--- a/src/libaktualizr/uptane/directorrepository.cc
+++ b/src/libaktualizr/uptane/directorrepository.cc
@@ -138,8 +138,12 @@ void DirectorRepository::updateMeta(INvStorage& storage, const IMetadataFetcher&
 }
 
 void DirectorRepository::dropTargets(INvStorage& storage) {
-  storage.clearNonRootMeta(RepositoryType::Director());
-  resetMeta();
+  try {
+    storage.clearNonRootMeta(RepositoryType::Director());
+    resetMeta();
+  } catch (const Uptane::Exception& ex) {
+    LOG_ERROR << "Failed to reset Director Targets metadata: " << ex.what();
+  }
 }
 
 bool DirectorRepository::matchTargetsWithImageTargets(const Uptane::Targets& image_targets) const {

--- a/src/libaktualizr/uptane/iterator.cc
+++ b/src/libaktualizr/uptane/iterator.cc
@@ -104,7 +104,7 @@ bool LazyTargetsList::DelegationIterator::operator==(const LazyTargetsList::Dele
 
 const Target &LazyTargetsList::DelegationIterator::operator*() {
   if (is_end_) {
-    throw std::runtime_error("Inconsistent delegation iterator");  // TODO(OTA-2178): UptaneException
+    throw std::runtime_error("Inconsistent delegation iterator");
   }
 
   if (!cur_targets_) {
@@ -112,7 +112,7 @@ const Target &LazyTargetsList::DelegationIterator::operator*() {
   }
 
   if (!cur_targets_ || target_idx_ >= cur_targets_->targets.size()) {
-    throw std::runtime_error("Inconsistent delegation iterator");  // TODO(OTA-2178): UptaneException
+    throw std::runtime_error("Inconsistent delegation iterator");
   }
 
   return cur_targets_->targets[target_idx_];

--- a/src/libaktualizr/uptane/manifest.cc
+++ b/src/libaktualizr/uptane/manifest.cc
@@ -4,21 +4,40 @@
 
 namespace Uptane {
 
-std::string Manifest::filepath() const { return (*this)["signed"]["installed_image"]["filepath"].asString(); }
+std::string Manifest::filepath() const {
+  try {
+    return (*this)["signed"]["installed_image"]["filepath"].asString();
+  } catch (const std::exception &ex) {
+    LOG_ERROR << "Unable to parse manifest: " << ex.what();
+    return "";
+  }
+}
 
 Hash Manifest::installedImageHash() const {
-  // TODO: proper verification of the required fields
-  return Hash(Hash::Type::kSha256, (*this)["signed"]["installed_image"]["fileinfo"]["hashes"]["sha256"].asString());
+  try {
+    return Hash(Hash::Type::kSha256, (*this)["signed"]["installed_image"]["fileinfo"]["hashes"]["sha256"].asString());
+  } catch (const std::exception &ex) {
+    LOG_ERROR << "Unable to parse manifest: " << ex.what();
+    return Hash(Hash::Type::kUnknownAlgorithm, "");
+  }
 }
 
 std::string Manifest::signature() const {
-  // TODO: proper verification of the required fields
-  return (*this)["signatures"][0]["sig"].asString();
+  try {
+    return (*this)["signatures"][0]["sig"].asString();
+  } catch (const std::exception &ex) {
+    LOG_ERROR << "Unable to parse manifest: " << ex.what();
+    return "";
+  }
 }
 
 std::string Manifest::signedBody() const {
-  // TODO: proper verification of the required fields
-  return Utils::jsonToCanonicalStr((*this)["signed"]);
+  try {
+    return Utils::jsonToCanonicalStr((*this)["signed"]);
+  } catch (const std::exception &ex) {
+    LOG_ERROR << "Unable to parse manifest: " << ex.what();
+    return "";
+  }
 }
 
 bool Manifest::verifySignature(const PublicKey &pub_key) const {

--- a/src/libaktualizr/uptane/tuf.cc
+++ b/src/libaktualizr/uptane/tuf.cc
@@ -115,7 +115,7 @@ Target::Target(std::string filename, const Json::Value &content) : filename_(std
 
   length_ = content["length"].asUInt64();
 
-  Json::Value hashes = content["hashes"];
+  const Json::Value hashes = content["hashes"];
   for (auto i = hashes.begin(); i != hashes.end(); ++i) {
     Hash h(i.key().asString(), (*i).asString());
     if (h.HaveAlgorithm()) {
@@ -166,6 +166,15 @@ std::string Target::hashString(Hash::Type type) const {
 std::string Target::sha256Hash() const { return hashString(Hash::Type::kSha256); }
 
 std::string Target::sha512Hash() const { return hashString(Hash::Type::kSha512); }
+
+std::string Target::custom_version() const {
+  try {
+    return custom_["version"].asString();
+  } catch (const std::exception &ex) {
+    LOG_ERROR << "Unable to parse custom version: " << ex.what();
+    return "";
+  }
+}
 
 bool Target::IsOstree() const {
   // NOLINTNEXTLINE(bugprone-branch-clone)

--- a/src/libaktualizr/utilities/types.cc
+++ b/src/libaktualizr/utilities/types.cc
@@ -71,22 +71,6 @@ std::ostream &operator<<(std::ostream &os, const TimeStamp &t) {
 }
 
 namespace data {
-Json::Value Package::toJson() const {
-  Json::Value json;
-  json["name"] = name;
-  json["version"] = version;
-  return json;
-}
-
-Package Package::fromJson(const std::string &json_str) {
-  std::istringstream jsonss(json_str);
-  Json::Value json;
-  Json::parseFromStream(Json::CharReaderBuilder(), jsonss, &json, nullptr);
-  Package package;
-  package.name = json["name"].asString();
-  package.version = json["version"].asString();
-  return package;
-}
 
 const std::map<data::ResultCode::Numeric, const char *> data::ResultCode::string_repr{
     {ResultCode::Numeric::kOk, "OK"},


### PR DESCRIPTION
Generally, only fatal exceptions should be thrown through the API. Non-fatal exceptions are caught inside libaktualizr and converted to error codes. Also:
* All Secondary communication is now wrapped in try-catches.
* JSON parsing is wrapped in try-catches when appropriate. (The Uptane code does most of the json parsing, and that's already covered by higher-level try-catches in SotaUptaneClient.)
* Uptane exceptions are no longer be exposed through the API.
* All SQL exceptions are thrown as SQLException or a subclass thereof (SQLInternalException).
* The list of exceptions thrown in aktualizr.h has been revised accordingly, and a few inaccuracies have been corrected.
* Some logging and error messages have been improved.
* Some unused types have been removed.

There is probably still room for improvement in the SQL code. However, it's generally fairly low-level and only internally relevant, so it didn't seem worth the effort to refactor it too substantially. Some functions return bools while others throw exceptions, and some do both. It might be nice to only throw exceptions, but that would take some work to get right, and no one seems to bothered by the current state of affairs.