### PR TITLE
OTA-4864 - improve binary file download progress logging

### DIFF
--- a/src/libaktualizr/package_manager/packagemanagerinterface.cc
+++ b/src/libaktualizr/package_manager/packagemanagerinterface.cc
@@ -77,8 +77,7 @@ static int ProgressHandler(void* clientp, curl_off_t dltotal, curl_off_t dlnow, 
       auto now = std::chrono::steady_clock::now();
       auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(now - ds->time_lastreport);
       if(milliseconds.count() > LogProgressInterval || progress == 100) {
-        auto clocktime = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-        LOG_INFO << std::put_time(std::localtime(&clocktime), "%T") <<" Downloading "<< ds->target.filename() <<" progress " << progress << std::endl;
+        LOG_INFO << "Download progress for file " << ds->target.filename() <<": " << progress << std::endl;
         ds->time_lastreport = now;
       }
     }

--- a/src/libaktualizr/package_manager/packagemanagerinterface.cc
+++ b/src/libaktualizr/package_manager/packagemanagerinterface.cc
@@ -35,8 +35,9 @@ struct DownloadMetaStruct {
   Uptane::Target target;
   const api::FlowControlToken* token;
   FetcherProgressCb progress_cb;
-  std::chrono::time_point<std::chrono::steady_clock> time_start; //download start time
-  std::chrono::time_point<std::chrono::steady_clock> time_lastreport; // each XXX sec report dowload progress to user to do not stuck with bit files
+  std::chrono::time_point<std::chrono::steady_clock> time_start;  // download start time
+  std::chrono::time_point<std::chrono::steady_clock>
+      time_lastreport;  // each XXX sec report dowload progress to user to do not stuck with bit files
 
  private:
   MultiPartSHA256Hasher sha256_hasher;
@@ -72,12 +73,12 @@ static int ProgressHandler(void* clientp, curl_off_t dltotal, curl_off_t dlnow, 
   if (ds->progress_cb && progress > ds->last_progress) {
     ds->last_progress = progress;
     ds->progress_cb(ds->target, "Downloading", progress);
-    //OTA-4864:Improve binary file download progress logging. Report each XX sec report event that notify user
-    if (!ds->target.IsOstree()) {      
+    // OTA-4864:Improve binary file download progress logging. Report each XX sec report event that notify user
+    if (!ds->target.IsOstree()) {
       auto now = std::chrono::steady_clock::now();
       auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(now - ds->time_lastreport);
-      if(milliseconds.count() > LogProgressInterval || progress == 100) {
-        LOG_INFO << "Download progress for file " << ds->target.filename() <<": " << progress << std::endl;
+      if (milliseconds.count() > LogProgressInterval || progress == 100) {
+        LOG_INFO << "Download progress for file " << ds->target.filename() << ": " << progress << std::endl;
         ds->time_lastreport = now;
       }
     }
@@ -112,7 +113,8 @@ bool PackageManagerInterface::fetchTarget(const Uptane::Target& target, Uptane::
       return true;
     }
     std::unique_ptr<DownloadMetaStruct> ds = std_::make_unique<DownloadMetaStruct>(target, progress_cb, token);
-    ds->time_start = ds->time_lastreport = std::chrono::steady_clock::now(); //use this time to report download progress it download take long time
+    ds->time_start = ds->time_lastreport =
+        std::chrono::steady_clock::now();  // use this time to report download progress it download take long time
     if (target.length() == 0) {
       LOG_INFO << "Skipping download of target with length 0";
       ds->fhandle = createTargetFile(target);

--- a/src/libaktualizr/package_manager/packagemanagerinterface.cc
+++ b/src/libaktualizr/package_manager/packagemanagerinterface.cc
@@ -35,7 +35,6 @@ struct DownloadMetaStruct {
   Uptane::Target target;
   const api::FlowControlToken* token;
   FetcherProgressCb progress_cb;
-  std::chrono::time_point<std::chrono::steady_clock> time_start;  // download start time
   std::chrono::time_point<std::chrono::steady_clock>
       time_lastreport;  // each XXX sec report dowload progress to user to do not stuck with bit files
 
@@ -74,13 +73,11 @@ static int ProgressHandler(void* clientp, curl_off_t dltotal, curl_off_t dlnow, 
     ds->last_progress = progress;
     ds->progress_cb(ds->target, "Downloading", progress);
     // OTA-4864:Improve binary file download progress logging. Report each XX sec report event that notify user
-    if (!ds->target.IsOstree()) {
-      auto now = std::chrono::steady_clock::now();
-      auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(now - ds->time_lastreport);
-      if (milliseconds.count() > LogProgressInterval || progress == 100) {
-        LOG_INFO << "Download progress for file " << ds->target.filename() << ": " << progress << std::endl;
-        ds->time_lastreport = now;
-      }
+    auto now = std::chrono::steady_clock::now();
+    auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(now - ds->time_lastreport);
+    if (milliseconds.count() > LogProgressInterval) {
+      LOG_INFO << "Download progress for file " << ds->target.filename() << ": " << progress << "%";
+      ds->time_lastreport = now;
     }
   }
   if (ds->token != nullptr && !ds->token->canContinue(false)) {
@@ -113,7 +110,7 @@ bool PackageManagerInterface::fetchTarget(const Uptane::Target& target, Uptane::
       return true;
     }
     std::unique_ptr<DownloadMetaStruct> ds = std_::make_unique<DownloadMetaStruct>(target, progress_cb, token);
-    ds->time_start = ds->time_lastreport =
+    ds->time_lastreport =
         std::chrono::steady_clock::now();  // use this time to report download progress it download take long time
     if (target.length() == 0) {
       LOG_INFO << "Skipping download of target with length 0";


### PR DESCRIPTION
Log into output download progress each 15sec for big binary files