### PR TITLE
Restore reboot_command to aktualizr config doc.

### DIFF
--- a/docs/ota-client-guide/modules/ROOT/pages/aktualizr-config-options.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/aktualizr-config-options.adoc
@@ -206,5 +206,6 @@ Options for configuring boot-specific behavior
 | `rollback_mode`        | `"none"`                        | Controls rollback on supported platforms, see xref:rollback.adoc[]. Options: `"none"`, `"uboot_generic"`, `"uboot_masked"`
 | `reboot_sentinel_dir`  | `"/var/run/aktualizr-session"`  | Base directory for reboot detection sentinel. Must reside in a temporary file system.
 | `reboot_sentinel_name` | `"need_reboot"`                 | Name of the reboot detection sentinel.
+| `reboot_command`       | `"/sbin/reboot"`                | Command to reboot the system after update completes. Applicable only if `uptane::force_install_completion` is set to `true`.
 |==========================================================================================
 


### PR DESCRIPTION
It was lost during the docs transition last year. See 056b80d4c749358daff8c13b14b1b3b1a7236300 or https://github.com/advancedtelematic/aktualizr/pull/1274 for the original feature.

Note this is targeted at the 2020.9-docs branch so that it'll be live on the portal sooner. It should get merged into master as part of making the next release.