### PR TITLE
packagemanage: Fix output of pacman config

### DIFF
--- a/src/libaktualizr/package_manager/CMakeLists.txt
+++ b/src/libaktualizr/package_manager/CMakeLists.txt
@@ -31,12 +31,15 @@ if(BUILD_OSTREE)
     endif(BUILD_DOCKERAPP)
 endif(BUILD_OSTREE)
 
+add_aktualizr_test(NAME packagemanagerconfig SOURCES packagemanagerconfig_test.cc NO_VALGRIND)
 add_aktualizr_test(NAME packagemanager_factory SOURCES packagemanagerfactory_test.cc
                    ARGS ${PROJECT_BINARY_DIR}/ostree_repo)
 add_aktualizr_test(NAME fetcher SOURCES fetcher_test.cc ARGS PROJECT_WORKING_DIRECTORY LIBRARIES PUBLIC uptane_generator_lib)
 add_aktualizr_test(NAME fetcher_death SOURCES fetcher_death_test.cc NO_VALGRIND ARGS PROJECT_WORKING_DIRECTORY)
 
 aktualizr_source_file_checks(fetcher_death_test.cc fetcher_test.cc)
+
+aktualizr_source_file_checks(packagemanagerconfig_test.cc)
 
 aktualizr_source_file_checks(packagemanagerfake_test.cc packagemanagerfactory_test.cc ostreemanager_test.cc)
 

--- a/src/libaktualizr/package_manager/packagemanagerconfig.cc
+++ b/src/libaktualizr/package_manager/packagemanagerconfig.cc
@@ -40,6 +40,6 @@ void PackageConfig::writeToStream(std::ostream& out_stream) const {
   // note that this is imperfect as it will not print default values deduced
   // from users of `extra`
   for (const auto& e : extra) {
-    writeOption(out_stream, e.first, e.second);
+    writeOption(out_stream, e.second, e.first);
   }
 }

--- a/src/libaktualizr/package_manager/packagemanagerconfig_test.cc
+++ b/src/libaktualizr/package_manager/packagemanagerconfig_test.cc
@@ -1,0 +1,25 @@
+#include <gtest/gtest.h>
+
+#include "libaktualizr/config.h"
+#include "logging/logging.h"
+
+TEST(PackageManagerConfig, WriteToStream) {
+  PackageConfig config;
+  config.os = "amiga";
+  config.fake_need_reboot = true;
+  config.extra["foo"] = "bar";
+  std::stringstream out;
+  config.writeToStream(out);
+  std::string cfg = out.str();
+
+  ASSERT_NE(std::string::npos, cfg.find("os = \"amiga\""));
+  ASSERT_NE(std::string::npos, cfg.find("fake_need_reboot = 1"));
+  ASSERT_NE(std::string::npos, cfg.find("foo = \"bar\""));
+}
+
+#ifndef __NO_MAIN__
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+#endif


### PR DESCRIPTION
When the config is dumped out for the docker-app manager, the custom
config key/vals are printed val=key. eg:

 "/tmp/sota/docker-apps" = docker_apps_root

This fixes the issue.

Signed-off-by: Andy Doan <andy@foundries.io>