### PR TITLE
fixed checks for cert re-import

### DIFF
--- a/src/libaktualizr/storage/invstorage.cc
+++ b/src/libaktualizr/storage/invstorage.cc
@@ -80,9 +80,8 @@ void INvStorage::importUpdateCertificate(const boost::filesystem::path& base_pat
     if (!loadDeviceId(&old_device_id)) {
       LOG_DEBUG << "Unable to load previous device ID.";
     } else if (new_device_id != old_device_id) {
-      throw std::runtime_error(std::string("Certificate at ") + abs_path.string() + " has a device ID of " +
-                               new_device_id + " but the device currently is identified as " + old_device_id +
-                               ". Changing device ID is not supported!");
+      LOG_WARNING << "Certificate at " << abs_path.string() << " has a CN that may be used as device ID of "
+                  << new_device_id << " but the device currently is identified as " << old_device_id;
     }
 
     storeTlsCert(content);
@@ -92,7 +91,12 @@ void INvStorage::importUpdateCertificate(const boost::filesystem::path& base_pat
 
 void INvStorage::importPrimaryKeys(const boost::filesystem::path& base_path, const utils::BasedPath& import_pubkey_path,
                                    const utils::BasedPath& import_privkey_path) {
-  if (loadPrimaryKeys(nullptr, nullptr) || import_pubkey_path.empty() || import_privkey_path.empty()) {
+  if (import_pubkey_path.empty() || import_privkey_path.empty()) {
+    LOG_ERROR << "Couldn`t import data: empty path received";
+    return;
+  }
+  if (loadPrimaryKeys(nullptr, nullptr)) {
+    LOG_INFO << "Couldn`t import data: primary keys already in storage";
     return;
   }
   const boost::filesystem::path pubkey_abs_path = import_pubkey_path.get(base_path);

--- a/src/libaktualizr/storage/storage_common_test.cc
+++ b/src/libaktualizr/storage/storage_common_test.cc
@@ -603,9 +603,8 @@ TEST(StorageImport, ImportData) {
   Utils::writeFile(import_config.tls_clientcert_path.get(import_config.base_path).string(), tls_cert_in2);
   Utils::writeFile(import_config.tls_pkey_path.get(import_config.base_path).string(), tls_pkey_in2);
 
-  // Attempt to re-import, but expect failure because the TLS cert's device ID
-  // changed.
-  EXPECT_THROW(storage->importData(import_config), std::runtime_error);
+  // Attempt to re-import, TLS cert's device ID  changed. It allow reimport but keeps old device ID in the storage.
+  EXPECT_NO_THROW(storage->importData(import_config));
 
   EXPECT_TRUE(storage->loadPrimaryPublic(&primary_public));
   EXPECT_TRUE(storage->loadPrimaryPrivate(&primary_private));
@@ -613,13 +612,12 @@ TEST(StorageImport, ImportData) {
   EXPECT_TRUE(storage->loadTlsCert(&tls_cert));
   EXPECT_TRUE(storage->loadTlsPkey(&tls_pkey));
 
-  // Nothing should be updated. Uptane keys cannot be updated, and the TLS
-  // credentials should have failed.
+  // Allow import but do not update primary keys.
   EXPECT_EQ(primary_private, "uptane_private_1");
   EXPECT_EQ(primary_public, "uptane_public_1");
-  EXPECT_EQ(tls_ca, "tls_cacert_1");
-  EXPECT_EQ(tls_cert, tls_cert_in1);
-  EXPECT_EQ(tls_pkey, tls_pkey_in1);
+  EXPECT_EQ(tls_ca, "tls_cacert_2");
+  EXPECT_EQ(tls_cert, tls_cert_in2);
+  EXPECT_EQ(tls_pkey, tls_pkey_in2);
 
   // Create third TLS cert/key (with the same device ID as the first) and other
   // dummy files.
@@ -641,7 +639,7 @@ TEST(StorageImport, ImportData) {
   EXPECT_TRUE(storage->loadTlsCert(&tls_cert));
   EXPECT_TRUE(storage->loadTlsPkey(&tls_pkey));
 
-  // All TLS objects should be updated.
+  // All TLS objects should be updated exept primary keys.
   EXPECT_EQ(primary_private, "uptane_private_1");
   EXPECT_EQ(primary_public, "uptane_public_1");
   EXPECT_EQ(tls_ca, "tls_cacert_2");


### PR DESCRIPTION
do not throw exception if device id and CN in cert are different. E.g. if happens if we provides device_id in config. Added test to cover this case

Signed-off-by: Anatoliy Odukha <aodukha@gmail.com>