### PR TITLE
log exceptions when processing delegation metadata

### DIFF
--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -888,6 +888,7 @@ result::UpdateCheck SotaUptaneClient::checkUpdates() {
     }
   } catch (const std::exception &e) {
     last_exception = std::current_exception();
+    LOG_ERROR << e.what();
     result = result::UpdateCheck({}, 0, result::UpdateStatus::kError, Utils::parseJSON(director_targets),
                                  "Target mismatch.");
     storeInstallationFailure(


### PR DESCRIPTION
findTargetInDelegationTree() has a number of possibly thrown exceptions:
- SecurityException("image", "Rollback attempt on delegated targets")
- Uptane::Exception("image", "Inconsistent delegations")
- Uptane::DelegationMissing
- Uptane::DelegationHashMismatch
- VersionMismatch

Log the exceptions when caught


## Background
I was chasing a bug where our delegations didn't match what was in snapshots role. To learn this however, I had to add this extra logging. Aktualizr didn't otherwise report any errors, it would quietly report an installation failure of "Metadata_Verification_Failed". so the only way to see it from the client-logs was to run with `--loglevel 0`

It seems that most (but not all) exceptions do log something when they are thrown from `iterator.cc::getTrustedDelegation()`. I considered added logging there, but it wasn't clear if this was the standard. Additionally, this way we are guaranteed not to miss any exceptions.

Signed-off-by: Benjamin Clouser <ben.clouser@toradex.com>